### PR TITLE
Read from env var for all npm publishing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,6 +14,7 @@ node_modules
 npm-debug.log
 .swo
 .swp
+.npmrc
 
 # Generated icon library file
 /src/iconLibrary.story.jsx

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
 save-exact=true
-//registry.npmjs.org/:_authToken=\${NPM_TOKEN}
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
 save-exact=true
+//registry.npmjs.org/:_authToken=\${NPM_TOKEN}
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,6 @@ addons:
     packages:
       - g++-4.8
 
-before_install:
-  - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
-
 after_success:
   - git config --global user.email "builds@travis-ci.com"
   - git config --global user.name "Travis CI"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 0.0.$(CI_BUILD_NUMBER)
+VERSION ?= 0.1.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)


### PR DESCRIPTION
no need to 'dynamically' update `.npmrc`. You can't publish from your local machine without an `NPM_TOKEN` env variable, but we never publish from local machines anyway