### PR TITLE
git commit npmrc during Travis build but don't push

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
 save-exact=true
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,9 @@ after_success:
   - echo "NPM_TAG=$NPM_TAG"
   - >
     [ "${TRAVIS_BRANCH}" = "master" ] &&
+    git commit -am "Commit .npmrc in tag pushed to npm" &&
     npm version $GIT_TAG -m "Version $GIT_TAG built by Travis CI - https://travis-ci.com/$TRAVIS_REPO_SLUG/builds/$TRAVIS_JOB_ID" &&
     git push -q https://$GITHUB_USER:$GITHUB_TOKEN@github.com/$TRAVIS_REPO_SLUG --tags &&
-    git commit -am "Temp commit of .npmrc changes - do not push" &&
     npm publish --tag $NPM_TAG ||
     echo "skipping versioning"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ addons:
     packages:
       - g++-4.8
 
+before_install:
+    - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
+
 after_success:
   - git config --global user.email "builds@travis-ci.com"
   - git config --global user.name "Travis CI"
@@ -38,6 +41,7 @@ after_success:
     [ "${TRAVIS_BRANCH}" = "master" ] &&
     npm version $GIT_TAG -m "Version $GIT_TAG built by Travis CI - https://travis-ci.com/$TRAVIS_REPO_SLUG/builds/$TRAVIS_JOB_ID" &&
     git push -q https://$GITHUB_USER:$GITHUB_TOKEN@github.com/$TRAVIS_REPO_SLUG --tags &&
+    git commit -am "Temp commit of .npmrc changes - do not push" &&
     npm publish --tag $NPM_TAG ||
     echo "skipping versioning"
 


### PR DESCRIPTION
This update removes the `NPM_TOKEN` reference from all git branches, but _will_ commit a reference to it in the tagged releases. In practice, we shouldn't ever see the modified `.npmrc`, but it is technically in our git repo in a headless commit - just the env var name, not the value, so no security concern