### PR TITLE
Storybook SVG icons

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,7 +1,5 @@
 const path = require('path');
-const SvgStore = require('webpack-svgstore-plugin');
 
-const ICON_PATH = path.resolve(__dirname, '../icons', '**/*.svg');
 const SCSS_PATH = path.resolve(__dirname, '../assets', 'scss');
 const CSS_PATH = path.resolve(__dirname, '../assets', 'css');
 const SRC_PATH = path.resolve(__dirname, '../src');
@@ -40,23 +38,6 @@ module.exports = {
 
 	resolve: {
 		extensions: ['', '.js', '.jsx']
-	},
-
-	plugins: [
-		new SvgStore(
-			[ICON_PATH], // input path
-			'svg',       // output path
-			{
-				name: '[hash].sprite.svg',
-				chunk: 'preview',
-				prefix: 'icon-',
-				svgoOptions: {
-					plugins: [
-						{ removeTitle: true }
-					]
-				}
-			}
-		)
-	]
+	}
 };
 

--- a/package.json
+++ b/package.json
@@ -36,12 +36,9 @@
     "babel-preset-react": "6.16.0",
     "babel-preset-stage-2": "6.18.0",
     "babel-register": "6.18.0",
-    "bourbon": "4.2.7",
     "classnames": "2.2.5",
     "eslint": "3.9.1",
     "eslint-plugin-react": "6.4.1",
-    "julep": "1.4.5",
-    "meetup-swatches": "3.1.1",
     "meetup-web-platform": "0.5.189",
     "node-sass": "3.10.1",
     "react": "15.3.2",
@@ -49,7 +46,8 @@
     "react-dom": "15.3.2",
     "react-intl": "2.1.5",
     "react-transform-catch-errors": "1.0.2",
-    "sassquatch2": "2.4.2"
+    "sassquatch2": "2.4.3",
+    "swarm-icons": "0.0.1"
   },
   "devDependencies": {
     "@kadira/storybook": "2.24.1",
@@ -57,11 +55,11 @@
     "coveralls": "2.11.14",
     "css-loader": "0.23.1",
     "eslint-loader": "1.5.0",
+    "file-loader": "0.9.0",
     "inquirer": "1.2.2",
     "jest-cli": "15.1.1",
     "npm-run-all": "2.3.0",
     "sass-loader": "4.0.2",
-    "style-loader": "0.13.1",
-    "webpack-svgstore-plugin": "3.0.3"
+    "style-loader": "0.13.1"
   }
 }

--- a/src/Icon.jsx
+++ b/src/Icon.jsx
@@ -11,6 +11,8 @@ export const MEDIA_SIZES = {
 	xl: '72',
 };
 
+const spritePath = require('file!swarm-icons/dist/sprite/sprite.inc');
+
 /**
  * Icon component used to insert an svg icon into a component or page
  *
@@ -47,8 +49,10 @@ class Icon extends React.Component {
 					viewBox={`0 0 ${dim} ${dim}`}
 					className='svg-icon valign--middle'
 					role='img'
+					aria-labelledby={`${shape}_title`}
 					{...other}>
-					<use xlinkHref={`#icon-${shape}`}></use>
+					<title id={`${shape}_title`} />
+					<use role='presentation' xlinkHref={`${spritePath}#icon-${shape}`} />
 				</svg>
 			</span>
 		);
@@ -61,7 +65,7 @@ Icon.defaultProps = {
 
 Icon.propTypes = {
 	shape: React.PropTypes.string.isRequired,
-	size: React.PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl'])
+	size: React.PropTypes.oneOf(Object.keys(MEDIA_SIZES))
 };
 
 export default Icon;

--- a/src/utils/create-icon-story.js
+++ b/src/utils/create-icon-story.js
@@ -3,7 +3,7 @@ const path = require('path');
 require('babel-register');  // process all further imports through babel
 
 const ICONS_PATH = path.resolve(__dirname, '../../icons');
-const FOUNDATION_PATH = path.resolve(__dirname, '../../src');
+const SRC_PATH = path.resolve(__dirname, '../../src');
 
 function generateIconStory() {
 	'use strict';
@@ -34,7 +34,7 @@ function generateIconStory() {
 
 	// ------
 	// write generated stories to icon library file
-	const filepath = path.resolve(FOUNDATION_PATH, 'iconLibrary.story.jsx');
+	const filepath = path.resolve(SRC_PATH, 'iconLibrary.story.jsx');
 	console.log('Writing component story', filepath);
 
 	fs.writeFileSync(


### PR DESCRIPTION
See https://meetup.atlassian.net/browse/WC-5.

The svgstore webpack plugin doesn't work with well with storybook. Instead I'm attempting to use the svg sprite from the `swarm-icons` pkg.

From what I can tell this should be working, but when you run `npm run storybook` and select any of the `Icon` components, nothing renders.

The sprite is emitted via the webpack `file-loader` at `/<hash>.inc`, and the path is being injected into the `use xlink:href` correctly. 

Here's sample generated markup:

```
<span data-reactroot="" class="svg svg--chevron-right">
	<svg
		preserveAspectRatio="xMinYMin meet"
		width="16" height="16" viewBox="0 0 16 16"
		class="svg-icon valign--middle"
		role="img"
		aria-labelledby="chevron-right_title">
			<title id="chevron-right_title"></title>
			<use role="presentation" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/d7dfcb588c5221f44c7adc243bca425a.inc#icon-chevron-right"></use>
	</svg>
</span>
```

cc @akdetrick @mmcgahan I could use some help with this one, if anyone has ideas. I tried a few other ways of loading the sprite as well, but since this is being loaded and emitted correctly, I'm assuming the issue is somewhere the JSX.