### PR TITLE
Use mocks repo and upgrade sassquatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,20 +36,17 @@
     "babel-preset-react": "6.16.0",
     "babel-preset-stage-2": "6.18.0",
     "babel-register": "6.18.0",
-    "bourbon": "4.2.7",
     "classnames": "2.2.5",
     "eslint": "3.9.1",
     "eslint-plugin-react": "6.4.1",
-    "julep": "1.4.5",
-    "meetup-swatches": "3.1.1",
-    "meetup-web-platform": "0.5.189",
+    "meetup-web-mocks": "0.1.6",
     "node-sass": "3.10.1",
     "react": "15.3.2",
     "react-addons-test-utils": "15.3.2",
     "react-dom": "15.3.2",
     "react-intl": "2.1.5",
     "react-transform-catch-errors": "1.0.2",
-    "sassquatch2": "2.4.2"
+    "sassquatch2": "2.4.4"
   },
   "devDependencies": {
     "@kadira/storybook": "2.24.1",

--- a/src/avatar.story.jsx
+++ b/src/avatar.story.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Avatar from './Avatar.jsx';
 import { storiesOf, action } from '@kadira/storybook';
-import { MOCK_MEMBER } from 'meetup-web-platform/lib/util/mocks/api';
+import { MOCK_MEMBER } from 'meetup-web-mocks/lib/api';
 import { Annotate } from './utils/storyComponents';
 
 const MOCK_IMAGE_SRC = 'http://placekitten.com/g/400/400';

--- a/src/avatarmember.story.jsx
+++ b/src/avatarmember.story.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import AvatarMember from './AvatarMember.jsx';
 import { storiesOf } from '@kadira/storybook';
-import { MOCK_MEMBER } from 'meetup-web-platform/lib/util/mocks/api';
+import { MOCK_MEMBER } from 'meetup-web-mocks/lib/api';
 
 storiesOf('AvatarMember', module)
 	.add('default', () => <AvatarMember member={MOCK_MEMBER}></AvatarMember>)

--- a/src/avatarmember.test.js
+++ b/src/avatarmember.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
-import { MOCK_MEMBER } from 'meetup-web-platform/lib/util/mocks/api';
+import { MOCK_MEMBER } from 'meetup-web-mocks/lib/api';
 import AvatarMember from './AvatarMember';
 
 describe('AvatarMember', function() {

--- a/src/datedisplay.test.js
+++ b/src/datedisplay.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
 import { IntlProvider } from 'react-intl';
-import { MOCK_DATETIME } from 'meetup-web-platform/lib/util/mocks/app';
+import { MOCK_DATETIME } from 'meetup-web-mocks/lib/app';
 import { hasChildByClassName } from './utils/testUtils';
 import DateDisplay from './DateDisplay';
 

--- a/src/groupcard.story.jsx
+++ b/src/groupcard.story.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import GroupCard from './GroupCard.jsx';
 import { storiesOf } from '@kadira/storybook';
-import { MOCK_GROUP } from 'meetup-web-platform/lib/util/mocks/api';
+import { MOCK_GROUP } from 'meetup-web-mocks/lib/api';
 
 storiesOf('GroupCard', module)
 	.add('default', () => (

--- a/src/groupcard.test.jsx
+++ b/src/groupcard.test.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
+import { MOCK_GROUP } from 'meetup-web-mocks/lib/api';
 import { GroupCard } from './GroupCard';
-import { MOCK_GROUP } from 'meetup-web-platform/lib/util/mocks/api';
 
 describe('GroupCard', function() {
 


### PR DESCRIPTION
Use the `meetup-web-mocks` repo, and upgrade sassquatch2 to avoid dependency warnings.

Fixes #14 
Fixes https://meetup.atlassian.net/browse/WC-9