### PR TITLE
Break out Modal component from responsify

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -1,7 +1,7 @@
 {
   "collectCoverageFrom": [
     "src/**/*.{js,jsx}",
-    "!**/{node_modules,lib,coverage,assets,icons}/**",
+    "!**/{node_modules,lib,coverage,assets,icons,utils}/**",
     "!**/*.story.{js,jsx}"
   ],
   "coverageDirectory": "<rootDir>/coverage",

--- a/src/Modal.jsx
+++ b/src/Modal.jsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import cx from 'classnames';
+import Icon from './Icon';
+import Button from './Button';
+
+export const MODAL_CLOSE_BUTTON = 'modal-closeButton';
+
+/**
+ * SQ2 Modal component
+ * @see {@link http://meetup.github.io/sassquatch2/views.html#modals}
+ * @module Modal
+ */
+class Modal extends React.Component {
+	constructor(props){
+		super(props);
+		this.onDismiss = this.onDismiss.bind(this);
+		this.onKeyDown = this.onKeyDown.bind(this);
+	}
+
+	onDismiss(e) {
+		e.stopPropagation();
+
+		if (this.props.onDismiss) {
+			this.props.onDismiss(e);
+		}
+	}
+
+	onKeyDown(e) {
+		if (e.key === 'Escape') {
+			this.onDismiss(e);
+		}
+	}
+
+	render() {
+		const {
+			className,
+			children,
+			fullscreen,
+			...other
+		} = this.props;
+
+		delete other.onDismiss; // onDismiss is consumed in this.onDismiss - do not pass it along to children
+
+		const classNames = cx(
+			className,
+			'modal'
+		);
+
+		const modalClasses = cx(
+			'view',
+			'padding--all',
+			{
+				'view--modalFull': fullscreen,
+				'view--modalSnap': !fullscreen
+			}
+		);
+
+		const dismissButtonClasses = cx(
+			MODAL_CLOSE_BUTTON,
+			'border--none'
+		);
+
+		return (
+			<div
+				role='dialog'
+				tabIndex='0'
+				onKeyDown={this.onKeyDown}
+				className={classNames}
+				{...other}>
+
+				<div className='overlayShim' onClick={this.onDismiss}>
+					<div className='inverted'></div>
+				</div>
+
+				<div className={modalClasses} >
+					<div className='align--right'>
+						<Button onClick={this.onDismiss} className={dismissButtonClasses}>
+							<Icon shape='cross' size='s' />
+						</Button>
+					</div>
+
+					{children}
+				</div>
+			</div>
+		);
+	}
+}
+
+Modal.propTypes = {
+	onDismiss: React.PropTypes.func.isRequired,
+	fullscreen: React.PropTypes.bool
+};
+
+Modal.defaultProps = {
+	fullscreen: false
+};
+
+export default Modal;

--- a/src/modal.story.jsx
+++ b/src/modal.story.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { storiesOf, action } from '@kadira/storybook';
+import Button from './Button';
+import Modal from './Modal';
+
+const onDismiss = e => {
+	action('Dismissing modal')(e);
+};
+
+const content = (
+	<div>
+		<h2 className='align--center'>This is a modal!</h2>
+		<div className='row align--center margin--top'>
+			<div className='row-item'>
+				<Button onClick={onDismiss} fullWidth>Cancel</Button>
+			</div>
+			<div className='row-item'>
+				<Button onClick={action('Confirmed!')} primary fullWidth>Confirm</Button>
+			</div>
+		</div>
+	</div>
+);
+
+storiesOf('Modal', module)
+	.add('default', () => {
+		return (
+			<Modal
+				onDismiss={onDismiss}>
+				{content}
+			</Modal>
+		);
+	}).add('fullscreen', () => {
+		return (
+			<Modal
+				onDismiss={onDismiss}
+				fullscreen >
+				{content}
+			</Modal>
+		);
+	});
+
+

--- a/src/modal.test.js
+++ b/src/modal.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
+import { findComponentsWithType } from 'meetup-web-mocks/lib/testUtils';
 import Modal, { MODAL_CLOSE_BUTTON } from './Modal';
 
 describe('Modal', () => {
@@ -38,15 +39,15 @@ describe('Modal', () => {
 	});
 
 	it('creates an Icon component for dismissal', () => {
-		const icon = modalEl.getElementsByClassName('svg-icon')[0];
+		const closeButton = modalEl.getElementsByClassName(MODAL_CLOSE_BUTTON)[0];
+		const icon = closeButton.getElementsByClassName('svg--cross');
 
-		expect(icon).not.toBeNull();
+		expect(icon.length).toBe(1);
 	});
 
 	it('creates a Button component for dismissal', () => {
-		const closeButton = modalEl.getElementsByClassName(MODAL_CLOSE_BUTTON)[0];
-
-		expect(closeButton).not.toBeNull();
+		const closeButton = findComponentsWithType(modal, 'Button')[0];
+		expect(closeButton.props.className).toContain(MODAL_CLOSE_BUTTON);
 	});
 
 	it('executes onDismiss when dismiss button is clicked', () => {

--- a/src/modal.test.js
+++ b/src/modal.test.js
@@ -38,17 +38,18 @@ describe('Modal', () => {
 		expect(modalEl.innerHTML).toContain(content);
 	});
 
-	it('creates an Icon component for dismissal', () => {
+	it('creates a Button component for dismissal', () => {
+		const buttons = findComponentsWithType(modal, 'Button');
+		expect(buttons.filter(button => button.props.className.includes(MODAL_CLOSE_BUTTON)).length).toBe(1);
+	});
+
+	it('creates an svg icon with `svg--cross` for dismissal', () => {
 		const closeButton = modalEl.getElementsByClassName(MODAL_CLOSE_BUTTON)[0];
 		const icon = closeButton.getElementsByClassName('svg--cross');
 
 		expect(icon.length).toBe(1);
 	});
 
-	it('creates a Button component for dismissal', () => {
-		const buttons = findComponentsWithType(modal, 'Button');
-		expect(buttons.filter(button => button.props.className.includes(MODAL_CLOSE_BUTTON)).length).toBe(1);
-	});
 
 	it('executes onDismiss when dismiss button is clicked', () => {
 		const closeButton = modalEl.getElementsByClassName(MODAL_CLOSE_BUTTON)[0];

--- a/src/modal.test.js
+++ b/src/modal.test.js
@@ -46,8 +46,8 @@ describe('Modal', () => {
 	});
 
 	it('creates a Button component for dismissal', () => {
-		const closeButton = findComponentsWithType(modal, 'Button')[0];
-		expect(closeButton.props.className).toContain(MODAL_CLOSE_BUTTON);
+		const buttons = findComponentsWithType(modal, 'Button');
+		expect(buttons.filter(button => button.props.className.includes(MODAL_CLOSE_BUTTON)).length).toBe(1);
 	});
 
 	it('executes onDismiss when dismiss button is clicked', () => {

--- a/src/modal.test.js
+++ b/src/modal.test.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-addons-test-utils';
+import Modal, { MODAL_CLOSE_BUTTON } from './Modal';
+
+describe('Modal', () => {
+
+	let modal, modalEl, spyable;
+	const content = 'Test model content';
+
+	beforeEach(() => {
+		spyable = {
+			onDismiss: (e) => {}
+		};
+
+		spyOn(spyable, 'onDismiss');
+
+		modal = TestUtils.renderIntoDocument(
+			<Modal onDismiss={spyable.onDismiss}>{content}</Modal>
+		);
+		modalEl = ReactDOM.findDOMNode(modal);
+	});
+
+	afterEach(() => {
+		modalEl = null;
+	});
+
+	it('exists', () => {
+		expect(modalEl).not.toBeNull();
+	});
+
+	it('has SQ2 modal styles', () => {
+		expect(modalEl.classList).toContain('modal');
+	});
+
+	it('displays modal content', () => {
+		expect(modalEl.innerHTML).toContain(content);
+	});
+
+	it('creates an Icon component for dismissal', () => {
+		const icon = modalEl.getElementsByClassName('svg-icon')[0];
+
+		expect(icon).not.toBeNull();
+	});
+
+	it('creates a Button component for dismissal', () => {
+		const closeButton = modalEl.getElementsByClassName(MODAL_CLOSE_BUTTON)[0];
+
+		expect(closeButton).not.toBeNull();
+	});
+
+	it('executes onDismiss when dismiss button is clicked', () => {
+		const closeButton = modalEl.getElementsByClassName(MODAL_CLOSE_BUTTON)[0];
+
+		TestUtils.Simulate.click(closeButton);
+
+		expect(spyable.onDismiss).toHaveBeenCalled();
+	});
+
+	it('executes onDismiss when Escape key is pressed', () => {
+		TestUtils.Simulate.keyDown(modalEl, {key: 'Escape', keyCode: 27});
+
+		expect(spyable.onDismiss).toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
#### Description
The modal component needs to be added to MUG Comm. This PR breaks out that component from responsify land so that we can use it in mup-web. The goal was to keep this component as "dumb" as possible so we are passing in a dismiss handler rather than handling dismissal within the component.

#### Screenshot

<img width="526" alt="screen shot 2016-12-22 at 7 22 35 am" src="https://cloud.githubusercontent.com/assets/1885153/21401005/7cd62c18-c817-11e6-90bc-62ee99edc831.png">
