### PR TITLE
WC-25: TabsTab - adding other proptypes for labels

### DIFF
--- a/src/TabsTab.jsx
+++ b/src/TabsTab.jsx
@@ -34,7 +34,10 @@ class TabsTab extends React.Component {
 }
 TabsTab.propTypes = {
 	url: React.PropTypes.string.isRequired,
-	label: React.PropTypes.string.isRequired,
+	label: React.PropTypes.oneOfType([
+		React.PropTypes.string,
+		React.PropTypes.element,
+	]).isRequired,
 	isActive: React.PropTypes.bool,
 };
 


### PR DESCRIPTION
We are using other proptypes for labels like formatMessage, making list of acceptable labels more flexible.