### PR TITLE
Fix Avatar links

### DIFF
--- a/src/Avatar.jsx
+++ b/src/Avatar.jsx
@@ -55,18 +55,10 @@ class Avatar extends React.Component {
 		};
 
 		if (this.props.to || this.props.href) {
-			return (
-				<a {...allProps}>
-					{alt}
-				</a>
-			);
+			return <a {...allProps}>{alt}</a>;
 		}
 
-		return (
-			<span {...allProps}>
-				{alt}
-			</span>
-		);
+		return <span {...allProps}>{alt}</span>;
 	}
 }
 

--- a/src/Avatar.jsx
+++ b/src/Avatar.jsx
@@ -54,11 +54,19 @@ class Avatar extends React.Component {
 			...other
 		};
 
-		return (
-			<span {...allProps}>
-				{alt}
-			</span>
-		);
+		if (this.props.to || this.props.href) {
+			return (
+				<a {...allProps}>
+					{alt}
+				</a>
+			);
+		} else {
+			return (
+				<span {...allProps}>
+					{alt}
+				</span>
+			);
+		}
 	}
 }
 

--- a/src/Avatar.jsx
+++ b/src/Avatar.jsx
@@ -60,13 +60,13 @@ class Avatar extends React.Component {
 					{alt}
 				</a>
 			);
-		} else {
-			return (
-				<span {...allProps}>
-					{alt}
-				</span>
-			);
 		}
+
+		return (
+			<span {...allProps}>
+				{alt}
+			</span>
+		);
 	}
 }
 

--- a/src/avatar.test.js
+++ b/src/avatar.test.js
@@ -50,7 +50,7 @@ describe('Avatar', function() {
 
 		expect(avatarComponent.tagName.toLowerCase()).toBe('a');
 	});
-	it('renders a span element if `href` passed in', () => {
+	it('renders a span element if no `href` or `to` prop passed in', () => {
 		const avatar = TestUtils.renderIntoDocument(<Avatar className='test' />);
 		const avatarComponent = TestUtils.findRenderedDOMComponentWithClass(avatar, 'test');
 

--- a/src/avatar.test.js
+++ b/src/avatar.test.js
@@ -37,4 +37,23 @@ describe('Avatar', function() {
 		const avatarWithSrcNode = ReactDOM.findDOMNode(avatarWithSrc);
 		expect(avatarWithSrcNode.classList.contains('avatar--noPhoto')).toBe(false);
 	});
+
+	it('renders a link element if `href` passed in', () => {
+		const avatar = TestUtils.renderIntoDocument(<Avatar className='test' href='/' />);
+		const avatarComponent = TestUtils.findRenderedDOMComponentWithClass(avatar, 'test');
+
+		expect(avatarComponent.tagName.toLowerCase()).toBe('a');
+	});
+	it('renders a link element if `to` passed in', () => {
+		const avatar = TestUtils.renderIntoDocument(<Avatar className='test' to='/' />);
+		const avatarComponent = TestUtils.findRenderedDOMComponentWithClass(avatar, 'test');
+
+		expect(avatarComponent.tagName.toLowerCase()).toBe('a');
+	});
+	it('renders a span element if `href` passed in', () => {
+		const avatar = TestUtils.renderIntoDocument(<Avatar className='test' />);
+		const avatarComponent = TestUtils.findRenderedDOMComponentWithClass(avatar, 'test');
+
+		expect(avatarComponent.tagName.toLowerCase()).toBe('span');
+	});
 });


### PR DESCRIPTION
#### Related issues

Fixes https://meetup.atlassian.net/browse/WC-28

#### Description
This PR checks whether `href` or `to` props are passed into the component and conditionally returns a `<a>` or `<span>` element. This should fix the problem of not being able to click a `<span>` element in `mup-web`.

#### Prelim
Adding the Prelim tag until I confirm this works on `mup-web`.