### PR TITLE
use direct child selectors for popover option children styling

### DIFF
--- a/assets/scss/_popover.scss
+++ b/assets/scss/_popover.scss
@@ -37,7 +37,10 @@ $popoverShadow: 0 2px 2px 0 $C_border,0 3px 1px -2px $C_separator,0 1px 5px 0 $C
 
 .popover-menu-option {
 	cursor: pointer;
-	a, span, div, button {
+	& > a,
+	& > span,
+	& > div,
+	& > button {
 		display: block;
 		padding: $space-half $space;
 
@@ -50,7 +53,10 @@ $popoverShadow: 0 2px 2px 0 $C_border,0 3px 1px -2px $C_separator,0 1px 5px 0 $C
 
 .popover-container--menu:hover {
 	.popover-menu-option {
-		a, span, div, button {
+		& > a,
+		& > span,
+		& > div,
+		& > button {
 			&:focus {
 				background: transparent;
 			}


### PR DESCRIPTION
This fixes a bug where indirect children of `.popover-menu-option` were being unintentionally styled as options.