### PR TITLE
Remove popover overflow style

### DIFF
--- a/assets/scss/_popover.scss
+++ b/assets/scss/_popover.scss
@@ -24,7 +24,6 @@ $popoverShadow: 0 2px 2px 0 $C_border,0 3px 1px -2px $C_separator,0 1px 5px 0 $C
 	box-sizing: border-box;
 	box-shadow: $popoverShadow;
 	max-height: $block-6;
-	overflow: scroll;
 	position: absolute;
 	width: $view-minWidth;
 	z-index: 1;


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/MUP-7694

#### Description
The popover menu had a weird padding on _some_ screens. Removing this overflow style attribute seemed to do the trick, but I'm not sure why. After chatting with @akdetrick, this attribute might have been unintentional, so I don't see the harm in removing it.

