### PR TITLE
fully render each tab instead of just the children of the component

### DIFF
--- a/src/Tabs.jsx
+++ b/src/Tabs.jsx
@@ -16,7 +16,7 @@ class Tabs extends React.Component {
 				<li
 					key={i}
 					className={classNames}>
-					{tab.props.children}
+					{tab}
 				</li>
 			);
 		});


### PR DESCRIPTION
If you pass in a `<Link` component in the `tabs` prop, the `<Link` will not be rendered; only its children. This PR will allow the entire component to render.