### PR TITLE
Remove React Router peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-intl": "^2.2.3",
-    "react-router": "^3.0.2",
     "sassquatch2": "^2.4.4"
   },
   "devDependencies": {


### PR DESCRIPTION
#### Description

None of the MWC components use `<Link>`, so it doesn't need to be a peer dependency. Eventually we'll probably want something like Avatar to be able to use a within-app `<Link>`, but until then, there's no need for the peer dep.
