### PR TITLE
Accordion component

### DIFF
--- a/assets/scss/_accordion.scss
+++ b/assets/scss/_accordion.scss
@@ -1,0 +1,37 @@
+//
+// Animation values taken from https://github.com/google/material-design-lite/blob/mdl-1.x/src/_variables.scss
+// Maybe we can bring this into `swarm-constants` or `swarm-animation`?
+//
+
+$A_curve-fast-out-slow-in: cubic-bezier(0.4, 0, 0.2, 1);
+$A_curve-default: $A_curve-fast-out-slow-in;
+$A_duration: 0.2s;
+
+.accordionPanel-animator {
+	overflow: hidden;
+	transition: height $A_duration $A_curve-default;
+}
+
+.accordionPanel-animator--collapse {
+	height: 0;
+	margin-bottom: 0 !important;
+}
+
+.accordionPanel-label {
+	background: inherit;
+	border: inherit;
+	text-align: inherit;
+	padding: 0;
+}
+
+.accordionPanel-icon .svg--chevron-down .svg-icon {
+	-webkit-transform: rotate(0deg);
+	transform: rotate(0deg);
+	transition: transform $A_duration $A_curve-default;
+
+	.accordionPanel--active & {
+		-webkit-transform: rotate(180deg);
+		transform: rotate(180deg);
+	}
+
+}

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -14,4 +14,5 @@
 //
 // COMPONENT SPECIFIC
 //
+@import "accordion";
 @import "popover";

--- a/src/AccordionPanel.jsx
+++ b/src/AccordionPanel.jsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import cx from 'classnames';
+
+import Chunk from './Chunk';
+import Flex from './Flex';
+import FlexItem from './FlexItem';
+import Icon from './Icon';
+
+/**
+ * @module AccordionPanel
+ */
+class AccordionPanel extends React.Component {
+	/**
+	 * Document this for PR
+	 */
+	constructor(props){
+		super(props);
+		this.state = {
+			open: this.props.isOpen
+		};
+
+		this._handleToggle = this._handleToggle.bind(this);
+		this._updateHeight = this._updateHeight.bind(this);
+	}
+
+	/**
+	 * Document this for PR
+	 */
+	_handleToggle(event){
+		this.setState({
+			open: !this.state.open
+		});
+	}
+
+	_updateHeight() {
+		const content = ReactDOM.findDOMNode(this.content);
+		const animator = ReactDOM.findDOMNode(this.animator);
+		const height = this.props.isOpen ? content.clientHeight : 0;
+		const cssHeight = `${height}px`;
+
+		if (animator.style.height === cssHeight) {
+			return;
+		}
+
+		animator.style.height = cssHeight;
+	}
+
+	componentDidMount() {
+		this._updateHeight();
+	}
+
+	componentDidUpdate() {
+		this._updateHeight();
+	}
+
+	componentWillReceiveProps(nextProps) {
+		if (nextProps.isOpen !== this.state.open) {
+			this.setState({ open: nextProps.isOpen });
+		}
+	}
+
+	render() {
+		const {
+			isOpen, // eslint-disable-line no-unused-vars
+			name,
+			onTriggerClick,
+			panelContent,
+			triggerIconShape,
+			triggerIconShapeActive,
+			triggerIconSize,
+			triggerIconAlign,
+			triggerLabel,
+			animated,
+			classNamesActive,
+			className,
+			...other
+		} = this.props;
+
+		const classNames = {
+			accordionPanel: cx(
+				'accordionPanel',
+				{
+					'accordionPanel--active': this.state.open,
+					[classNamesActive]: this.state.open && classNamesActive
+				},
+				className
+			),
+			content: cx(
+				{
+					'accordionPanel-animator': animated,
+					'accordionPanel-animator--collapse': !this.state.open,
+					'visibility--a11yHide': !animated && !this.state.open
+				}
+			)
+		};
+
+		console.log(onTriggerClick);
+
+		return(
+			<Flex
+				className={classNames.accordionPanel}
+				rowReverse={triggerIconAlign == 'left' ? 'atAll' : null}
+				{...other}>
+
+				<FlexItem>
+					<Chunk>
+						<button
+							role='tab'
+							id={`label-${name}`}
+							aria-controls={`panel-${name}`}
+							aria-expanded={this.state.open}
+							aria-selected={this.state.open}
+							className='accordionPanel-label display--block span--100'
+							onClick={onTriggerClick}>
+								{triggerLabel}
+						</button>
+					</Chunk>
+
+					<Chunk
+						role='tabpanel'
+						aria-labelledby={`label-${name}`}
+						aria-hidden={!this.state.open}
+						className={classNames.content}
+						ref={(el) => { this.animator = el; }}>
+						<div
+							className='accordionPanel-content'
+							ref={(div) => { this.content = div; }}>
+							{panelContent}
+						</div>
+					</Chunk>
+				</FlexItem>
+
+				{triggerIconShape &&
+					<FlexItem
+						className='accordionPanel-icon'
+						onClick={onTriggerClick}
+						shrink>
+							{this.state.open && triggerIconShapeActive ?
+								<Icon
+									shape={triggerIconShapeActive}
+									size={triggerIconSize} /> :
+								<Icon
+									shape={triggerIconShape}
+									size={triggerIconSize} />
+								}
+					</FlexItem>
+				}
+
+			</Flex>
+		);
+	}
+}
+
+AccordionPanel.defaultProps = {
+	triggerIconAlign: 'right',
+	triggerIconShape: 'chevron-down',
+	triggerIconSize: 'xs',
+	isOpen: false
+};
+
+AccordionPanel.propTypes = {
+	isOpen: React.PropTypes.bool,
+	triggerIconAlign: React.PropTypes.string,
+	triggerIconShape: React.PropTypes.string,
+	triggerIconSize: React.React.PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl']),
+};
+
+export default AccordionPanel;

--- a/src/AccordionPanel.jsx
+++ b/src/AccordionPanel.jsx
@@ -95,8 +95,6 @@ class AccordionPanel extends React.Component {
 			)
 		};
 
-		console.log(onTriggerClick);
-
 		return(
 			<Flex
 				className={classNames.accordionPanel}
@@ -112,7 +110,7 @@ class AccordionPanel extends React.Component {
 							aria-expanded={this.state.open}
 							aria-selected={this.state.open}
 							className='accordionPanel-label display--block span--100'
-							onClick={onTriggerClick}>
+							onClick={onTriggerClick || this._handleToggle}>
 								{triggerLabel}
 						</button>
 					</Chunk>
@@ -134,7 +132,7 @@ class AccordionPanel extends React.Component {
 				{triggerIconShape &&
 					<FlexItem
 						className='accordionPanel-icon'
-						onClick={onTriggerClick}
+						onClick={onTriggerClick || this._handleToggle}
 						shrink>
 							{this.state.open && triggerIconShapeActive ?
 								<Icon
@@ -163,7 +161,7 @@ AccordionPanel.propTypes = {
 	isOpen: React.PropTypes.bool,
 	triggerIconAlign: React.PropTypes.string,
 	triggerIconShape: React.PropTypes.string,
-	triggerIconSize: React.React.PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl']),
+	triggerIconSize: React.PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl']),
 };
 
 export default AccordionPanel;

--- a/src/AccordionPanelGroup.jsx
+++ b/src/AccordionPanelGroup.jsx
@@ -84,6 +84,7 @@ class AccordionPanelGroup extends React.Component {
 			accordionPanels, // eslint-disable-line no-unused-vars
 			triggerIconAlign, // eslint-disable-line no-unused-vars
 			triggerIconShape, // eslint-disable-line no-unused-vars
+			triggerIconShapeActive, // eslint-disable-line no-unused-vars
 			triggerIconSize, // eslint-disable-line no-unused-vars
 			multiSelectable,
 			className,
@@ -120,6 +121,7 @@ AccordionPanelGroup.propTypes = {
 	accordionPanels: React.PropTypes.arrayOf(React.PropTypes.element).isRequired,
 	multiSelectable: React.PropTypes.bool,
 	triggerIconAlign: React.PropTypes.string,
+	triggerIconShapeActive: React.PropTypes.string,
 	triggerIconShape: React.PropTypes.string,
 	triggerIconSize: React.PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl']),
 };

--- a/src/AccordionPanelGroup.jsx
+++ b/src/AccordionPanelGroup.jsx
@@ -121,7 +121,7 @@ AccordionPanelGroup.propTypes = {
 	multiSelectable: React.PropTypes.bool,
 	triggerIconAlign: React.PropTypes.string,
 	triggerIconShape: React.PropTypes.string,
-	triggerIconSize: React.React.PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl']),
+	triggerIconSize: React.PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl']),
 };
 
 export default AccordionPanelGroup;

--- a/src/AccordionPanelGroup.jsx
+++ b/src/AccordionPanelGroup.jsx
@@ -1,0 +1,127 @@
+import _ from 'lodash';
+import React from 'react';
+import cx from 'classnames';
+
+/**
+ * @module AccordionPanelGroup
+ */
+class AccordionPanelGroup extends React.Component {
+	constructor(props) {
+		super(props);
+		const activePanelsArr = [];
+
+		this.accordionPanels = this.props.accordionPanels.map((accordionPanel, i) => {
+			if(accordionPanel.props.isOpen) {
+				activePanelsArr.push(i);
+			}
+			return activePanelsArr;
+		});
+
+		this.state = {
+			activePanels: activePanelsArr || []
+		};
+		this._onClickTrigger = this._onClickTrigger.bind(this);
+	}
+
+	/**
+	 * Document this for PR
+	 */
+	_onClickTrigger(e, i){
+		const index = this.state.activePanels.indexOf(i);
+		const activePanelArr = this.state.activePanels;
+		const filtered = activePanelArr.filter(panel => i !== activePanelArr.indexOf(i));
+
+		if (index > -1){
+			activePanelArr.splice(index, 1);
+		} else {
+			activePanelArr.push(i);
+		}
+
+		if (!this.props.multiSelectable) {
+			_.pullAll(activePanelArr, filtered);
+		}
+
+		this.setState({
+			activePanels: activePanelArr
+		});
+
+	}
+
+	renderAccordionPanels() {
+		const toCamelCase = (str) => str.slice(0,20).replace(/(?:^\w|[A-Z]|\b\w)/g, (ltr, idx) => idx === 0 ? ltr.toLowerCase() : ltr.toUpperCase()).replace(/\s+/g, '');
+		this.accordionPanels = this.props.accordionPanels.map((accordionPanel, i) => {
+
+			return (
+				<li
+					className='list-item'
+					key={i}
+				>
+					{
+						React.cloneElement(accordionPanel,
+							{
+								triggerIconAlign: this.props.triggerIconAlign,
+								triggerIconShape: this.props.triggerIconShape,
+								triggerIconShapeActive: this.props.triggerIconShapeActive,
+								triggerIconSize: this.props.triggerIconSize,
+								animated: this.props.animated,
+								name: toCamelCase(accordionPanel.props.triggerLabel),
+								className: accordionPanel.props.className,
+								isOpen: this.state.activePanels.includes(i),
+								onTriggerClick: (e) => this._onClickTrigger(e, i),
+							}
+						)
+					}
+				</li>
+			);
+		});
+
+		return this.accordionPanels;
+	}
+
+	render() {
+		const {
+			animated, // eslint-disable-line no-unused-vars
+			accordionPanels, // eslint-disable-line no-unused-vars
+			triggerIconAlign, // eslint-disable-line no-unused-vars
+			triggerIconShape, // eslint-disable-line no-unused-vars
+			triggerIconSize, // eslint-disable-line no-unused-vars
+			multiSelectable,
+			className,
+			...other
+		} = this.props;
+
+		const classNames = cx(
+			'accordionPanelGroup',
+			'list',
+			className
+		);
+
+		return (
+			<ul
+				role='tabList'
+				aria-multiselectable={multiSelectable}
+				className={classNames}
+				{...other}>
+					{this.renderAccordionPanels()}
+			</ul>
+		);
+	}
+}
+
+AccordionPanelGroup.defaultProps = {
+	multiSelectable: true,
+	triggerIconAlign: 'right',
+	triggerIconShape: 'chevron-down',
+	triggerIconSize: 'xs',
+};
+
+
+AccordionPanelGroup.propTypes = {
+	accordionPanels: React.PropTypes.arrayOf(React.PropTypes.element).isRequired,
+	multiSelectable: React.PropTypes.bool,
+	triggerIconAlign: React.PropTypes.string,
+	triggerIconShape: React.PropTypes.string,
+	triggerIconSize: React.React.PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl']),
+};
+
+export default AccordionPanelGroup;

--- a/src/accordionPanel.story.jsx
+++ b/src/accordionPanel.story.jsx
@@ -1,0 +1,26 @@
+
+import React from 'react';
+import AccordionPanel from './AccordionPanel';
+import { storiesOf } from '@kadira/storybook';
+
+/*
+ * -- Inline SVG icon sprite --
+ *
+ * raw SVG sprite from `swarm-icons`
+ */
+const iconSpriteStyle = { display: 'none' };
+const iconSprite = require('raw-loader!swarm-icons/dist/sprite/sprite.inc');
+
+storiesOf('AccordionPanel', module)
+	.add('default', () => (
+		<div className='span--100 padding--all'>
+			<AccordionPanel
+				triggerLabel='First Section'
+				panelContent={
+					<div className='runningText'>
+						<p>Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.</p>
+					</div>
+				} />
+			<div style={iconSpriteStyle} dangerouslySetInnerHTML={{__html: iconSprite}} />
+		</div>
+	));

--- a/src/accordionPanel.test.jsx
+++ b/src/accordionPanel.test.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-addons-test-utils';
+import AccordionPanel from './AccordionPanel';
+
+describe('AccordionPanel', function() {
+
+	it('exists', function() {
+		const accordion = TestUtils.renderIntoDocument(<AccordionPanel />);
+		const accordionNode = ReactDOM.findDOMNode(accordion);
+
+		expect(accordionNode).not.toBeNull();
+	});
+
+});

--- a/src/accordionPanelGroup.story.jsx
+++ b/src/accordionPanelGroup.story.jsx
@@ -1,0 +1,231 @@
+
+import React from 'react';
+import AccordionPanelGroup from './AccordionPanelGroup';
+import AccordionPanel from './AccordionPanel';
+import { storiesOf } from '@kadira/storybook';
+
+/*
+ * -- Inline SVG icon sprite --
+ *
+ * raw SVG sprite from `swarm-icons`
+ */
+const iconSpriteStyle = { display: 'none' };
+const iconSprite = require('raw-loader!swarm-icons/dist/sprite/sprite.inc');
+
+storiesOf('AccordionPanelGroup', module)
+	.add('default', () => (
+		<div className='span--100 padding--all'>
+			<AccordionPanelGroup
+				accordionPanels={[
+					<AccordionPanel
+						triggerLabel='First Section'
+						panelContent={
+							<div className='runningText'>
+								<p>Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.</p>
+							</div>
+						} />,
+					<AccordionPanel
+						triggerLabel='Next Section'
+						panelContent={
+							<div>
+								<div className='runningText'>
+									<p>Any kind of content can go in here, even inputs.</p>
+								</div>
+								<div className='chunk'>
+									<label htmlFor='test-textinput'>I'm a label</label>
+									<input id='test-textinput' type='text' placeholder='Input placeholder' />
+								</div>
+							</div>
+						} />,
+					<AccordionPanel
+						triggerLabel='Third Section'
+						panelContent={
+							<div className='runningText'>
+								<p>Classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.</p>
+							</div>
+						} />,
+				]}/>
+			<div style={iconSpriteStyle} dangerouslySetInnerHTML={{__html: iconSprite}} />
+		</div>
+	))
+	.add('Custom icons', () => (
+		<div className='span--100 padding--all'>
+			<AccordionPanelGroup
+				triggerIconShape='plus'
+				triggerIconShapeActive='minus'
+				accordionPanels={[
+					<AccordionPanel
+						triggerLabel='First Section'
+						panelContent={
+							<div className='runningText'>
+								<p>Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.</p>
+							</div>
+						} />,
+					<AccordionPanel
+						triggerLabel='Next Section'
+						panelContent={
+							<div>
+								<div className='runningText'>
+									<p>Any kind of content can go in here, even inputs.</p>
+								</div>
+								<div className='chunk'>
+									<label htmlFor='test-textinput'>I'm a label</label>
+									<input id='test-textinput' type='text' placeholder='Input placeholder' />
+								</div>
+							</div>
+						} />,
+					<AccordionPanel
+						triggerLabel='Third Section'
+						panelContent={
+							<div className='runningText'>
+								<p>Classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.</p>
+							</div>
+						} />,
+				]}/>
+			<div style={iconSpriteStyle} dangerouslySetInnerHTML={{__html: iconSprite}} />
+		</div>
+	))
+	.add('Left-aligned icon', () => (
+		<div className='span--100 padding--all'>
+			<AccordionPanelGroup
+				triggerIconAlign='left'
+				accordionPanels={[
+					<AccordionPanel
+						triggerLabel='First Section'
+						panelContent={
+							<div className='runningText'>
+								<p>Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.</p>
+							</div>
+						} />,
+					<AccordionPanel
+						triggerLabel='Next Section'
+						panelContent={
+							<div>
+								<div className='runningText'>
+									<p>Any kind of content can go in here, even inputs.</p>
+								</div>
+								<div className='chunk'>
+									<label htmlFor='test-textinput'>I'm a label</label>
+									<input id='test-textinput' type='text' placeholder='Input placeholder' />
+								</div>
+							</div>
+						} />,
+					<AccordionPanel
+						triggerLabel='Third Section'
+						panelContent={
+							<div className='runningText'>
+								<p>Classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.</p>
+							</div>
+						} />,
+				]}/>
+			<div style={iconSpriteStyle} dangerouslySetInnerHTML={{__html: iconSprite}} />
+		</div>
+	))
+	.add('Animated', () => (
+		<div className='span--100 padding--all'>
+			<AccordionPanelGroup
+				animated
+				accordionPanels={[
+					<AccordionPanel
+						triggerLabel='First Section'
+						panelContent={
+							<div className='runningText'>
+								<p>Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.</p>
+							</div>
+						} />,
+					<AccordionPanel
+						triggerLabel='Next Section'
+						panelContent={
+							<div>
+								<div className='runningText'>
+									<p>Any kind of content can go in here, even inputs.</p>
+								</div>
+								<div className='chunk'>
+									<label htmlFor='test-textinput'>I'm a label</label>
+									<input id='test-textinput' type='text' placeholder='Input placeholder' />
+								</div>
+							</div>
+						} />,
+					<AccordionPanel
+						triggerLabel='Third Section'
+						panelContent={
+							<div className='runningText'>
+								<p>Classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.</p>
+							</div>
+						} />,
+				]}/>
+			<div style={iconSpriteStyle} dangerouslySetInnerHTML={{__html: iconSprite}} />
+		</div>
+	))
+	.add('Select open panels', () => (
+		<div className='span--100 padding--all'>
+			<AccordionPanelGroup
+				accordionPanels={[
+					<AccordionPanel
+						isOpen
+						triggerLabel='First Section'
+						panelContent={
+							<div className='runningText'>
+								<p>Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.</p>
+							</div>
+						} />,
+					<AccordionPanel
+						triggerLabel='Next Section'
+						panelContent={
+							<div>
+								<div className='runningText'>
+									<p>Any kind of content can go in here, even inputs.</p>
+								</div>
+								<div className='chunk'>
+									<label htmlFor='test-textinput'>I'm a label</label>
+									<input id='test-textinput' type='text' placeholder='Input placeholder' />
+								</div>
+							</div>
+						} />,
+					<AccordionPanel
+						triggerLabel='Third Section'
+						panelContent={
+							<div className='runningText'>
+								<p>Classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.</p>
+							</div>
+						} />,
+				]}/>
+			<div style={iconSpriteStyle} dangerouslySetInnerHTML={{__html: iconSprite}} />
+		</div>
+	))
+	.add('One panel at a time', () => (
+		<div className='span--100 padding--all'>
+			<AccordionPanelGroup
+				multiSelectable={false}
+				accordionPanels={[
+					<AccordionPanel
+						triggerLabel='First Section'
+						panelContent={
+							<div className='runningText'>
+								<p>Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.</p>
+							</div>
+						} />,
+					<AccordionPanel
+						triggerLabel='Next Section'
+						panelContent={
+							<div>
+								<div className='runningText'>
+									<p>Any kind of content can go in here, even inputs.</p>
+								</div>
+								<div className='chunk'>
+									<label htmlFor='test-textinput'>I'm a label</label>
+									<input id='test-textinput' type='text' placeholder='Input placeholder' />
+								</div>
+							</div>
+						} />,
+					<AccordionPanel
+						triggerLabel='Third Section'
+						panelContent={
+							<div className='runningText'>
+								<p>Classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.</p>
+							</div>
+						} />,
+				]}/>
+			<div style={iconSpriteStyle} dangerouslySetInnerHTML={{__html: iconSprite}} />
+		</div>
+	));

--- a/src/accordionPanelGroup.test.jsx
+++ b/src/accordionPanelGroup.test.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-addons-test-utils';
+import AccordionPanelGroupContainer from './AccordionPanelGroupContainer';
+
+describe('AccordionPanelGroupContainer', function() {
+
+	it('exists', function() {
+		const accordionPanelGroup = TestUtils.renderIntoDocument(<AccordionPanelGroupContainer />);
+		const accordionPanelGroupNode = ReactDOM.findDOMNode(accordionPanelGroup);
+
+		expect(accordionPanelGroupNode).not.toBeNull();
+	});
+
+});


### PR DESCRIPTION
#### Related issues
For the upcoming work on event create

#### Description
A component to handle cases where we hide and show panels of related content. Each panel has a label that is always visible and summarizes the content that will be shown by clicking the label.

#### Screenshots (if applicable)
![screen shot 2017-02-13 at 3 06 19 pm](https://cloud.githubusercontent.com/assets/2313998/22900935/1ad6b27e-f1fe-11e6-8046-e42cf8a8c938.png)

