### PR TITLE
Copy testUtils from mocks repo into compenents repo

### DIFF
--- a/src/modal.test.js
+++ b/src/modal.test.js
@@ -1,8 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
-import { findComponentsWithType } from 'meetup-web-mocks/lib/testUtils';
-import Modal, { MODAL_CLOSE_BUTTON } from './Modal';
+import
+	Modal,
+	{ MODAL_CLOSE_BUTTON }
+from './Modal';
+
+import { findComponentsWithType } from './utils/testUtils';
 
 describe('Modal', () => {
 

--- a/src/modal.test.js
+++ b/src/modal.test.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
-import
-	Modal,
-	{ MODAL_CLOSE_BUTTON }
-from './Modal';
 
-import { findComponentsWithType } from './utils/testUtils';
+import Button from './Button';
+import Modal, {
+	MODAL_CLOSE_BUTTON
+} from './Modal';
 
 describe('Modal', () => {
 
@@ -43,7 +42,7 @@ describe('Modal', () => {
 	});
 
 	it('creates a Button component for dismissal', () => {
-		const buttons = findComponentsWithType(modal, 'Button');
+		const buttons = TestUtils.scryRenderedComponentsWithType(modal, Button);
 		expect(buttons.filter(button => button.props.className.includes(MODAL_CLOSE_BUTTON)).length).toBe(1);
 	});
 

--- a/src/stripe.test.jsx
+++ b/src/stripe.test.jsx
@@ -9,7 +9,7 @@ import Stripe, {
 	STRIPE_HERO_CLASS,
 } from './Stripe';
 
-import { findComponentsWithType } from './utils/testUtils';
+import Bounds from './Bounds';
 
 describe('Stripe', function() {
 
@@ -85,7 +85,7 @@ describe('Stripe', function() {
 			expect(stripeNode.classList).toContain(STRIPE_HERO_CLASS);
 		});
 		it('should render a `Bounds` component', () => {
-			const boundComponent = findComponentsWithType(stripeHero, 'Bounds');
+			const boundComponent = TestUtils.scryRenderedComponentsWithType(stripeHero, Bounds);
 			expect(boundComponent.length).toBe(1);
 		});
 	});

--- a/src/stripe.test.jsx
+++ b/src/stripe.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
-import { findComponentsWithType } from 'meetup-web-mocks/lib/testUtils';
 
 import Stripe, {
 	STRIPE_CLASS,
@@ -9,6 +8,8 @@ import Stripe, {
 	STRIPE_INVERTED_CLASS,
 	STRIPE_HERO_CLASS,
 } from './Stripe';
+
+import { findComponentsWithType } from './utils/testUtils';
 
 describe('Stripe', function() {
 

--- a/src/utils/testUtils.js
+++ b/src/utils/testUtils.js
@@ -1,6 +1,53 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
+import RouterContext from 'react-router/lib/RouterContext';
+import match from 'react-router/lib/match';
+
+import { IntlProvider } from 'react-intl';
+import { Provider } from 'react-redux';
+import { MOCK_APP_STATE } from 'meetup-web-mocks/lib/app';
+
+
+export const findComponentsWithType = (tree, typeString) =>
+	TestUtils.findAllInRenderedTree(
+		tree,
+		(component) => component && component.constructor.name === typeString
+	);
+
+export const createFakeStore = fakeData => ({
+	getState() {
+		return fakeData;
+	},
+	dispatch() {},
+	subscribe() {},
+});
+
+/**
+ * Curry a function that takes a set of React Router routes and a location to
+ * render, and return a Promise that resolves with the rendered React app
+ *
+ * @example
+ * ```
+ * const renderLocation = routeRenderer(routes);
+ * renderLocation('/').then(app => ...);
+ * renderLocation('/foo').then(app => ...);
+ * ```
+ */
+export const routeRenderer = routes => (location, state=MOCK_APP_STATE) =>
+	new Promise((resolve, reject) =>
+		match({ location, routes }, (err, redirectLocation, renderProps) => {
+			const FAKE_STORE = createFakeStore(state);
+			const app = TestUtils.renderIntoDocument(
+				<IntlProvider locale='en'>
+					<Provider store={FAKE_STORE}>
+						<RouterContext {...renderProps} />
+					</Provider>
+				</IntlProvider>
+			);
+			resolve(app);
+		})
+	);
 
 export const variantTest = (FoundationComponent, className, variants) => {
 	variants.forEach(variant => {

--- a/src/utils/testUtils.js
+++ b/src/utils/testUtils.js
@@ -1,53 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
-import RouterContext from 'react-router/lib/RouterContext';
-import match from 'react-router/lib/match';
-
-import { IntlProvider } from 'react-intl';
-import { Provider } from 'react-redux';
-import { MOCK_APP_STATE } from 'meetup-web-mocks/lib/app';
-
-
-export const findComponentsWithType = (tree, typeString) =>
-	TestUtils.findAllInRenderedTree(
-		tree,
-		(component) => component && component.constructor.name === typeString
-	);
-
-export const createFakeStore = fakeData => ({
-	getState() {
-		return fakeData;
-	},
-	dispatch() {},
-	subscribe() {},
-});
-
-/**
- * Curry a function that takes a set of React Router routes and a location to
- * render, and return a Promise that resolves with the rendered React app
- *
- * @example
- * ```
- * const renderLocation = routeRenderer(routes);
- * renderLocation('/').then(app => ...);
- * renderLocation('/foo').then(app => ...);
- * ```
- */
-export const routeRenderer = routes => (location, state=MOCK_APP_STATE) =>
-	new Promise((resolve, reject) =>
-		match({ location, routes }, (err, redirectLocation, renderProps) => {
-			const FAKE_STORE = createFakeStore(state);
-			const app = TestUtils.renderIntoDocument(
-				<IntlProvider locale='en'>
-					<Provider store={FAKE_STORE}>
-						<RouterContext {...renderProps} />
-					</Provider>
-				</IntlProvider>
-			);
-			resolve(app);
-		})
-	);
 
 export const variantTest = (FoundationComponent, className, variants) => {
 	variants.forEach(variant => {


### PR DESCRIPTION
We want to minimize the number of dependencies that the meetup-web-mocks repo has, so we're going to have each consumer repo maintain it's own testUtils.jsx.
