### PR TITLE
Adding onChange prop for TextInput

### DIFF
--- a/src/TextInput.jsx
+++ b/src/TextInput.jsx
@@ -19,10 +19,6 @@ class TextInput extends React.Component {
 		this.props.onChange(e);
 	}
 
-	getValue() {
-		return this.state.value;
-	}
-
 	render() {
 		const {
 			name,

--- a/src/TextInput.jsx
+++ b/src/TextInput.jsx
@@ -16,18 +16,24 @@ class TextInput extends React.Component {
 
 	onChange(e) {
 		this.setState({ value: e.target.value });
+		this.props.onChange(e);
+	}
+
+	getValue() {
+		return this.state.value;
 	}
 
 	render() {
 		const {
 			name,
-			value,	// eslint-disable-line no-unused-vars
+			value, // eslint-disable-line no-unused-vars
 			label,
 			labelClassName,
 			className,
 			children,
 			error,
 			required,
+			onChange, // eslint-disable-line no-unused-vars
 			...other
 		} = this.props;
 
@@ -75,7 +81,8 @@ TextInput.propTypes = {
 		React.PropTypes.element
 	]),
 	labelClassName: React.PropTypes.string,
-	required: React.PropTypes.bool
+	required: React.PropTypes.bool,
+	onChange: React.PropTypes.func.isRequired,
 };
 
 export default TextInput;

--- a/src/TextInput.jsx
+++ b/src/TextInput.jsx
@@ -78,7 +78,7 @@ TextInput.propTypes = {
 	]),
 	labelClassName: React.PropTypes.string,
 	required: React.PropTypes.bool,
-	onChange: React.PropTypes.func.isRequired,
+	onChange: React.PropTypes.func,
 };
 
 export default TextInput;

--- a/src/TextInput.jsx
+++ b/src/TextInput.jsx
@@ -16,7 +16,9 @@ class TextInput extends React.Component {
 
 	onChange(e) {
 		this.setState({ value: e.target.value });
-		this.props.onChange(e);
+		if (this.props.onChange) {
+			this.props.onChange(e);
+		}
 	}
 
 	render() {

--- a/src/textInput.test.jsx
+++ b/src/textInput.test.jsx
@@ -78,11 +78,6 @@ describe('TextInput', function() {
 		expect(inputEl.value).toEqual(newValue);
 	});
 
-	it('should return value when `getValue`', function() {
-		TestUtils.Simulate.change(inputEl, { target: { value: `${VALUE}r` } });
-		expect(textInputComponent.getValue()).toEqual(inputEl.value);
-	});
-
 	it('should call onChange and setState with input change', function() {
 		const newValue = `${VALUE}r`;
 		const changeSpy = spyOn(TextInput.prototype, 'onChange').and.callThrough();

--- a/src/textInput.test.jsx
+++ b/src/textInput.test.jsx
@@ -19,13 +19,15 @@ describe('TextInput', function() {
 			maxLength: MAX_LEN,
 			error: ERROR_TEXT,
 			required: true,
-			onChange,
 		};
-		textInputComponent = TestUtils.renderIntoDocument(<TextInput
-			name={NAME_ATTR}
-			label={LABEL_TEXT}
-			value={VALUE}
-			{...formAttrs} />);
+		textInputComponent = TestUtils.renderIntoDocument(
+			<TextInput
+				name={NAME_ATTR}
+				label={LABEL_TEXT}
+				value={VALUE}
+				{...formAttrs}
+			/>
+		);
 
 		inputEl = TestUtils.findRenderedDOMComponentWithTag(textInputComponent, 'input');
 	});

--- a/src/textInput.test.jsx
+++ b/src/textInput.test.jsx
@@ -3,7 +3,7 @@ import TestUtils from 'react-addons-test-utils';
 import TextInput from './TextInput';
 
 describe('TextInput', function() {
-
+	const onChange = jest.fn();
 	const LABEL_TEXT = 'Super Hero',
 		VALUE = 'Batman',
 		NAME_ATTR = 'superhero',
@@ -18,7 +18,8 @@ describe('TextInput', function() {
 			id: NAME_ATTR,
 			maxLength: MAX_LEN,
 			error: ERROR_TEXT,
-			required: true
+			required: true,
+			onChange,
 		};
 		textInputComponent = TestUtils.renderIntoDocument(<TextInput
 			name={NAME_ATTR}
@@ -77,20 +78,45 @@ describe('TextInput', function() {
 		expect(inputEl.value).toEqual(newValue);
 	});
 
+	it('should return value when `getValue`', function() {
+		TestUtils.Simulate.change(inputEl, { target: { value: `${VALUE}r` } });
+		expect(textInputComponent.getValue()).toEqual(inputEl.value);
+	});
+
 	it('should call onChange and setState with input change', function() {
 		const newValue = `${VALUE}r`;
 		const changeSpy = spyOn(TextInput.prototype, 'onChange').and.callThrough();
 		const stateSpy = spyOn(TextInput.prototype, 'setState').and.callThrough();
 
-		const boundComponent = TestUtils.renderIntoDocument(<TextInput
-			name={NAME_ATTR}
-			label={LABEL_TEXT}
-			value={VALUE} />);
+		const boundComponent = TestUtils.renderIntoDocument(
+			<TextInput
+				name={NAME_ATTR}
+				label={LABEL_TEXT}
+				value={VALUE}
+				onChange={onChange}
+			/>
+		);
 
 		inputEl = TestUtils.findRenderedDOMComponentWithTag(boundComponent, 'input');
 		TestUtils.Simulate.change(inputEl, { target: { value: newValue } });
 
 		expect(changeSpy).toHaveBeenCalled();
 		expect(stateSpy).toHaveBeenCalledWith({ value: newValue });
+	});
+
+	it('should call onChange `props` function when input is changed', () => {
+		const newValue = `${VALUE}r`;
+		const boundComponent = TestUtils.renderIntoDocument(
+			<TextInput
+				name={NAME_ATTR}
+				label={LABEL_TEXT}
+				value={VALUE}
+				onChange={onChange}
+			/>
+		);
+		inputEl = TestUtils.findRenderedDOMComponentWithTag(boundComponent, 'input');
+		TestUtils.Simulate.change(inputEl, { target: { value: newValue } });
+
+		expect(onChange).toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
#### Description
DoD:
- Adding onChange prop so outside React components can get updates as input changes
- Adding a `getValue` function for form submissions
