### PR TITLE
Add optional label to PageHead

### DIFF
--- a/src/PageHead.jsx
+++ b/src/PageHead.jsx
@@ -64,7 +64,9 @@ class PageHead extends React.Component {
 					direction='column'
 					switchDirection='large'
 				>
-					<FlexItem>
+					<FlexItem
+						growFactor={2}
+					>
 						<Chunk className='align--center atMedium_align--left'>
 							{titleLabel &&
 								<p className={classNames.titleLabel}>{titleLabel}</p>

--- a/src/PageHead.jsx
+++ b/src/PageHead.jsx
@@ -27,6 +27,7 @@ class PageHead extends React.Component {
 			subtitle,
 			title,
 			titleLabel,
+			titleLabelClass,
 			menuItems,
 			...other
 		} = this.props;
@@ -34,6 +35,11 @@ class PageHead extends React.Component {
 		const classNames = cx(
 			PAGE_HEAD_CLASS,
 			className
+		);
+
+		const titleLabelClassNames = cx(
+			PAGE_TITLELABEL_CLASS,
+			titleLabelClass
 		);
 
 		const menuRender = menuItems.map((menuItem, i) => (
@@ -55,7 +61,7 @@ class PageHead extends React.Component {
 					<FlexItem>
 						<Chunk className='align--center atMedium_align--left'>
 							{titleLabel &&
-								<p className={`${PAGE_TITLELABEL_CLASS} text--label`}>{titleLabel}</p>
+								<p className={`${titleLabelClassNames} text--label`}>{titleLabel}</p>
 							}
 							<h1 className='text--display1'>{title}</h1>
 							{subtitle &&
@@ -86,6 +92,11 @@ PageHead.propTypes = {
 		React.PropTypes.string,
 		React.PropTypes.element
 	]),
+	titleLabel: React.PropTypes.oneOfType([
+		React.PropTypes.string,
+		React.PropTypes.element
+	]),
+	titleLabelClass: React.PropTypes.string,
 	menuItems: React.PropTypes.array,
 };
 PageHead.defaultProps = {

--- a/src/PageHead.jsx
+++ b/src/PageHead.jsx
@@ -7,6 +7,7 @@ import Section from './Section';
 
 export const PAGE_HEAD_CLASS = 'pageHead';
 export const PAGE_TITLE_CLASS = 'pageTitle';
+export const PAGE_TITLELABEL_CLASS = 'pageTitleLabel';
 export const PAGE_SUBTITLE_CLASS = 'pageSubtitle';
 export const PAGE_ACTIONS_CLASS = 'pageActions';
 export const PAGE_ACTION_CLASS = 'pageAction';
@@ -25,6 +26,7 @@ class PageHead extends React.Component {
 			className,
 			subtitle,
 			title,
+			titleLabel,
 			menuItems,
 			...other
 		} = this.props;
@@ -52,6 +54,9 @@ class PageHead extends React.Component {
 				>
 					<FlexItem>
 						<Chunk className='align--center atMedium_align--left'>
+							{titleLabel &&
+								<p className={`${PAGE_TITLELABEL_CLASS} text--label`}>{titleLabel}</p>
+							}
 							<h1 className='text--display1'>{title}</h1>
 							{subtitle &&
 								<p className={`${PAGE_SUBTITLE_CLASS} text--secondary`}>{subtitle}</p>

--- a/src/PageHead.jsx
+++ b/src/PageHead.jsx
@@ -32,15 +32,21 @@ class PageHead extends React.Component {
 			...other
 		} = this.props;
 
-		const classNames = cx(
-			PAGE_HEAD_CLASS,
-			className
-		);
-
-		const titleLabelClassNames = cx(
-			PAGE_TITLELABEL_CLASS,
-			titleLabelClass
-		);
+		const classNames = {
+			pageHead: cx(
+				PAGE_HEAD_CLASS,
+				className
+			),
+			titleLabel: cx(
+				PAGE_TITLELABEL_CLASS,
+				'text--label',
+				titleLabelClass
+			),
+			subtitle: cx(
+				PAGE_SUBTITLE_CLASS,
+				'text--secondary'
+			)
+		};
 
 		const menuRender = menuItems.map((menuItem, i) => (
 			<FlexItem className={PAGE_ACTION_CLASS} key={i} shrink>
@@ -50,7 +56,7 @@ class PageHead extends React.Component {
 
 		return (
 			<Section
-				className={classNames}
+				className={classNames.pageHead}
 				{...other}
 			>
 				<Flex
@@ -61,11 +67,11 @@ class PageHead extends React.Component {
 					<FlexItem>
 						<Chunk className='align--center atMedium_align--left'>
 							{titleLabel &&
-								<p className={`${titleLabelClassNames} text--label`}>{titleLabel}</p>
+								<p className={classNames.titleLabel}>{titleLabel}</p>
 							}
 							<h1 className='text--display1'>{title}</h1>
 							{subtitle &&
-								<p className={`${PAGE_SUBTITLE_CLASS} text--secondary`}>{subtitle}</p>
+								<p className={classNames.subtitle}>{subtitle}</p>
 							}
 						</Chunk>
 					</FlexItem>

--- a/src/pageHead.story.jsx
+++ b/src/pageHead.story.jsx
@@ -41,6 +41,14 @@ storiesOf('PageHead', module)
 			/>
 		</div>
 	))
+	.add('title and titleLabel', () => (
+		<div style={{border:'1px dotted red', width:'100%'}}>
+			<PageHead
+				titleLabel='Not vegetarian'
+				title='Sirloin short ribs rump ham turducken pork chop drumstick'
+			/>
+		</div>
+	))
 	.add('title and actions', () => {
 		const menu = [
 			<PageActionButton icon={searchIcon} label='Search' />,

--- a/src/pageHead.story.jsx
+++ b/src/pageHead.story.jsx
@@ -49,6 +49,22 @@ storiesOf('PageHead', module)
 			/>
 		</div>
 	))
+	.add('title and styled titleLabel', () => (
+		<div style={{border:'1px dotted red', width:'100%'}}>
+			<style>
+				{'\
+					.pageTitleLabel--urgent{\
+						color: #ED1C40;\
+					}\
+				'}
+			</style>
+			<PageHead
+				titleLabel='Not vegetarian'
+				titleLabelClass='pageTitleLabel--urgent'
+				title='Sirloin short ribs rump ham turducken pork chop drumstick'
+			/>
+		</div>
+	))
 	.add('title and actions', () => {
 		const menu = [
 			<PageActionButton icon={searchIcon} label='Search' />,

--- a/src/pageHead.test.jsx
+++ b/src/pageHead.test.jsx
@@ -81,14 +81,10 @@ describe('PageHead', function() {
 			expect(pageTitle.textContent).toContain(titleLabel);
 		});
 		it(`should have an element with class of '${PAGE_TITLELABEL_CLASS}'`, () => {
-			const pageHeadEl = ReactDOM.findDOMNode(pageHead);
-			const titleLabelEl = pageHeadEl.getElementsByClassName(PAGE_TITLELABEL_CLASS);
-			expect(titleLabelEl.length).toBe(1);
+			expect(() => TestUtils.findRenderedDOMComponentWithClass(pageHead, PAGE_TITLELABEL_CLASS)).not.toThrow();
 		});
 		it('should handle custom classes', () => {
-			const pageHeadEl = ReactDOM.findDOMNode(pageHead);
-			const titleLabelEl = pageHeadEl.getElementsByClassName(titleLabelCustomClass);
-			expect(titleLabelEl.length).toBe(1);
+			expect(() => TestUtils.findRenderedDOMComponentWithClass(pageHead, titleLabelCustomClass)).not.toThrow();
 		});
 	});
 	describe('subtitle', () => {

--- a/src/pageHead.test.jsx
+++ b/src/pageHead.test.jsx
@@ -29,6 +29,7 @@ const menu = [
 	],
 	pageTitle = 'Page title',
 	titleLabel = 'Title label',
+	titleLabelCustomClass = `${PAGE_TITLELABEL_CLASS}--urgent`,
 	subtitle = 'Sub title';
 
 let pageHead;
@@ -72,7 +73,7 @@ describe('PageHead', function() {
 	describe('titleLabel', () => {
 		beforeEach(() => {
 			pageHead = TestUtils.renderIntoDocument(
-				<PageHead title={pageTitle} titleLabel={titleLabel} />
+				<PageHead title={pageTitle} titleLabel={titleLabel} titleLabelClass={titleLabelCustomClass} />
 			);
 		});
 		it('should display a text label area', () => {
@@ -82,6 +83,11 @@ describe('PageHead', function() {
 		it(`should have an element with class of '${PAGE_TITLELABEL_CLASS}'`, () => {
 			const pageHeadEl = ReactDOM.findDOMNode(pageHead);
 			const titleLabelEl = pageHeadEl.getElementsByClassName(PAGE_TITLELABEL_CLASS);
+			expect(titleLabelEl.length).toBe(1);
+		});
+		it('should handle custom classes', () => {
+			const pageHeadEl = ReactDOM.findDOMNode(pageHead);
+			const titleLabelEl = pageHeadEl.getElementsByClassName(titleLabelCustomClass);
 			expect(titleLabelEl.length).toBe(1);
 		});
 	});

--- a/src/pageHead.test.jsx
+++ b/src/pageHead.test.jsx
@@ -5,6 +5,7 @@ import TestUtils from 'react-addons-test-utils';
 import PageHead, {
 	PAGE_HEAD_CLASS,
 	PAGE_TITLE_CLASS,
+	PAGE_TITLELABEL_CLASS,
 	PAGE_SUBTITLE_CLASS,
 	PAGE_ACTIONS_CLASS,
 } from './PageHead';
@@ -27,6 +28,7 @@ const menu = [
 		/>
 	],
 	pageTitle = 'Page title',
+	titleLabel = 'Title label',
 	subtitle = 'Sub title';
 
 let pageHead;
@@ -60,6 +62,27 @@ describe('PageHead', function() {
 			const pageHeadEl = ReactDOM.findDOMNode(pageHead);
 			const subtitleEl = pageHeadEl.getElementsByClassName(PAGE_SUBTITLE_CLASS);
 			expect(subtitleEl.length).toBe(0);
+		});
+		it(`should NOT have a '${PAGE_TITLELABEL_CLASS}' tag`, () => {
+			const pageHeadEl = ReactDOM.findDOMNode(pageHead);
+			const titleLabelEl = pageHeadEl.getElementsByClassName(PAGE_TITLELABEL_CLASS);
+			expect(titleLabelEl.length).toBe(0);
+		});
+	});
+	describe('titleLabel', () => {
+		beforeEach(() => {
+			pageHead = TestUtils.renderIntoDocument(
+				<PageHead title={pageTitle} titleLabel={titleLabel} />
+			);
+		});
+		it('should display a text label area', () => {
+			const pageTitle = TestUtils.scryRenderedDOMComponentsWithClass(pageHead, PAGE_TITLE_CLASS)[0];
+			expect(pageTitle.textContent).toContain(titleLabel);
+		});
+		it(`should have an element with class of '${PAGE_TITLELABEL_CLASS}'`, () => {
+			const pageHeadEl = ReactDOM.findDOMNode(pageHead);
+			const titleLabelEl = pageHeadEl.getElementsByClassName(PAGE_TITLELABEL_CLASS);
+			expect(titleLabelEl.length).toBe(1);
 		});
 	});
 	describe('subtitle', () => {


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/MW-739

#### Description
Adds a label above the title in PageHead
**NOTE:** small-caps (English-only) coming with a sasstools fix from @akdetrick 

#### Screenshots (if applicable)
![screen shot 2017-03-20 at 2 27 15 pm](https://cloud.githubusercontent.com/assets/2313998/24115355/7a4497bc-0d79-11e7-95ec-cc3303bca23e.png)
![screen shot 2017-03-20 at 2 27 31 pm](https://cloud.githubusercontent.com/assets/2313998/24115356/7a4a0238-0d79-11e7-839e-246bec2c3a84.png)

