### PR TITLE
rm try/catch from base64 util; rm no photo Avatar story

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "classnames": "2.2.5",
     "coveralls": "2.12.0",
     "css-loader": "0.27.3",
+    "base64-image-loader": "1.2.0",
     "eslint": "3.17.1",
     "eslint-loader": "1.6.3",
     "eslint-plugin-react": "6.10.0",
@@ -73,8 +74,5 @@
     "swarm-icons": "0.1.0",
     "swarm-sasstools": "1.1.9",
     "webpack": "^2.2"
-  },
-  "dependencies": {
-    "base64-image-loader": "1.2.0"
   }
 }

--- a/src/avatar.story.jsx
+++ b/src/avatar.story.jsx
@@ -29,8 +29,5 @@ storiesOf('Avatar', module)
 				src={MOCK_IMAGE_SRC}>
 			</Avatar>
 		</WithNotes>
-	))
-	.add('no photo', () => (
-		<Avatar></Avatar>
 	));
 

--- a/src/utils/base64.js
+++ b/src/utils/base64.js
@@ -4,5 +4,5 @@
  * @returns {string} base64-encoded data uri for SVG icon
  */
 export const getIconAsBase64Uri = name => {
-	return require(`base64-image!swarm-icons/dist/optimized/${name}.svg`);
+	return require(`base64-image-loader!swarm-icons/dist/optimized/${name}.svg`);
 };

--- a/src/utils/base64.js
+++ b/src/utils/base64.js
@@ -4,9 +4,5 @@
  * @returns {string} base64-encoded data uri for SVG icon
  */
 export const getIconAsBase64Uri = name => {
-	try {
-		return require(`base64-image!swarm-icons/dist/optimized/${name}.svg`);
-	} catch(e) {
-		return new Error(`Could not construct base64 uri for icon "${name}" \n ${e}`);
-	}
+	return require(`base64-image!swarm-icons/dist/optimized/${name}.svg`);
 };


### PR DESCRIPTION
The base64 loader will fail at build time, not at runtime.

Also removed the no photo `Avatar` story. For things other than members, there's no product use case for a no photo avatar.