### PR TITLE
oneOf should be oneOfType

### DIFF
--- a/src/SectionTitle.jsx
+++ b/src/SectionTitle.jsx
@@ -45,7 +45,7 @@ class SectionTitle extends React.Component {
 	}
 }
 SectionTitle.propTypes = {
-	title: React.PropTypes.oneOf([
+	title: React.PropTypes.oneOfType([
 		React.PropTypes.element,
 		React.PropTypes.string
 	]).isRequired,


### PR DESCRIPTION
I'm seeing this issue when trying to use `<SectionTitle title='Members' />`:

```
Warning: Failed prop type: Invalid prop `title` of value `Members` supplied to `SectionTitle`, expected one of [null,null].
    in SectionTitle (created by Search)
    in Search (created by Form(Search))
    in Form(Search) (created by Connect(Form(Search)))
    in Connect(Form(Search)) (created by ReduxForm)
    in ReduxForm (created by MembersContainer)
    in div (created by MembersContainer)
    in MembersContainer (created by Connect(MembersContainer))
    in Connect(MembersContainer) (created by RouterContext)
    in div (created by PageWrap)
    in PageWrap (created by AppContainer)
    in IntlProvider (created by AppContainer)
    in AppContainer (created by Connect(AppContainer))
    in Connect(AppContainer) (created by RouterContext)
    in RouterContext (created by Router)
    in Router
    in Provider
```

This appears to be because `oneOf` was used instead of `oneOfType` where declaring propTypes

More info: https://facebook.github.io/react/docs/typechecking-with-proptypes.html