### PR TITLE
adding check for null children

### DIFF
--- a/src/Tabs.jsx
+++ b/src/Tabs.jsx
@@ -70,7 +70,7 @@ Tabs.propTypes = {
 
 		const validChildren = React.Children.map(
 			children,
-			child => child.type === TabsTab
+			child => child && child.type === TabsTab
 		).every(child => child);
 
 		if (!validChildren) {


### PR DESCRIPTION
null children error occurring when a check lives with a <Tab> component that results in a child not being rendered

e.g. of when error occurs
<Tab>
   {something && <TabsTab />}
</Tab>