### PR TITLE
DateTimePicker render should not depend on DOM; fix 3rd party CSS import

### DIFF
--- a/assets/scss/components/_dateTimePicker.scss
+++ b/assets/scss/components/_dateTimePicker.scss
@@ -1,4 +1,4 @@
-@import "~flatpickr/dist/flatpickr.css"; // calendar component
+@import "~flatpickr/dist/flatpickr"; // calendar component
 
 .dateTimePicker {
 	position:relative;
@@ -6,7 +6,7 @@
 
 .calendarTimeComponent {	
 	.input--dateTimePicker {
-		position:absolute;
+		position: relative;
 		top:0;
 		left:0;
 		display:inline-block;	
@@ -20,7 +20,7 @@
 	}
 
 	.input--time {
-		position:absolute;
+		position: absolute;
 		right:0;
 		top:0;
 		display:inline-block;	

--- a/src/CalendarComponent.jsx
+++ b/src/CalendarComponent.jsx
@@ -26,20 +26,18 @@ class CalendarComponent extends React.Component {
 		// lazy-loading flatpickr ensures it is
 		// imported only in clientside envs.
 		const Flatpickr = require('flatpickr');
-		if (Flatpickr) {
-			const options = {
-				onChange: this.onChange,
-				onOpen: this.onOpen,
-				onClose: this.onClose,
-				altInput: true,
-				allowInput: true,
-				altFormat: 'D M d, Y', // TODO localize
-				defaultDate: this.props.value
-			};
+		const options = {
+			onChange: this.onChange,
+			onOpen: this.onOpen,
+			onClose: this.onClose,
+			altInput: true,
+			allowInput: true,
+			altFormat: 'D M d, Y', // TODO localize
+			defaultDate: this.props.value
+		};
 
-			Object.assign(options, this.props.opts);
-			this.flatpickr = new Flatpickr(this.inputEl, options);
-		}
+		Object.assign(options, this.props.opts);
+		this.flatpickr = new Flatpickr(this.inputEl, options);
 	}
 
 	componentWillUnmount() {

--- a/src/CalendarComponent.jsx
+++ b/src/CalendarComponent.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import cx from 'classnames';
-import Flatpickr from 'flatpickr';
 
 /**
  * @module CalendarComponent
@@ -22,18 +21,25 @@ class CalendarComponent extends React.Component {
 	* @description init the js date flatpickr component
 	*/
 	componentDidMount() {
-		const options = {
-			onChange: this.onChange,
-			onOpen: this.onOpen,
-			onClose: this.onClose,
-			altInput: true,
-			allowInput: true,
-			altFormat: 'D M d, Y', // TODO localize
-			defaultDate: this.props.value
-		};
+		// flatpickr uses `window` on import,
+		// which breaks on server-sider render.
+		// lazy-loading flatpickr ensures it is
+		// imported only in clientside envs.
+		const Flatpickr = require('flatpickr');
+		if (Flatpickr) {
+			const options = {
+				onChange: this.onChange,
+				onOpen: this.onOpen,
+				onClose: this.onClose,
+				altInput: true,
+				allowInput: true,
+				altFormat: 'D M d, Y', // TODO localize
+				defaultDate: this.props.value
+			};
 
-		Object.assign(options, this.props.opts);
-		this.flatpickr = new Flatpickr(this.inputEl, options);
+			Object.assign(options, this.props.opts);
+			this.flatpickr = new Flatpickr(this.inputEl, options);
+		}
 	}
 
 	componentWillUnmount() {

--- a/src/DateTimePicker.jsx
+++ b/src/DateTimePicker.jsx
@@ -29,7 +29,12 @@ class DateTimePicker extends React.Component {
 		this.onBlur = this.onBlur.bind(this);
 	}
 
-	componentWillMount() {
+	// call `hasBrowserSupport` after mounting so server
+	// and client-side renders match, then immediately
+	// force a re-render. otherwise, client-side render
+	// will default to the server render, which never has
+	// browser support.
+	componentDidMount() {
 		this.setState({ isDateTimeLocalSupported: this.hasBrowserSupport() });
 	}
 
@@ -41,6 +46,10 @@ class DateTimePicker extends React.Component {
 	hasBrowserSupport() {
 		if (this.props.forceCalendar) {
 			return;
+		}
+
+		if (typeof document === 'undefined') {
+			return false;
 		}
 
 		const input = document.createElement('input'),
@@ -160,6 +169,7 @@ class DateTimePicker extends React.Component {
 			label,
 			value,	// eslint-disable-line no-unused-vars
 			required,
+			name,
 			...other
 		} = this.props;
 

--- a/src/DateTimePicker.jsx
+++ b/src/DateTimePicker.jsx
@@ -28,12 +28,14 @@ class DateTimePicker extends React.Component {
 		this.onFocus = this.onFocus.bind(this);
 		this.onBlur = this.onBlur.bind(this);
 	}
-
-	// call `hasBrowserSupport` after mounting so server
-	// and client-side renders match, then immediately
-	// force a re-render. otherwise, client-side render
-	// will default to the server render, which never has
-	// browser support.
+	/**
+	/* call `hasBrowserSupport` after mounting so server
+	/* and client-side renders match, then immediately
+	/* force a re-render. otherwise, client-side render
+	/* will default to the server render, which never has
+	/* browser support.
+	/* @returns {undefined}
+	*/
 	componentDidMount() {
 		this.setState({ isDateTimeLocalSupported: this.hasBrowserSupport() });
 	}
@@ -44,11 +46,7 @@ class DateTimePicker extends React.Component {
 	* @return bool whether or not this browser supports datetime local
 	*/
 	hasBrowserSupport() {
-		if (this.props.forceCalendar) {
-			return;
-		}
-
-		if (typeof document === 'undefined') {
+		if (this.props.forceCalendar || typeof document === 'undefined') {
 			return false;
 		}
 


### PR DESCRIPTION
#### Description

- fix style dependency on flatpickr
- flatpickr depends on dom, which breaks on server-side rendering in mup-web. remove dom-dependent aspects of datetimepicker.
- profit

https://meetup.atlassian.net/browse/SDS-226 

#### Screenshots (if applicable)

