### PR TITLE
use dependency instead of devDependency for base64-image-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-intl": "^2.2.3"
   },
   "dependencies": {
+    "base64-image-loader": "1.2.0",
     "flatpickr": "2.4.7"
   },
   "devDependencies": {
@@ -52,7 +53,6 @@
     "babel-preset-react": "6.23.0",
     "babel-preset-stage-2": "6.22.0",
     "babel-register": "6.24.0",
-    "base64-image-loader": "1.2.0",
     "classnames": "2.2.5",
     "coveralls": "2.12.0",
     "css-loader": "0.27.3",


### PR DESCRIPTION
Moves the `base64-image-loader` package to `dependencies` from `devDependencies`. I believe this will prevent a missing module problem when using `Avatar` in other repos, but could use confirmation from someone more familiar with Yarn

