### PR TITLE
remove CSS filter from groupCard styles

### DIFF
--- a/assets/scss/components/_groupCard.scss
+++ b/assets/scss/components/_groupCard.scss
@@ -1,3 +1,26 @@
+/// PRIVATE
+/// legacy text protection mixin from SQ2
+@mixin textProtectionScrimDark($placement: 'bottom') {
+	&:before {
+		content: '';
+		display: block;
+		height: 100%;
+		position: absolute;
+		width: 100%;
+		z-index: 0;
+		left: 0;
+		mix-blend-mode: hard-light;
+
+		@if $placement == 'bottom' {
+			@include linear-gradient(180deg, transparentize($C_black, .9) 25%, transparentize($C_black, .7) 100%);
+			bottom: 0;
+		} @else {
+			@include linear-gradient(0deg, transparentize($C_black, .9) 25%, transparentize($C_black, .7) 100%);
+			top: 0;
+		}
+	}
+}
+
 /*doc
 ---
 title: Cards
@@ -85,8 +108,7 @@ $_eventStripes: (
 }
 
 .card--group {
-	@include textProtectionScrim(top);
-	@include filter(grayscale(20%) contrast(110%));
+	@include textProtectionScrimDark(top);
 	border-radius: 0;
 	padding: $space;
 	height: $block-4;


### PR DESCRIPTION
Avoids a Safari paint performance problem. This slightly darkens the text protection gradient in place of the desaturate and contrast filters.

## Before
![screen shot 2017-04-04 at 2 20 16 pm](https://cloud.githubusercontent.com/assets/231252/24672220/0a4e9348-1942-11e7-9151-439d25f443b2.png)


## After
![screen shot 2017-04-04 at 2 19 35 pm](https://cloud.githubusercontent.com/assets/231252/24672224/0d0c9d00-1942-11e7-85d5-db23b24025b6.png)
