### PR TITLE
Update getModalPosition & tests for updated product requirements

### DIFF
--- a/src/Modal.jsx
+++ b/src/Modal.jsx
@@ -15,17 +15,26 @@ export const MARGIN_TOP_OFFSET = 36;
  * @param {String} scrollPosition window scroll position
  * @param {String} viewportHeight client height
  * @param {Boolean} isFullScreen true if the modal full screen
+ * @param {Boolean} isMobileSize true if the viewport is below `medium` breakpoint
  *
  * @returns {String} CSS value for setting modal margin-top
  */
-export const getModalPosition = (scrollPosition, viewportHeight, isFullScreen) => {
+export const getModalPosition = (scrollPosition, viewportHeight, isFullScreen, isMobileSize) => {
 
-	// check if user is scrolled below fold before setting a custom offset
-	const newTopOffset = scrollPosition > viewportHeight ?
+	// full screen dialogs should be flush with top of the viewport
+	if (isFullScreen) {
+		return '0px';
+	}
+
+	// for mobile-sized viewports, return the scroll position without a gutter
+	if (isMobileSize) {
+		return scrollPosition;
+	}
+
+	// set the margin-top based on scroll position unless user is above fold
+	return scrollPosition > viewportHeight ?
 		scrollPosition + MARGIN_TOP_OFFSET :
 		DEFAULT_MARGIN_TOP;
-
-	return isFullScreen ? '0px' : newTopOffset;
 };
 
 /**
@@ -68,7 +77,8 @@ class Modal extends React.Component {
 					topPosition: getModalPosition(
 						window.pageYOffset,
 						Math.max(document.documentElement.clientHeight, window.innerHeight || 0),
-						this.props.fullscreen || this.mediaQuery && !this.mediaQuery.matches
+						this.props.fullscreen,
+						this.mediaQuery && !this.mediaQuery.matches
 					),
 				});
 			};

--- a/src/modal.test.js
+++ b/src/modal.test.js
@@ -75,13 +75,13 @@ describe('Modal', () => {
 describe('Modal positioning', () => {
 
 	it('returns the default margin top if the user is not below the fold', () => {
-		const calculatedPosition = getModalPosition(0, 400, false);
+		const calculatedPosition = getModalPosition(0, 400, false, false);
 		expect(calculatedPosition).toBe(DEFAULT_MARGIN_TOP);
 	});
 
-	it('always returns 0px when full screen', () => {
-		const calculatedPositionAtTop = getModalPosition(0, 400, true);
-		const calculatedPositionBelowFold = getModalPosition(800, 400, true);
+	it('always returns 0px when full screen prop is set', () => {
+		const calculatedPositionAtTop = getModalPosition(0, 400, true, false);
+		const calculatedPositionBelowFold = getModalPosition(800, 400, true, false);
 
 		expect(calculatedPositionAtTop).toBe('0px');
 		expect(calculatedPositionBelowFold).toBe('0px');
@@ -89,7 +89,14 @@ describe('Modal positioning', () => {
 
 	it('returns scroll position + MARGIN_TOP_OFFSET when modal is not full screen and user is below fold', () => {
 		const scrollPosition = 800;
-		const calculatedPosition = getModalPosition(scrollPosition, 400, false);
+		const calculatedPosition = getModalPosition(scrollPosition, 400, false, false);
 		expect(calculatedPosition).toBe(scrollPosition + MARGIN_TOP_OFFSET);
 	});
+
+	it('returns scroll position *without gutter* when modal is below fold and viewport is mobile size', () => {
+		const scrollPosition = 800;
+		const calculatedPosition = getModalPosition(scrollPosition, 400, false, true);
+		expect(calculatedPosition).toBe(scrollPosition);
+	});
+
 });


### PR DESCRIPTION
When testing the experience of the modal in `mup-web` on small screens, the "snapped" modal (snaps to the edges of the viewport) isn't positioned correctly with the scroll.

When the viewport is small, we should set the `margin-top` of the modal to match the exact scroll position for a better experience.

See updated tests for a detailed view of new requirements.