### PR TITLE
Hero headers into Modals

### DIFF
--- a/assets/scss/components/_modal.scss
+++ b/assets/scss/components/_modal.scss
@@ -4,6 +4,7 @@ $modal-width: 440px;
 	@include transform(translate3d(0, 0, 0));
 	@include transition(transform .2s ease);
 	@include centerAbsolute($modal-width);
+	border-radius: $defaultRadius;
 	min-height: 0;
 	width: $modal-width !important;
 
@@ -103,6 +104,16 @@ lays out as a dialog on background content on larger screens.
 	z-index: map-get($zindex-map, "modal");
 }
 
+.view--modal {
+	.stripe-heroContent {
+		min-height: 0;
+		text-align: inherit;
+
+		@include atMediaUp(medium) {
+			min-height: 0;
+		}
+	}
+}
 
 /*doc
 ---

--- a/assets/scss/components/_stripe.scss
+++ b/assets/scss/components/_stripe.scss
@@ -31,6 +31,10 @@ Class                | Description
 	@include responsiveVarContext--base() {
 		padding-bottom: $base*2;
 	}
+
+	&:first-child {
+		border-top: none;
+	}
 }
 
 .stripe--collection {

--- a/src/interactive/Modal.jsx
+++ b/src/interactive/Modal.jsx
@@ -103,7 +103,7 @@ class Modal extends React.Component {
 			heroBgColor,
 			heroBgImage,
 			heroContent,
-			heroInverted,
+			inverted,
 			...other
 		} = this.props;
 
@@ -143,7 +143,7 @@ class Modal extends React.Component {
 
 		const heroStyles = {
 			backgroundColor: heroBgColor || 'transparent',
-			backgroundImage: `url(${heroBgImage})`
+			backgroundImage: heroBgImage && `url(${heroBgImage})`,
 		};
 
 		return (
@@ -164,7 +164,7 @@ class Modal extends React.Component {
 					{ heroContent ?
 						<Stripe
 							hero
-							inverted={heroInverted}
+							inverted={inverted}
 							style={heroStyles}
 						>
 							{closeArea}

--- a/src/interactive/Modal.jsx
+++ b/src/interactive/Modal.jsx
@@ -3,6 +3,7 @@ import cx from 'classnames';
 
 import Icon from '../media/Icon';
 import Button from '../forms/Button';
+import Stripe from '../layout/Stripe';
 import { MEDIA_QUERIES } from '../utils/designConstants';
 
 export const MODAL_CLOSE_BUTTON = 'modal-closeButton';
@@ -99,6 +100,10 @@ class Modal extends React.Component {
 			className,
 			children,
 			fullscreen,
+			heroBgColor,
+			heroBgImage,
+			heroContent,
+			heroInverted,
 			...other
 		} = this.props;
 
@@ -110,8 +115,7 @@ class Modal extends React.Component {
 		);
 
 		const modalClasses = cx(
-			'view',
-			'padding--all',
+			'view view--modal',
 			{
 				'view--modalFull': fullscreen,
 				'view--modalSnap': !fullscreen
@@ -120,7 +124,7 @@ class Modal extends React.Component {
 
 		const dismissButtonClasses = cx(
 			MODAL_CLOSE_BUTTON,
-			'border--none'
+			'button--reset'
 		);
 
 		const overlayShim = (
@@ -128,6 +132,19 @@ class Modal extends React.Component {
 				<div className='inverted'></div>
 			</div>
 		);
+
+		const closeArea = (
+			<div className='padding--all'>
+				<Button onClick={this.onDismiss} className={dismissButtonClasses}>
+					<Icon shape='cross' size='s' />
+				</Button>
+			</div>
+		);
+
+		const heroStyles = {
+			backgroundColor: heroBgColor || 'transparent',
+			backgroundImage: `url(${heroBgImage})`
+		};
 
 		return (
 			<div
@@ -144,11 +161,18 @@ class Modal extends React.Component {
 					className={modalClasses}
 					style={{marginTop: this.state.topPosition}}
 				>
-					<div className='align--right'>
-						<Button onClick={this.onDismiss} className={dismissButtonClasses}>
-							<Icon shape='cross' size='s' />
-						</Button>
-					</div>
+					{ heroContent ?
+						<Stripe
+							hero
+							inverted={heroInverted}
+							style={heroStyles}
+						>
+							{closeArea}
+							{heroContent}
+						</Stripe>
+					:
+						closeArea
+					}
 
 					{children}
 				</div>

--- a/src/interactive/Modal.jsx
+++ b/src/interactive/Modal.jsx
@@ -182,8 +182,12 @@ class Modal extends React.Component {
 }
 
 Modal.propTypes = {
+	fullscreen: React.PropTypes.bool,
+	heroBgColor: React.PropTypes.string,
+	heroBgImage: React.PropTypes.string,
+	heroContent: React.PropTypes.element,
+	inverted: React.PropTypes.bool,
 	onDismiss: React.PropTypes.func.isRequired,
-	fullscreen: React.PropTypes.bool
 };
 
 Modal.defaultProps = {

--- a/src/interactive/modal.story.jsx
+++ b/src/interactive/modal.story.jsx
@@ -3,13 +3,23 @@ import { storiesOf, action } from '@kadira/storybook';
 import { InfoWrapper } from '../utils/storyComponents';
 import Button from '../forms/Button';
 import Modal from './Modal';
+import Section from '../layout/Section';
+import Stripe from '../layout/Stripe';
+
+/*
+ * -- Inline SVG icon sprite --
+ *
+ * raw SVG sprite from `swarm-icons`
+ */
+const iconSpriteStyle = { display: 'none' };
+const iconSprite = require('raw-loader!swarm-icons/dist/sprite/sprite.inc');
 
 const onDismiss = e => {
 	action('Dismissing modal')(e);
 };
 
 const content = (
-	<div>
+	<Stripe><Section>
 		<h2 className='align--center'>This is a modal!</h2>
 		<div className='row align--center margin--top'>
 			<div className='row-item'>
@@ -19,7 +29,7 @@ const content = (
 				<Button onClick={action('Confirmed!')} primary fullWidth>Confirm</Button>
 			</div>
 		</div>
-	</div>
+	</Section></Stripe>
 );
 
 const wrapperStyle = {
@@ -39,6 +49,73 @@ storiesOf('Modal', module)
 					>
 						{content}
 					</Modal>
+					<div style={iconSpriteStyle} dangerouslySetInnerHTML={{__html: iconSprite}} />
+				</InfoWrapper>
+			</div>
+		)
+	)
+	.addWithInfo(
+		'has hero - color',
+		'This is the component with an extended header.',
+		() => (
+			<div style={wrapperStyle}>
+				<InfoWrapper>
+					<Modal
+						onDismiss={onDismiss}
+						heroInverted
+						heroBgColor='rgb(55,30,172)'
+						heroContent={
+							<Section>
+								<h1 className='text--display align--center'>I can be your hero</h1>
+							</Section>
+						}
+					>
+						<Stripe><Section>
+							<h2 className='align--center'>This is a modal!</h2>
+							<div className='row align--center margin--top'>
+								<div className='row-item'>
+									<Button onClick={onDismiss} fullWidth>Cancel</Button>
+								</div>
+								<div className='row-item'>
+									<Button onClick={action('Confirmed!')} primary fullWidth>Confirm</Button>
+								</div>
+							</div>
+						</Section></Stripe>
+					</Modal>
+					<div style={iconSpriteStyle} dangerouslySetInnerHTML={{__html: iconSprite}} />
+				</InfoWrapper>
+			</div>
+		)
+	)
+	.addWithInfo(
+		'has hero - image',
+		'This is the component with an extended header.',
+		() => (
+			<div style={wrapperStyle}>
+				<InfoWrapper>
+					<Modal
+						onDismiss={onDismiss}
+						heroInverted
+						heroBgImage='http://www.cheatsheet.com/wp-content/uploads/2016/09/Homemade-Meat-Gyro-with-French-Fries.jpg'
+						heroContent={
+							<Section>
+								<h1 className='text--display align--center'>I can be your hero</h1>
+							</Section>
+						}
+					>
+						<Stripe><Section>
+							<h2 className='align--center'>This is a modal!</h2>
+							<div className='row align--center margin--top'>
+								<div className='row-item'>
+									<Button onClick={onDismiss} fullWidth>Cancel</Button>
+								</div>
+								<div className='row-item'>
+									<Button onClick={action('Confirmed!')} primary fullWidth>Confirm</Button>
+								</div>
+							</div>
+						</Section></Stripe>
+					</Modal>
+					<div style={iconSpriteStyle} dangerouslySetInnerHTML={{__html: iconSprite}} />
 				</InfoWrapper>
 			</div>
 		)
@@ -54,6 +131,7 @@ storiesOf('Modal', module)
 			>
 				{content}
 			</Modal>
+			<div style={iconSpriteStyle} dangerouslySetInnerHTML={{__html: iconSprite}} />
 		</div>
 	));
 

--- a/src/interactive/modal.story.jsx
+++ b/src/interactive/modal.story.jsx
@@ -62,7 +62,7 @@ storiesOf('Modal', module)
 				<InfoWrapper>
 					<Modal
 						onDismiss={onDismiss}
-						heroInverted
+						inverted
 						heroBgColor='rgb(55,30,172)'
 						heroContent={
 							<Section>
@@ -95,7 +95,7 @@ storiesOf('Modal', module)
 				<InfoWrapper>
 					<Modal
 						onDismiss={onDismiss}
-						heroInverted
+						inverted
 						heroBgImage='http://www.cheatsheet.com/wp-content/uploads/2016/09/Homemade-Meat-Gyro-with-French-Fries.jpg'
 						heroContent={
 							<Section>

--- a/src/interactive/modal.test.js
+++ b/src/interactive/modal.test.js
@@ -9,6 +9,10 @@ import Modal, {
 	MARGIN_TOP_OFFSET,
 	getModalPosition,
 } from './Modal';
+import {
+	STRIPE_INVERTED_CLASS,
+	STRIPE_HERO_CLASS,
+} from '../layout/Stripe';
 
 describe('Modal', () => {
 
@@ -70,6 +74,55 @@ describe('Modal', () => {
 
 		expect(spyable.onDismiss).toHaveBeenCalled();
 	});
+});
+
+describe('Modal hero header', () => {
+	let modal, heroEl;
+	const content = 'Test model content';
+	const bgColor = 'rgb(55, 30, 172)';
+	const bgImage = 'http://www.cheatsheet.com/wp-content/uploads/2016/09/Homemade-Meat-Gyro-with-French-Fries.jpg';
+	const HERO_CONTENT_CLASS = 'heroContent';
+	const heroContentHtml = <h1 className={HERO_CONTENT_CLASS}>I can be your hero</h1>;
+
+	beforeEach(() => {
+		modal = TestUtils.renderIntoDocument(
+			<Modal
+				inverted
+				heroBgColor={bgColor}
+				heroBgImage={bgImage}
+				heroContent={heroContentHtml}
+				onDismiss={(e) => {}}
+			>
+				{content}
+			</Modal>
+		);
+		heroEl = TestUtils.findRenderedDOMComponentWithClass(modal, STRIPE_HERO_CLASS);
+	});
+
+	afterEach(() => {
+		heroEl = null;
+	});
+
+	it('gets hero stripe styling', () => {
+		expect(() => TestUtils.findRenderedDOMComponentWithClass(modal, STRIPE_HERO_CLASS)).not.toThrow();
+	});
+
+	it('sets a background color when supplied', () => {
+		expect(heroEl.style.backgroundColor).toContain(bgColor);
+	});
+
+	it('sets a background image when supplied', () => {
+		expect(heroEl.style.backgroundImage).toContain(bgImage);
+	});
+
+	it('sets the hero Stripe to inverted', () => {
+		expect(() => TestUtils.findRenderedDOMComponentWithClass(modal, STRIPE_INVERTED_CLASS)).not.toThrow();
+	});
+
+	it('displays the hero content', () => {
+		expect(() => TestUtils.findRenderedDOMComponentWithClass(modal, HERO_CONTENT_CLASS)).not.toThrow();
+	});
+
 });
 
 describe('Modal positioning', () => {


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-35
https://meetup.atlassian.net/browse/MW-814

#### Description
Some modals, like the RSVP success modal, are designed to have a full bleed hero header

#### Screenshots (if applicable)
<img width="467" alt="screen shot 2017-04-21 at 10 17 19 am" src="https://cloud.githubusercontent.com/assets/2313998/25281564/c570e40a-267b-11e7-8cda-b94f3876fe57.png">
<img width="468" alt="screen shot 2017-04-21 at 10 17 26 am" src="https://cloud.githubusercontent.com/assets/2313998/25281569/c6d93e14-267b-11e7-9689-2dcdce53edb7.png">

