### PR TITLE
fix inlineblocklist prop types

### DIFF
--- a/src/layout/InlineBlockList.jsx
+++ b/src/layout/InlineBlockList.jsx
@@ -38,10 +38,12 @@ class InlineBlockList extends React.Component {
 }
 
 InlineBlockList.propTypes = {
-	items: React.PropTypes.oneOf([
-		React.PropTypes.arrayOf(React.PropTypes.element),
-		React.PropTypes.arrayOf(React.PropTypes.string)
-	]).isRequired,
+	items: React.PropTypes.arrayOf(
+		React.PropTypes.oneOfType([
+			React.PropTypes.element,
+			React.PropTypes.string
+		])
+	).isRequired,
 	separator: React.PropTypes.string
 };
 


### PR DESCRIPTION
Fixes bad proptype validation that was causing this error:
```
Warning: Failed prop type: Invalid prop 'items' of value '[object Object],[object Object],[object Object]' supplied to 'InlineBlockList', expected one of [null,null].
```
