### PR TITLE
instruct screen readers not to speak separator glyphs in inlineblocklist

### DIFF
--- a/assets/scss/components/_inlineblockList.scss
+++ b/assets/scss/components/_inlineblockList.scss
@@ -64,6 +64,7 @@ Class                        | Description
 
 	&:after {
 		content: attr(data-separator);
+		speak: none;
 		@include responsiveVarContext--base() {
 			padding-left: $base/2;
 		}


### PR DESCRIPTION
🎼 
Don't speak
Screen-readers know what you're saying
So please stop conveying
CSS content 'cause it hurts

Hush, hush don't read these glyphs 'cause it hurts
🎶 
