### PR TITLE
Rename noBorder prop in Section

### DIFF
--- a/assets/scss/components/_section.scss
+++ b/assets/scss/components/_section.scss
@@ -16,13 +16,13 @@ $sectionSpaceMultiple: 2;
 		padding: $base*$sectionSpaceMultiple 0 $base*$sectionSpaceMultiple - $base 0;
 
 	}
-	.atAll_section--noBorder {
+	.atAll_section--noSeparator {
 		border-bottom-width: 0;
 		padding: $base*$sectionSpaceMultiple 0 0 0;
 	}
 }
 
-@include _bpModifier(section, noBorder) {
+@include _bpModifier(section, noSeparator) {
 	border-bottom-width: 0;
 	@include responsiveVarContext--base() {
 		padding: $base*$sectionSpaceMultiple 0 0 0;

--- a/src/layout/Section.jsx
+++ b/src/layout/Section.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import cx from 'classnames';
 
 export const SECTION_CLASS = 'section';
-export const SECTION_NOBORDER_CLASS = 'section--noBorder';
+export const SECTION_NOSEPARATOR_CLASS = 'section--noSeparator';
 export const VALID_BREAKPOINTS = {
 	all: 'atAll',
 	medium: 'atMedium',
@@ -18,16 +18,16 @@ class Section extends React.Component {
 		const {
 			children,
 			className,
-			noBorder,
+			noSeparator,
 			...other
 		} = this.props;
 
-		const noBorderBreakpoint = VALID_BREAKPOINTS[noBorder] || VALID_BREAKPOINTS['all'];
+		const noSeparatorBreakpoint = VALID_BREAKPOINTS[noSeparator] || VALID_BREAKPOINTS['all'];
 
 		const classNames = cx(
 			SECTION_CLASS,
 			{
-				[`${noBorderBreakpoint}_${SECTION_NOBORDER_CLASS}`]: noBorder,
+				[`${noSeparatorBreakpoint}_${SECTION_NOSEPARATOR_CLASS}`]: noSeparator,
 			},
 			className
 		);
@@ -43,7 +43,7 @@ class Section extends React.Component {
 	}
 }
 Section.propTypes = {
-	noBorder: React.PropTypes.oneOf(Object.keys(VALID_BREAKPOINTS))
+	noSeparator: React.PropTypes.oneOf(Object.keys(VALID_BREAKPOINTS))
 };
 
 export default Section;

--- a/src/layout/section.story.jsx
+++ b/src/layout/section.story.jsx
@@ -50,49 +50,50 @@ storiesOf('Section', module)
 			</InfoWrapper>
 		)
 	)
-	.add('No border', () => (
+	.add('No separator', () => (
 		<div style={{width: '100%'}}>
 			<div style={{maxWidth: '850px', margin: 'auto'}}>
-				<Section noBorder style={shadingStyles}>
+				<Section noSeparator style={shadingStyles}>
 					<div className='chunk'>
-						<h2 className='text--display2'>These sections are never get border styling</h2>
+						<h2 className='text--display2'>These sections never get separators</h2>
+						<p className='text--bold text--secondary'>Separators contain bottom padding and a bottom border</p>
+						<p>Lorem Ipsum was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
 					</div>
 				</Section>
-				<Section noBorder style={shadingStyles}>
+				<Section noSeparator style={shadingStyles}>
 					<div className='chunk'>
 						<p className='text--bold'>123 attending</p>
 						<p>Hosted by Amy, Rick, Mike, Natalie</p>
 					</div>
 				</Section>
-				<Section noBorder style={shadingStyles}>
+				<Section noSeparator style={shadingStyles}>
 					<div className='chunk'>
 						<div className='runningText'>
-							<p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
+							<p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged.</p>
 						</div>
 					</div>
 				</Section>
 			</div>
 		</div>
 	))
-	.add('Conditional noBorder (at large breakpoint)', () => (
+	.add('Conditional noSeparator (at large breakpoint)', () => (
 		<div style={{width: '100%'}}>
 			<Flex direction='column' switchDirection='large'>
 				<FlexItem>
 					<div style={{maxWidth: '850px', margin: 'auto'}}>
 						<Section style={shadingStyles}>
 							<div className='chunk'>
-								<p className='text--bold'>These sections stack at medium breakpoint</p>
+								<p className='text--bold'>These sections stack at large breakpoint</p>
 							</div>
 						</Section>
 						<Section style={shadingStyles}>
 							<div className='chunk'>
-								<p className='text--bold'>123 attending</p>
-								<p>Hosted by Amy, Rick, Mike, Natalie</p>
+								<p className='text--bold'>These sections stack at large breakpoint</p>
 							</div>
 						</Section>
-						<Section noBorder='large' style={shadingStyles}>
+						<Section noSeparator='large' style={shadingStyles}>
 							<div className='chunk'>
-								<p className='text--bold'>This section needs border styling when stacked</p>
+								<p className='text--bold'>This section needs separator styling when stacked</p>
 							</div>
 						</Section>
 					</div>
@@ -102,18 +103,17 @@ storiesOf('Section', module)
 					<div style={{maxWidth: '850px', margin: 'auto'}}>
 						<Section style={shadingStyles}>
 							<div className='chunk'>
-								<p className='text--bold'>These sections stack at medium breakpoint</p>
+								<p className='text--bold'>These sections stack at large breakpoint</p>
 							</div>
 						</Section>
 						<Section style={shadingStyles}>
 							<div className='chunk'>
-								<p className='text--bold'>These sections stack at medium breakpoint</p>
+								<p className='text--bold'>These sections stack at large breakpoint</p>
 							</div>
 						</Section>
-						<Section noBorder='all' style={shadingStyles}>
+						<Section noSeparator='all' style={shadingStyles}>
 							<div className='chunk'>
-								<p className='text--bold'>123 attending</p>
-								<p>Hosted by Amy, Rick, Mike, Natalie</p>
+								<p className='text--bold'>This section never gets separator styling</p>
 							</div>
 						</Section>
 					</div>

--- a/src/layout/section.test.jsx
+++ b/src/layout/section.test.jsx
@@ -4,7 +4,7 @@ import TestUtils from 'react-addons-test-utils';
 
 import Section, {
 	SECTION_CLASS,
-	SECTION_NOBORDER_CLASS,
+	SECTION_NOSEPARATOR_CLASS,
 	VALID_BREAKPOINTS,
 } from './Section';
 
@@ -27,13 +27,13 @@ describe('Section', function() {
 		expect(sectionNode.classList).toContain(SECTION_CLASS);
 	});
 
-	describe('Section noBorder', () => {
-		it(`check that default component has '${SECTION_NOBORDER_CLASS}' class`, function() {
+	describe('Section noSeparator', () => {
+		it(`check that component has '${SECTION_NOSEPARATOR_CLASS}' class`, function() {
 			Object.keys(VALID_BREAKPOINTS).forEach(breakpoint => {
-				section = TestUtils.renderIntoDocument(<Section noBorder={breakpoint} />);
+				section = TestUtils.renderIntoDocument(<Section noSeparator={breakpoint} />);
 				sectionNode = ReactDOM.findDOMNode(section);
 				expect(sectionNode.classList).toContain(SECTION_CLASS);
-				expect(sectionNode.classList).toContain(`${VALID_BREAKPOINTS[breakpoint]}_${SECTION_NOBORDER_CLASS}`);
+				expect(sectionNode.classList).toContain(`${VALID_BREAKPOINTS[breakpoint]}_${SECTION_NOSEPARATOR_CLASS}`);
 			});
 		});
 	});


### PR DESCRIPTION
`noBorder` sounds like all it does is remove the bottom border - `className='border--none'` is better for that

What we actually want is to remove the bottom border _and_ the bottom padding. This is useful when working with 2 columns of `<Section>`s that stack at mobile