### PR TITLE
Section noSeparator proptype fix

### DIFF
--- a/src/layout/Section.jsx
+++ b/src/layout/Section.jsx
@@ -43,7 +43,10 @@ class Section extends React.Component {
 	}
 }
 Section.propTypes = {
-	noSeparator: React.PropTypes.oneOf(Object.keys(VALID_BREAKPOINTS))
+	noSeparator: React.PropTypes.oneOfType([
+		React.PropTypes.bool,
+		React.PropTypes.oneOf(Object.keys(VALID_BREAKPOINTS))
+	])
 };
 
 export default Section;


### PR DESCRIPTION
#### Related issues
PR feedback for upgrading layout components in [mup-web](https://github.com/meetup/mup-web/pull/1007)

#### Description
noSeparator prop can be a boolean or one of the breakpoints 