### PR TITLE
Reset more styles on button reset

### DIFF
--- a/assets/scss/components/_button.scss
+++ b/assets/scss/components/_button.scss
@@ -266,8 +266,10 @@ Class                   | Description
 	@include buttonHover(transparent);
 	background: transparent;
 	border-width: 0 !important;
-	padding: 0;
+	border-radius: 0;
 	font-weight: normal;
+	min-height: 0;
+	padding: 0;
 
 	&[disabled] {
 		background: transparent !important;


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-280
Helps with https://meetup.atlassian.net/browse/MW-1027

#### Description
Removes height and border-radius from buttons with the `reset` prop to truly "reset" buttons.
