### PR TITLE
Reduce spacing in icon buttons

### DIFF
--- a/assets/scss/components/_button.scss
+++ b/assets/scss/components/_button.scss
@@ -370,6 +370,10 @@ $_iconGutter: $space;
 	@include flex-wrap(nowrap);
 	@include flex-direction(row);
 	@include justify-content(space-between);
+
+	.atAll_flex--rowReverse.button--icon-wrapper & {
+		padding-left: $space/4;
+	}
 }
 
 .button-label,
@@ -383,6 +387,10 @@ $_iconGutter: $space;
 	// this full shorthand property for `flex`
 	// is required to prevent IE11 from "shrinkwrapping" text nodes
 	@include flex(1 1 auto);
+
+	.button--icon-wrapper & {
+		padding-left: $space/4;
+	}
 }
 
 .button-icon {


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-286
Will help with: [MW-1023](https://meetup.atlassian.net/browse/MW-1023) and [MW-1027](https://meetup.atlassian.net/browse/MW-1027)

#### Description
Just reducing padding coming from `.flex-item`. The CSS selectors to do this without making changes to `Button` aren't ideal
