### PR TITLE
make the modal close area toggleable

### DIFF
--- a/src/interactive/Modal.jsx
+++ b/src/interactive/Modal.jsx
@@ -133,7 +133,7 @@ class Modal extends React.Component {
 			</div>
 		);
 
-		const closeArea = (
+		const closeArea = this.props.closeArea && (
 			<div className='padding--all'>
 				<Button onClick={this.onDismiss} className={dismissButtonClasses}>
 					<Icon shape='cross' size='s' />
@@ -188,10 +188,12 @@ Modal.propTypes = {
 	heroContent: React.PropTypes.element,
 	inverted: React.PropTypes.bool,
 	onDismiss: React.PropTypes.func.isRequired,
+	closeArea: React.PropTypes.bool,
 };
 
 Modal.defaultProps = {
-	fullscreen: false
+	fullscreen: false,
+	closeArea: true,
 };
 
 export default Modal;

--- a/src/interactive/modal.story.jsx
+++ b/src/interactive/modal.story.jsx
@@ -133,6 +133,17 @@ storiesOf('Modal', module)
 			</Modal>
 			<div style={iconSpriteStyle} dangerouslySetInnerHTML={{__html: iconSprite}} />
 		</div>
+	))
+	.addWithInfo(
+		'No close area',
+		'Modals with no close area are set with the `closeArea` boolean prop',
+		() => (
+		<div style={wrapperStyle}>
+			<Modal
+				closeArea={false}
+			>
+				{content}
+			</Modal>
+			<div style={iconSpriteStyle} dangerouslySetInnerHTML={{__html: iconSprite}} />
+		</div>
 	));
-
-

--- a/src/interactive/modal.test.js
+++ b/src/interactive/modal.test.js
@@ -74,6 +74,15 @@ describe('Modal', () => {
 
 		expect(spyable.onDismiss).toHaveBeenCalled();
 	});
+
+	it('should not render a close button', () => {
+		const modal = TestUtils.renderIntoDocument(
+			<Modal closeArea={false}>{content}</Modal>
+		);
+		const closeButtons = TestUtils
+			.scryRenderedDOMComponentsWithClass(modal, MODAL_CLOSE_BUTTON);
+		expect(closeButtons).toHaveLength(0);
+	});
 });
 
 describe('Modal hero header', () => {


### PR DESCRIPTION
#### Related issues
https://meetup.atlassian.net/browse/MUP-10807

#### Description
We've been tasked with adding a modal that doesn't have a close area at the top. This change allows the Modal component to accept a `closeArea` prop that can determine whether the close area is displayed or not. The default behaviour does not change when the `closeArea` prop is omitted (the close area displays by default)

#### Screenshots (if applicable)
![change subscription](https://cloud.githubusercontent.com/assets/847987/26006819/e2b942c8-370b-11e7-8048-c30f77fca48d.png)
![reactivate](https://cloud.githubusercontent.com/assets/847987/26006821/e454097e-370b-11e7-8285-72a14f8cd7a8.png)

