### PR TITLE
Wc 50/icon shape variant support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 1.0.$(CI_BUILD_NUMBER)
+VERSION ?= 1.1.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Table of Contents
     * [Verifying child elements](#verifying-child-elements)
   * [Linting](#linting)
   * [Storybook](#storybook)
+  * [Release notes](#release-notes)
 
 ## Releases
 
@@ -165,3 +166,16 @@ And open the viewer at [http://localhost:9001](http://localhost:9001)
 All of the available components are listed on the left, and clicking on
 one will open it in the preview pane. Variants are also listed in the left
 column to show how different states affect the rendered component.
+
+## Release notes
+
+### `v1.1.X`
+Icons update
+
+- Updated `swarm-icons` to `1.0.0`
+- Updated `Icon` component to support rendering of separate SVG symbols for `xs` sizes
+- Added `_icon.scss` component sass partial
+	- allows `meetup-web-components` to provide icon styling to consumer apps
+	- changes default icon color to `secondary` from `inherit`
+- Removes unused and confusing `auto` prop from `Icon`
+- Fixed issue where `Icon` would not accept the `xxl` media size

--- a/assets/scss/components/_all.scss
+++ b/assets/scss/components/_all.scss
@@ -18,6 +18,7 @@
 @import "button";
 @import "dateDisplay";
 @import "groupCard";
+@import "icon";
 @import "modal";
 @import "popover";
 @import "tabs";

--- a/assets/scss/components/_icon.scss
+++ b/assets/scss/components/_icon.scss
@@ -1,0 +1,53 @@
+/**
+* Icon styles
+* -----------------
+* supports `swarm-icons` SVG icon lib
+*
+* See also:
+* [Icon list](https://meetup.github.io/swarm-icons/)
+*/
+
+@mixin _iconColor( $color, $invertedColor ) {
+	@include color-svg($color);
+	.inverted & {
+		@include color-svg($invertedColor);
+	}
+}
+@include keyframes(spin) {
+	0% {
+		@include transform(rotate(0deg));
+	}
+	100% {
+		@include transform(rotate(360deg));
+	}
+}
+
+//
+// Base icon styles
+//
+.svg { // SVG wrapping span
+	display: inline-block;
+}
+
+.svg-icon { // SVG element
+	@include _iconColor( $C_textSecondary, $C_textSecondaryInverted );
+	@include display(inline-flex);
+	vertical-align: bottom;
+	font-size: 0;
+
+	// click handling on svg elements
+	// (ensures the entire element is clickable, not just the drawn bits
+	position: relative;
+
+	use { pointer-events: none; }
+}
+
+
+//
+// Specific icon styles
+//
+.svg--updates {
+	@include transform-origin(center center);
+	@include animation(spin 0.4s linear);
+	@include animation-iteration-count(infinite);
+}

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "sass-loader": "6.0.3",
     "storybook-addon-i18n-tools": "1.0.0",
     "style-loader": "0.16.1",
-    "swarm-icons": "0.2.2",
+    "swarm-icons": "1.0.0",
     "swarm-sasstools": "1.3.14",
     "webpack": "2.4.1"
   }

--- a/src/media/Icon.jsx
+++ b/src/media/Icon.jsx
@@ -47,16 +47,15 @@ class Icon extends React.PureComponent {
 			className
 		);
 
-		const viewBox = size === 'auto' ? MEDIA_SIZES['xl'] : MEDIA_SIZES[size];
-		const dim = MEDIA_SIZES[size];
+		const sizeVal = MEDIA_SIZES[size];
 
 		return (
 			<span className={classNames}>
 				<svg
 					preserveAspectRatio='xMinYMin meet'
-					width={dim}
-					height={dim}
-					viewBox={`0 0 ${viewBox} ${viewBox}`}
+					width={sizeVal}
+					height={sizeVal}
+					viewBox={`0 0 ${sizeVal} ${sizeVal}`}
 					className='svg-icon valign--middle'
 					role='img'
 					{...other}>
@@ -68,12 +67,12 @@ class Icon extends React.PureComponent {
 }
 
 Icon.defaultProps = {
-	size: 'm'
+	size: 's'
 };
 
 Icon.propTypes = {
 	shape: React.PropTypes.string.isRequired,
-	size: React.PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl', 'auto'])
+	size: React.PropTypes.oneOf(Object.keys(MEDIA_SIZES))
 };
 
 export default Icon;

--- a/src/media/Icon.jsx
+++ b/src/media/Icon.jsx
@@ -39,8 +39,6 @@ class Icon extends React.PureComponent {
 			...other
 		} = this.props;
 
-		const generatedShape = getIconShape(shape, size);
-
 		const classNames = cx(
 			ICON_CLASS,
 			`svg--${shape}`,
@@ -59,7 +57,7 @@ class Icon extends React.PureComponent {
 					className='svg-icon valign--middle'
 					role='img'
 					{...other}>
-					<use xlinkHref={`#icon-${generatedShape}`}></use>
+					<use xlinkHref={`#icon-${getIconShape(shape,size)}`}></use>
 				</svg>
 			</span>
 		);

--- a/src/media/Icon.jsx
+++ b/src/media/Icon.jsx
@@ -10,6 +10,12 @@ export const ICON_CLASS = 'svg';
  * @returns {String} icon name (with or without suffix)
  */
 export const getIconShape = (shape, size) => {
+
+	// third party icons (yahoo, facebook, etc) do not have small variants
+	if (shape.includes('external')) {
+		return shape;
+	}
+
 	const suffix = size == 'xs' ? '--small' : '';
 	return `${shape}${suffix}`;
 };

--- a/src/media/Icon.jsx
+++ b/src/media/Icon.jsx
@@ -5,6 +5,16 @@ import { MEDIA_SIZES } from '../utils/designConstants';
 export const ICON_CLASS = 'svg';
 
 /**
+ * @param {String} shape - icon shape
+ * @param {String} size - icon size
+ * @returns {String} icon name (with or without suffix)
+ */
+export const getIconShape = (shape, size) => {
+	const suffix = size == 'xs' ? '--small' : '';
+	return `${shape}${suffix}`;
+};
+
+/**
  * Icon component used to insert an svg icon into a component or page
  *
  * **Accessibility** If an Icon is used on its own without supporting
@@ -22,6 +32,8 @@ class Icon extends React.PureComponent {
 			size,
 			...other
 		} = this.props;
+
+		const generatedShape = getIconShape(shape, size);
 
 		const classNames = cx(
 			ICON_CLASS,
@@ -42,7 +54,7 @@ class Icon extends React.PureComponent {
 					className='svg-icon valign--middle'
 					role='img'
 					{...other}>
-					<use xlinkHref={`#icon-${shape}`}></use>
+					<use xlinkHref={`#icon-${generatedShape}`}></use>
 				</svg>
 			</span>
 		);

--- a/src/media/icon.story.jsx
+++ b/src/media/icon.story.jsx
@@ -52,9 +52,13 @@ storiesOf('Icon', module)
 			<Icon shape={ICON_NAME} size='xl' />
 		</div>
 	))
-	.add('Auto', () => (
-		<div className='margin--center'>
-			<Icon shape={ICON_NAME} size='auto' />
-		</div>
-	));
+	.addWithInfo(
+		'Loading indicator',
+		'The `updates` icon is animated by default.',
+		() => (
+			<div className='margin--center padding--all'>
+				<Icon shape='updates' size='l' />
+			</div>
+		)
+	);
 

--- a/src/media/icon.test.jsx
+++ b/src/media/icon.test.jsx
@@ -78,5 +78,12 @@ describe('Icon', () => {
 			const expected = shape;
 			expect(actual).toBe(expected);
 		});
+
+		it('does NOT render a --small shape variant for third party icons', () => {
+			const xsIconShape = 'external-friendster';
+			const actual = getIconShape(xsIconShape, 'xs');
+			const expected = xsIconShape;
+			expect(actual).toBe(expected);
+		});
 	});
 });

--- a/src/media/icon.test.jsx
+++ b/src/media/icon.test.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
-import Icon, { ICON_CLASS } from './Icon';
+import Icon, {
+	ICON_CLASS,
+	getIconShape
+} from './Icon';
 import { MEDIA_SIZES } from '../utils/designConstants';
 
 describe('Icon', () => {
@@ -61,6 +64,19 @@ describe('Icon', () => {
 
 		it('renders each size correctly', () => {
 			Object.keys(MEDIA_SIZES).forEach(sizeChecker);
+		});
+
+		it('renders small shape variant for "xs" icons', () => {
+			const xsIconShape = 'test';
+			const actual = getIconShape(xsIconShape, 'xs');
+			const expected = `${xsIconShape}--small`;
+			expect(actual).toBe(expected);
+		});
+
+		it('renders normal shape variant for icons larger than "xs"', () => {
+			const actual = getIconShape(shape, 'm');
+			const expected = shape;
+			expect(actual).toBe(expected);
 		});
 	});
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5910,9 +5910,9 @@ svgo@^0.7.0:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
-swarm-icons@0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/swarm-icons/-/swarm-icons-0.2.2.tgz#fd2d8617c7a1de75e1c21cf70611bca1692835f1"
+swarm-icons@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/swarm-icons/-/swarm-icons-1.0.0.tgz#eb855da66baa91559ee58497dcd3dd85b7bd2f9a"
 
 swarm-sasstools@1.3.14:
   version "1.3.14"


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-50

#### Description

**Support for `swarm-icons` icon set redesign.** The `Icon` component will now append `--small` to shape names when using `xs` size in order to support small icon variants. We've also moved base icon styles into this repo.

#### Screenshots (if applicable)

**From storybook:**
![screen shot 2017-05-18 at 3 47 33 pm](https://cloud.githubusercontent.com/assets/231252/26220695/a0da1320-3be1-11e7-9923-21395acadd8a.png)
![screen shot 2017-05-18 at 3 47 42 pm](https://cloud.githubusercontent.com/assets/231252/26220696/a0e23334-3be1-11e7-8989-27613d7ce591.png)


**Overview of design changes in `swarm-icons` `1.0.0`**
![screen shot 2017-05-18 at 3 49 00 pm](https://cloud.githubusercontent.com/assets/231252/26220691/9c154c10-3be1-11e7-99cc-bc20ebcf02d4.png)

