### PR TITLE
Bug fix - changed where color-mappings are imported

### DIFF
--- a/assets/scss/components/_all.scss
+++ b/assets/scss/components/_all.scss
@@ -1,3 +1,6 @@
+// color vars
+@import "../util/color-mappings";
+
 //
 // Layout
 //

--- a/assets/scss/storybook.scss
+++ b/assets/scss/storybook.scss
@@ -27,9 +27,6 @@ div[data-reactroot] {
 // sasstools CSS reset
 @import "~swarm-sasstools/scss/reset/all";
 
-// color vars
-@import "./util/color-mappings";
-
 // all meetup-web-components component partials
 @import "./components/all";
 


### PR DESCRIPTION
#### Description
Color mappings were only imported to storybook, not usable by all component CSS in other projects
