### PR TITLE
exclude `meetup-m` from using a `--small` variant shape

### DIFF
--- a/src/media/Icon.jsx
+++ b/src/media/Icon.jsx
@@ -8,8 +8,8 @@ export const ICON_CLASS = 'svg';
 
 const SMALL_ICON_VARIANT_WHITELIST = VALID_SHAPES
 	.filter(s =>
-		!s.startsWith('external')      // no third party icons
-		&& !s.startsWith('meetup-m')   // logo uses same path for `xs`
+		!s.startsWith('external') // no third party icons
+		&& !s === 'meetup-m'      // logo uses same path for `xs`
 	);
 
 

--- a/src/media/Icon.jsx
+++ b/src/media/Icon.jsx
@@ -6,7 +6,7 @@ import { VALID_SHAPES } from 'swarm-icons/dist/js/shapeConstants';
 
 export const ICON_CLASS = 'svg';
 
-const SMALL_ICON_WHITELIST = VALID_SHAPES
+const SMALL_ICON_VARIANT_WHITELIST = VALID_SHAPES
 	.filter(s =>
 		!s.startsWith('external')      // no third party icons
 		&& !s.startsWith('meetup-m')   // logo uses same path for `xs`
@@ -19,7 +19,7 @@ const SMALL_ICON_WHITELIST = VALID_SHAPES
  * @returns {String} icon name (with or without suffix)
  */
 export const getIconShape = (shape, size) => {
-	if (!SMALL_ICON_WHITELIST.includes(shape)) {
+	if (!SMALL_ICON_VARIANT_WHITELIST.includes(shape)) {
 		return shape;
 	}
 	const suffix = size == 'xs' ? '--small' : '';

--- a/src/media/Icon.jsx
+++ b/src/media/Icon.jsx
@@ -6,17 +6,22 @@ import { VALID_SHAPES } from 'swarm-icons/dist/js/shapeConstants';
 
 export const ICON_CLASS = 'svg';
 
+const SMALL_ICON_WHITELIST = VALID_SHAPES
+	.filter(s =>
+		!s.startsWith('external')      // no third party icons
+		&& !s.startsWith('meetup-m')   // logo uses same path for `xs`
+	);
+
+
 /**
  * @param {String} shape - icon shape
  * @param {String} size - icon size
  * @returns {String} icon name (with or without suffix)
  */
 export const getIconShape = (shape, size) => {
-	// third party icons (yahoo, facebook, etc) do not have small variants
-	if (shape.includes('external')) {
+	if (!SMALL_ICON_WHITELIST.includes(shape)) {
 		return shape;
 	}
-
 	const suffix = size == 'xs' ? '--small' : '';
 	return `${shape}${suffix}`;
 };

--- a/src/media/Icon.jsx
+++ b/src/media/Icon.jsx
@@ -8,10 +8,9 @@ export const ICON_CLASS = 'svg';
 
 const SMALL_ICON_VARIANT_WHITELIST = VALID_SHAPES
 	.filter(s =>
-		!s.startsWith('external') // no third party icons
-		&& !s === 'meetup-m'      // logo uses same path for `xs`
+		!s.startsWith('external')  // no third party icons
+		&& !s.startsWith('meetup') // logos use same path for `xs`
 	);
-
 
 /**
  * @param {String} shape - icon shape

--- a/src/media/icon.test.jsx
+++ b/src/media/icon.test.jsx
@@ -68,14 +68,14 @@ describe('Icon', () => {
 		});
 
 		it('renders small shape variant for "xs" icons', () => {
-			const xsIconShape = 'location';
+			const xsIconShape = 'plus';
 			const actual = getIconShape(xsIconShape, 'xs');
 			const expected = `${xsIconShape}${SVG_THIN_STYLE}`;
 			expect(actual).toBe(expected);
 		});
 
 		it('renders small shape variant for "s" icons', () => {
-			const xsIconShape = 'test';
+			const xsIconShape = 'plus';
 			const actual = getIconShape(xsIconShape, 's');
 			const expected = `${xsIconShape}${SVG_THIN_STYLE}`;
 			expect(actual).toBe(expected);

--- a/src/media/icon.test.jsx
+++ b/src/media/icon.test.jsx
@@ -80,7 +80,7 @@ describe('Icon', () => {
 		});
 
 		it('does NOT render a --small shape variant for third party icons', () => {
-			const xsIconShape = 'external-friendster';
+			const xsIconShape = 'external-yahoo';
 			const actual = getIconShape(xsIconShape, 'xs');
 			const expected = xsIconShape;
 			expect(actual).toBe(expected);

--- a/src/media/icon.test.jsx
+++ b/src/media/icon.test.jsx
@@ -81,7 +81,7 @@ describe('Icon', () => {
 			expect(actual).toBe(expected);
 		});
 
-		it('renders normal shape variant for icons larger than "xs"', () => {
+		it('renders normal shape variant for icons larger than "s"', () => {
 			const actual = getIconShape(shape, 'm');
 			const expected = shape;
 			expect(actual).toBe(expected);

--- a/src/media/icon.test.jsx
+++ b/src/media/icon.test.jsx
@@ -67,7 +67,7 @@ describe('Icon', () => {
 		});
 
 		it('renders small shape variant for "xs" icons', () => {
-			const xsIconShape = 'test';
+			const xsIconShape = 'location';
 			const actual = getIconShape(xsIconShape, 'xs');
 			const expected = `${xsIconShape}--small`;
 			expect(actual).toBe(expected);
@@ -81,6 +81,13 @@ describe('Icon', () => {
 
 		it('does NOT render a --small shape variant for third party icons', () => {
 			const xsIconShape = 'external-friendster';
+			const actual = getIconShape(xsIconShape, 'xs');
+			const expected = xsIconShape;
+			expect(actual).toBe(expected);
+		});
+
+		it('does NOT render a --small shape variant meetup m logo', () => {
+			const xsIconShape = 'meetup-m';
 			const actual = getIconShape(xsIconShape, 'xs');
 			const expected = xsIconShape;
 			expect(actual).toBe(expected);


### PR DESCRIPTION
The `meetup-m` logo icon uses the same path for all sizes. This branch introduces a whitelist that excludes both `meetup-m` and `external-[service]` icons from small variants.
