### PR TITLE
uprade swarm-icons peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-intl": "^2.2.3",
-    "swarm-icons": "1.1.48"
+    "swarm-icons": "^1.1.56"
   },
   "dependencies": {
     "autosize": "3.0.21",


### PR DESCRIPTION
The previous yarn-upgrade branch updated the `swarm-icons` dependency, but not the peerDependency version. Fixing here
