### PR TITLE
Refactor/generic dropdown component

### DIFF
--- a/assets/scss/components/_all.scss
+++ b/assets/scss/components/_all.scss
@@ -21,6 +21,7 @@
 @import "button";
 @import "checkbox";
 @import "dateDisplay";
+@import "dropdown";
 @import "forms";
 @import "groupCard";
 @import "icon";

--- a/assets/scss/components/_all.scss
+++ b/assets/scss/components/_all.scss
@@ -1,5 +1,6 @@
 // color vars
 @import "../util/color-mappings";
+@import "../util/vars";
 
 //
 // Layout

--- a/assets/scss/components/_dropdown.scss
+++ b/assets/scss/components/_dropdown.scss
@@ -1,7 +1,7 @@
 //
 // Dropdown
 //
-$dropdownShadow: 0 2px 2px 0 $C_border,0 3px 1px -2px $C_separator,0 1px 5px 0 $C_border;
+$dropdownShadow: $interactiveShadow;
 $content-minWidth: $block-6;
 $content-maxWidth: 512px; // match chapstick
 $triangleSize: 10px;

--- a/assets/scss/components/_dropdown.scss
+++ b/assets/scss/components/_dropdown.scss
@@ -8,6 +8,7 @@ $triangleSize: 10px;
 $spaceFromTrigger: $space-3 + $triangleSize;
 
 .dropdown {
+	display: inline-block;
 	position: relative;
 }
 

--- a/assets/scss/components/_dropdown.scss
+++ b/assets/scss/components/_dropdown.scss
@@ -2,7 +2,8 @@
 // Dropdown
 //
 $dropdownShadow: 0 2px 2px 0 $C_border,0 3px 1px -2px $C_separator,0 1px 5px 0 $C_border;
-$view-minWidth: 512px; // match chapstick
+$content-minWidth: $block-6;
+$content-maxWidth: 512px; // match chapstick
 $spaceFromTrigger: $space-4;
 
 .dropdown {
@@ -28,7 +29,8 @@ $spaceFromTrigger: $space-4;
 	box-sizing: border-box;
 	position: absolute;
 	top: $spaceFromTrigger;
-	max-width: $view-minWidth;
+	min-width: $content-minWidth;
+	max-width: $content-minWidth;
 	z-index: map-get($zindex-map, 'popup');
 
 	// outer triangle for border
@@ -39,7 +41,6 @@ $spaceFromTrigger: $space-4;
 		border-right: ($space + 1) solid transparent;
 		border-left: ($space + 1) solid transparent;
 		top: -$space - 0.5;
-		left: $space;
 	}
 
 	// inner triangle to match content color
@@ -50,7 +51,6 @@ $spaceFromTrigger: $space-4;
 		border-right: $space solid transparent;
 		border-left: $space solid transparent;
 		top: -$space + 1;
-		left: $space + 1;
 	}
 
 	&:before,
@@ -62,4 +62,23 @@ $spaceFromTrigger: $space-4;
 		z-index: map-get($zindex-map, 'popup') + 1;
 	}
 
+}
+
+.dropdown-content--right {
+	right: 0;
+	&:before {
+		right: $space;
+	}
+	&:after {
+		right: $space + 1;
+	}
+}
+.dropdown-content--left {
+	left: 0;
+	&:before {
+		left: $space;
+	}
+	&:after {
+		left: $space + 1;
+	}
 }

--- a/assets/scss/components/_dropdown.scss
+++ b/assets/scss/components/_dropdown.scss
@@ -1,0 +1,65 @@
+//
+// Dropdown
+//
+$dropdownShadow: 0 2px 2px 0 $C_border,0 3px 1px -2px $C_separator,0 1px 5px 0 $C_border;
+$view-minWidth: 512px; // match chapstick
+$spaceFromTrigger: $space-4;
+
+.dropdown {
+	position: relative;
+}
+
+.dropdown-trigger {
+	display: inline;
+	cursor: pointer;
+
+	&--active {
+		&:focus {
+			outline: 0;
+		}
+	}
+}
+
+.dropdown-content {
+	border: 1px solid $C_border;
+	border-radius: $defaultRadius;
+	background-color: $C_contentBG;
+	box-shadow: $dropdownShadow;
+	box-sizing: border-box;
+	position: absolute;
+	top: $spaceFromTrigger;
+	max-width: $view-minWidth;
+	z-index: map-get($zindex-map, 'popup');
+
+	// outer triangle for border
+	&:before {
+		width: 0;
+		height: 0;
+		border-bottom: ($space + 1) solid $C_border;
+		border-right: ($space + 1) solid transparent;
+		border-left: ($space + 1) solid transparent;
+		top: -$space - 0.5;
+		left: $space;
+	}
+
+	// inner triangle to match content color
+	&:after {
+		width: 0;
+		height: 0;
+		border-bottom: $space solid $C_white;
+		border-right: $space solid transparent;
+		border-left: $space solid transparent;
+		top: -$space + 1;
+		left: $space + 1;
+	}
+
+	&:before,
+	&:after {
+		content: '';
+		position: absolute;
+
+		// overlap content container
+		z-index: map-get($zindex-map, 'popup') + 1;
+	}
+
+}

--- a/assets/scss/components/_dropdown.scss
+++ b/assets/scss/components/_dropdown.scss
@@ -4,7 +4,8 @@
 $dropdownShadow: 0 2px 2px 0 $C_border,0 3px 1px -2px $C_separator,0 1px 5px 0 $C_border;
 $content-minWidth: $block-6;
 $content-maxWidth: 512px; // match chapstick
-$spaceFromTrigger: $space-4;
+$triangleSize: 10px;
+$spaceFromTrigger: $space-3 + $triangleSize;
 
 .dropdown {
 	position: relative;
@@ -37,20 +38,20 @@ $spaceFromTrigger: $space-4;
 	&:before {
 		width: 0;
 		height: 0;
-		border-bottom: ($space + 1) solid $C_border;
-		border-right: ($space + 1) solid transparent;
-		border-left: ($space + 1) solid transparent;
-		top: -$space - 0.5;
+		border-bottom: ($triangleSize + 1) solid $C_border;
+		border-right: ($triangleSize + 1) solid transparent;
+		border-left: ($triangleSize + 1) solid transparent;
+		top: -$triangleSize - 0.5;
 	}
 
 	// inner triangle to match content color
 	&:after {
 		width: 0;
 		height: 0;
-		border-bottom: $space solid $C_white;
-		border-right: $space solid transparent;
-		border-left: $space solid transparent;
-		top: -$space + 1;
+		border-bottom: $triangleSize solid $C_white;
+		border-right: $triangleSize solid transparent;
+		border-left: $triangleSize solid transparent;
+		top: -$triangleSize + 1;
 	}
 
 	&:before,
@@ -66,10 +67,10 @@ $spaceFromTrigger: $space-4;
 @mixin alignDropdown($direction) {
 	#{$direction}: 0;
 	&:before {
-		#{$direction}: $space;
+		#{$direction}: $space-2;
 	}
 	&:after {
-		#{$direction}: $space + 1;
+		#{$direction}: $space-2 + 1;
 	}
 }
 

--- a/assets/scss/components/_dropdown.scss
+++ b/assets/scss/components/_dropdown.scss
@@ -61,24 +61,21 @@ $spaceFromTrigger: $space-4;
 		// overlap content container
 		z-index: map-get($zindex-map, 'popup') + 1;
 	}
+}
 
+@mixin alignDropdown($direction) {
+	#{$direction}: 0;
+	&:before {
+		#{$direction}: $space;
+	}
+	&:after {
+		#{$direction}: $space + 1;
+	}
 }
 
 .dropdown-content--right {
-	right: 0;
-	&:before {
-		right: $space;
-	}
-	&:after {
-		right: $space + 1;
-	}
+	@include alignDropdown('right');
 }
 .dropdown-content--left {
-	left: 0;
-	&:before {
-		left: $space;
-	}
-	&:after {
-		left: $space + 1;
-	}
+	@include alignDropdown('left');
 }

--- a/assets/scss/components/_popover.scss
+++ b/assets/scss/components/_popover.scss
@@ -1,7 +1,7 @@
 //
 // Popover
 //
-$popoverShadow: 0 2px 2px 0 $C_border,0 3px 1px -2px $C_separator,0 1px 5px 0 $C_border;
+$popoverShadow: $interactiveShadow;
 $view-minWidth: 320px;
 
 .popover {

--- a/assets/scss/util/_vars.scss
+++ b/assets/scss/util/_vars.scss
@@ -1,0 +1,4 @@
+
+// shadow for "interactive" elements,
+// like popover or dropdown menus
+$interactiveShadow: 0 2px 2px 0 $C_border,0 3px 1px -2px $C_separator,0 1px 5px 0 $C_border;

--- a/src/interactive/Dropdown.jsx
+++ b/src/interactive/Dropdown.jsx
@@ -104,14 +104,10 @@ class Dropdown extends React.Component {
 	}
 }
 
-Dropdown.defaultProps = {
-	align: 'right'
-};
-
 Dropdown.propTypes = {
 	trigger: PropTypes.element.isRequired,
 	content: PropTypes.element.isRequired,
-	align: PropTypes.oneOf(['left', 'right']),
+	align: PropTypes.oneOf(['left', 'right']).isRequired,
 	className: PropTypes.string,
 };
 

--- a/src/interactive/Dropdown.jsx
+++ b/src/interactive/Dropdown.jsx
@@ -1,0 +1,183 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import cx from 'classnames';
+import bindAll from '../utils/bindAll';
+
+const POPOVER_MENU_CLASS = 'popover-menu-option';
+/**
+ * @module Popover
+ */
+class Popover extends React.Component {
+	constructor(props) {
+		super(props);
+
+		bindAll(this,
+			'open',
+			'close',
+			'onClick',
+			'onKeyDown',
+			'onClick',
+			'onBlur'
+		);
+
+		this.state = {
+			isActive: false,
+			selectedIndex: 0
+		};
+
+		this._menuItems = new Map();
+	}
+
+	open() {
+		this.setState({ isActive: true });
+	}
+
+	close() {
+		this.setState({ isActive: false });
+	}
+
+	focusCheck() {
+		const focusedOptionClass = document.activeElement.parentNode.classList;
+		// don't close the popover if we're moving focus to an menu item
+		if (focusedOptionClass && focusedOptionClass.contains(POPOVER_MENU_CLASS)) {
+			return;
+		}
+
+		this.closeMenu();
+	}
+
+	onBlur() {
+		// On blur, browsers always focus `<body>` before moving focus
+		// to the next actual focused element.
+		//
+		// This zero-length timeout ensures the browser will return the
+		// actual focused element instead of `<body>`
+		window.setTimeout(() => this.focusCheck(), 0);
+	}
+
+	onClick(e) {
+		this.openMenu();
+	}
+
+	onKeyDown(e) {
+		switch(e.key) {
+		case 'Enter':
+			if (!this.state.isActive) {
+				this.openMenu();
+			}
+			break;
+		case 'Escape':
+			this.closeMenu();
+			break;
+		}
+	}
+
+	componentDidUpdate() {
+		const selectedItemEl = this._menuItems.get(this.state.selectedIndex);
+		if (selectedItemEl) {
+			ReactDOM.findDOMNode(selectedItemEl).focus();
+		}
+	}
+
+	renderMenuItems() {
+		this.menuItems = this.props.menuItems.map((menuItem, i) => {
+			return (
+				<li
+					key={i}
+					className={POPOVER_MENU_CLASS}
+					role='menuitem'
+					onKeyDown={this.onKeyDownMenuItem}
+				>
+					{
+						/*
+						* treat each user-provided menu item element as the
+						* keyboard-navigable, focusable 'menuitem' role
+						*/
+						React.cloneElement(menuItem,
+							{
+								tabIndex: '-1',
+								onKeyDown: this.onKeyDownMenuItem,
+								className: cx('popover-menu-option-target', menuItem.props.className),
+								ref: (el) => this._menuItems.set(i, el),
+							}
+						)
+					}
+				</li>
+			);
+		});
+
+		return this.menuItems;
+	}
+
+	render() {
+		const isActive = this.state.isActive;
+		const {
+				className,
+				trigger,
+				menuItems, // eslint-disable-line no-unused-vars
+				align,
+				...other
+			} = this.props;
+
+		const classNames = {
+			popover: cx(
+				className,
+				'popover'
+			),
+			trigger: cx(
+				'popover-trigger',
+				{
+					'popover-trigger--active': isActive
+				}
+			),
+			menu: cx(
+				'popover-container',
+				'popover-container--menu',
+				{
+					'display--none': !isActive,
+					'popover-container--horizontal-left': (align === 'left'),
+					'popover-container--horizontal-right': (align === 'right')
+				}
+			)
+		};
+
+		return (
+			<div
+				className={classNames.popover}
+				aria-haspopup='true'
+				onKeyDown={this.onKeyDown}
+				onBlur={this.onBlur}
+				{...other}
+			>
+
+				<div
+					className={classNames.trigger}
+					tabIndex='0'
+					onClick={this.onClick}
+				>
+					{trigger}
+				</div>
+
+				<nav>
+					<ul
+						className={classNames.menu}
+						role='menu'
+						aria-hidden={!isActive}
+					>
+						{this.renderMenuItems()}
+					</ul>
+				</nav>
+			</div>
+		);
+	}
+}
+
+Popover.propTypes = {
+	trigger: PropTypes.element.isRequired,
+	menuItems: PropTypes.arrayOf(PropTypes.element).isRequired,
+	align: PropTypes.oneOf(['right', 'left']),
+	className: PropTypes.string,
+};
+
+export default Popover;

--- a/src/interactive/Dropdown.jsx
+++ b/src/interactive/Dropdown.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import ReactDOM from 'react-dom';
 import cx from 'classnames';
 import bindAll from '../utils/bindAll';
 
@@ -70,13 +69,6 @@ class Dropdown extends React.Component {
 		}
 	}
 
-	componentDidUpdate() {
-		const selectedItemEl = this._menuItems.get(this.state.selectedIndex);
-		if (selectedItemEl) {
-			ReactDOM.findDOMNode(selectedItemEl).focus();
-		}
-	}
-
 	render() {
 		const isActive = this.state.isActive;
 		const {
@@ -97,7 +89,7 @@ class Dropdown extends React.Component {
 					'dropdown-trigger--active': isActive
 				}
 			),
-			menu: 'dropdown-conent'
+			menu: 'dropdown-content'
 		};
 
 		return (
@@ -119,7 +111,7 @@ class Dropdown extends React.Component {
 
 				{/* TODO: fix aria attributes */}
 				<div
-					className={className.conent}
+					className={classNames.content}
 					role='menu'
 					aria-hidden={!isActive}
 				>

--- a/src/interactive/Dropdown.jsx
+++ b/src/interactive/Dropdown.jsx
@@ -43,6 +43,12 @@ class Dropdown extends React.Component {
 		}
 	}
 
+	componentDidMount() {
+	}
+
+	componentWillUnmount() {
+	}
+
 	render() {
 		const isActive = this.state.isActive;
 		const {

--- a/src/interactive/Dropdown.jsx
+++ b/src/interactive/Dropdown.jsx
@@ -41,7 +41,12 @@ class Dropdown extends React.Component {
 	}
 
 	onBodyClick(e) {
-		if (!this.contentRef.contains(e.target)) {
+		const isNotDropdownClick = [
+			this.contentRef,
+			this.triggerRef
+		].every(ref => !ref.contains(e.target));
+
+		if (isNotDropdownClick) {
 			this.closeContent();
 		}
 	}
@@ -103,6 +108,7 @@ class Dropdown extends React.Component {
 			>
 
 				<div
+					ref={(el) => this.triggerRef = el}
 					className={classNames.trigger}
 					tabIndex='0'
 					onClick={this.onClick}

--- a/src/interactive/Dropdown.jsx
+++ b/src/interactive/Dropdown.jsx
@@ -4,47 +4,44 @@ import ReactDOM from 'react-dom';
 import cx from 'classnames';
 import bindAll from '../utils/bindAll';
 
-const POPOVER_MENU_CLASS = 'popover-menu-option';
 /**
- * @module Popover
+ * @module Dropdown
  */
-class Popover extends React.Component {
+class Dropdown extends React.Component {
 	constructor(props) {
 		super(props);
 
 		bindAll(this,
-			'open',
-			'close',
+			'openContent',
+			'closeContent',
 			'onClick',
 			'onKeyDown',
 			'onClick',
 			'onBlur'
 		);
 
-		this.state = {
-			isActive: false,
-			selectedIndex: 0
-		};
-
-		this._menuItems = new Map();
+		this.state = { isActive: false };
 	}
 
-	open() {
-		this.setState({ isActive: true });
+	openContent() {
+		this.setState(() => ({ isActive: true }));
 	}
 
-	close() {
-		this.setState({ isActive: false });
+	closeContent() {
+		this.setState(() => ({ isActive: false }));
 	}
 
 	focusCheck() {
-		const focusedOptionClass = document.activeElement.parentNode.classList;
-		// don't close the popover if we're moving focus to an menu item
-		if (focusedOptionClass && focusedOptionClass.contains(POPOVER_MENU_CLASS)) {
-			return;
-		}
+		// const focusedOptionClass = document.activeElement.parentNode.classList;
 
-		this.closeMenu();
+		// TODO: bail out if active element is the content el
+		/*
+		 *if (focusedOptionClass && focusedOptionClass.contains(POPOVER_MENU_CLASS)) {
+		 *    return;
+		 *}
+		 */
+
+		this.closeContent();
 	}
 
 	onBlur() {
@@ -57,18 +54,18 @@ class Popover extends React.Component {
 	}
 
 	onClick(e) {
-		this.openMenu();
+		this.openContent();
 	}
 
 	onKeyDown(e) {
 		switch(e.key) {
 		case 'Enter':
 			if (!this.state.isActive) {
-				this.openMenu();
+				this.openContent();
 			}
 			break;
 		case 'Escape':
-			this.closeMenu();
+			this.closeContent();
 			break;
 		}
 	}
@@ -80,71 +77,32 @@ class Popover extends React.Component {
 		}
 	}
 
-	renderMenuItems() {
-		this.menuItems = this.props.menuItems.map((menuItem, i) => {
-			return (
-				<li
-					key={i}
-					className={POPOVER_MENU_CLASS}
-					role='menuitem'
-					onKeyDown={this.onKeyDownMenuItem}
-				>
-					{
-						/*
-						* treat each user-provided menu item element as the
-						* keyboard-navigable, focusable 'menuitem' role
-						*/
-						React.cloneElement(menuItem,
-							{
-								tabIndex: '-1',
-								onKeyDown: this.onKeyDownMenuItem,
-								className: cx('popover-menu-option-target', menuItem.props.className),
-								ref: (el) => this._menuItems.set(i, el),
-							}
-						)
-					}
-				</li>
-			);
-		});
-
-		return this.menuItems;
-	}
-
 	render() {
 		const isActive = this.state.isActive;
 		const {
 				className,
 				trigger,
-				menuItems, // eslint-disable-line no-unused-vars
-				align,
+				content,
 				...other
 			} = this.props;
 
 		const classNames = {
-			popover: cx(
+			dropdown: cx(
 				className,
-				'popover'
+				'dropdown'
 			),
 			trigger: cx(
-				'popover-trigger',
+				'dropdown-trigger',
 				{
-					'popover-trigger--active': isActive
+					'dropdown-trigger--active': isActive
 				}
 			),
-			menu: cx(
-				'popover-container',
-				'popover-container--menu',
-				{
-					'display--none': !isActive,
-					'popover-container--horizontal-left': (align === 'left'),
-					'popover-container--horizontal-right': (align === 'right')
-				}
-			)
+			menu: 'dropdown-conent'
 		};
 
 		return (
 			<div
-				className={classNames.popover}
+				className={classNames.dropdown}
 				aria-haspopup='true'
 				onKeyDown={this.onKeyDown}
 				onBlur={this.onBlur}
@@ -159,25 +117,23 @@ class Popover extends React.Component {
 					{trigger}
 				</div>
 
-				<nav>
-					<ul
-						className={classNames.menu}
-						role='menu'
-						aria-hidden={!isActive}
-					>
-						{this.renderMenuItems()}
-					</ul>
-				</nav>
+				{/* TODO: fix aria attributes */}
+				<div
+					className={className.conent}
+					role='menu'
+					aria-hidden={!isActive}
+				>
+					{content}
+				</div>
 			</div>
 		);
 	}
 }
 
-Popover.propTypes = {
+Dropdown.propTypes = {
 	trigger: PropTypes.element.isRequired,
-	menuItems: PropTypes.arrayOf(PropTypes.element).isRequired,
-	align: PropTypes.oneOf(['right', 'left']),
+	content: PropTypes.element.isRequired,
 	className: PropTypes.string,
 };
 
-export default Popover;
+export default Dropdown;

--- a/src/interactive/Dropdown.jsx
+++ b/src/interactive/Dropdown.jsx
@@ -11,8 +11,7 @@ class Dropdown extends React.Component {
 		super(props);
 
 		bindAll(this,
-			'openContent',
-			'closeContent',
+			'toggleContent',
 			'onClick',
 			'onKeyDown',
 			'onClick',
@@ -22,12 +21,8 @@ class Dropdown extends React.Component {
 		this.state = { isActive: false };
 	}
 
-	openContent() {
-		this.setState(() => ({ isActive: true }));
-	}
-
-	closeContent() {
-		this.setState(() => ({ isActive: false }));
+	toggleContent() {
+		this.setState(() => ({ isActive: !this.state.isActive}));
 	}
 
 	focusCheck() {
@@ -40,7 +35,7 @@ class Dropdown extends React.Component {
 		 *}
 		 */
 
-		this.closeContent();
+		this.toggleContent();
 	}
 
 	onBlur() {
@@ -53,18 +48,16 @@ class Dropdown extends React.Component {
 	}
 
 	onClick(e) {
-		this.openContent();
+		this.toggleContent();
 	}
 
 	onKeyDown(e) {
 		switch(e.key) {
 		case 'Enter':
-			if (!this.state.isActive) {
-				this.openContent();
-			}
+			this.toggleContent();
 			break;
 		case 'Escape':
-			this.closeContent();
+			this.toggleContent();
 			break;
 		}
 	}
@@ -89,7 +82,13 @@ class Dropdown extends React.Component {
 					'dropdown-trigger--active': isActive
 				}
 			),
-			menu: 'dropdown-content'
+			content: cx(
+				'dropdown-content',
+				{
+					'display--none': !isActive,
+					'display--block': isActive
+				}
+			)
 		};
 
 		return (
@@ -112,7 +111,6 @@ class Dropdown extends React.Component {
 				{/* TODO: fix aria attributes */}
 				<div
 					className={classNames.content}
-					role='menu'
 					aria-hidden={!isActive}
 				>
 					{content}

--- a/src/interactive/Dropdown.jsx
+++ b/src/interactive/Dropdown.jsx
@@ -14,37 +14,18 @@ class Dropdown extends React.Component {
 			'toggleContent',
 			'onClick',
 			'onKeyDown',
-			'onClick',
-			'onBlur'
+			'onClick'
 		);
 
 		this.state = { isActive: false };
 	}
 
+	closeContent() {
+		this.setState(() => ({ isActive: false }));
+	}
+
 	toggleContent() {
-		this.setState(() => ({ isActive: !this.state.isActive}));
-	}
-
-	focusCheck() {
-		// const focusedOptionClass = document.activeElement.parentNode.classList;
-
-		// TODO: bail out if active element is the content el
-		/*
-		 *if (focusedOptionClass && focusedOptionClass.contains(POPOVER_MENU_CLASS)) {
-		 *    return;
-		 *}
-		 */
-
-		this.toggleContent();
-	}
-
-	onBlur() {
-		// On blur, browsers always focus `<body>` before moving focus
-		// to the next actual focused element.
-		//
-		// This zero-length timeout ensures the browser will return the
-		// actual focused element instead of `<body>`
-		window.setTimeout(() => this.focusCheck(), 0);
+		this.setState(() => ({ isActive: !this.state.isActive }));
 	}
 
 	onClick(e) {
@@ -57,7 +38,7 @@ class Dropdown extends React.Component {
 			this.toggleContent();
 			break;
 		case 'Escape':
-			this.toggleContent();
+			this.closeContent();
 			break;
 		}
 	}
@@ -68,6 +49,7 @@ class Dropdown extends React.Component {
 				className,
 				trigger,
 				content,
+				align, // eslint-disable-line no-unused-vars
 				...other
 			} = this.props;
 
@@ -85,6 +67,8 @@ class Dropdown extends React.Component {
 			content: cx(
 				'dropdown-content',
 				{
+					'dropdown-content--right': (align == 'right'),
+					'dropdown-content--left': (align == 'left'),
 					'display--none': !isActive,
 					'display--block': isActive
 				}
@@ -96,7 +80,6 @@ class Dropdown extends React.Component {
 				className={classNames.dropdown}
 				aria-haspopup='true'
 				onKeyDown={this.onKeyDown}
-				onBlur={this.onBlur}
 				{...other}
 			>
 
@@ -112,6 +95,7 @@ class Dropdown extends React.Component {
 				<div
 					className={classNames.content}
 					aria-hidden={!isActive}
+					ref={(el) => this.contentEl}
 				>
 					{content}
 				</div>
@@ -120,9 +104,14 @@ class Dropdown extends React.Component {
 	}
 }
 
+Dropdown.defaultProps = {
+	align: 'right'
+};
+
 Dropdown.propTypes = {
 	trigger: PropTypes.element.isRequired,
 	content: PropTypes.element.isRequired,
+	align: PropTypes.oneOf(['left', 'right']),
 	className: PropTypes.string,
 };
 

--- a/src/interactive/Dropdown.jsx
+++ b/src/interactive/Dropdown.jsx
@@ -6,7 +6,7 @@ import bindAll from '../utils/bindAll';
 /**
  * @module Dropdown
  */
-class Dropdown extends React.Component {
+class Dropdown extends React.PureComponent {
 	constructor(props) {
 		super(props);
 

--- a/src/interactive/Dropdown.jsx
+++ b/src/interactive/Dropdown.jsx
@@ -14,7 +14,9 @@ class Dropdown extends React.Component {
 			'toggleContent',
 			'onClick',
 			'onKeyDown',
-			'onClick'
+			'onClick',
+			'onBodyClick',
+			'onBodyKeyDown'
 		);
 
 		this.state = { isActive: false };
@@ -33,20 +35,31 @@ class Dropdown extends React.Component {
 	}
 
 	onKeyDown(e) {
-		switch(e.key) {
-		case 'Enter':
+		if (e.key === 'Enter') {
 			this.toggleContent();
-			break;
-		case 'Escape':
+		}
+	}
+
+	onBodyClick(e) {
+		if (!this.contentRef.contains(e.target)) {
 			this.closeContent();
-			break;
+		}
+	}
+
+	onBodyKeyDown(e) {
+		if (e.key === 'Escape') {
+			this.closeContent();
 		}
 	}
 
 	componentDidMount() {
+		document.body.addEventListener('click', this.onBodyClick);
+		document.body.addEventListener('keydown', this.onBodyKeyDown);
 	}
 
 	componentWillUnmount() {
+		document.body.removeEventListener('click', this.onBodyClick);
+		document.body.removeEventListener('keydown', this.onBodyKeyDown);
 	}
 
 	render() {
@@ -97,11 +110,10 @@ class Dropdown extends React.Component {
 					{trigger}
 				</div>
 
-				{/* TODO: fix aria attributes */}
 				<div
+					ref={(el) => this.contentRef = el}
 					className={classNames.content}
 					aria-hidden={!isActive}
-					ref={(el) => this.contentEl}
 				>
 					{content}
 				</div>

--- a/src/interactive/dropdown.story.jsx
+++ b/src/interactive/dropdown.story.jsx
@@ -14,11 +14,15 @@ const dropdownContent = (
 		<Chunk>
 			<h2 className='text--big text--bold'>Dropdown content</h2>
 		</Chunk>
-		<Chunk>
+		<Chunk className='runningText'>
 			<p>
 				This is a basic dropdown component.
 				It accepts a `content` prop with which you
 				can pass arbitrary JSX content.
+			</p>
+			<p>
+				<a href='#'>Tab-focusable links</a> should
+				work as if they're in normal document flow
 			</p>
 		</Chunk>
 	</Section>

--- a/src/interactive/dropdown.story.jsx
+++ b/src/interactive/dropdown.story.jsx
@@ -5,6 +5,8 @@ import { decorateWithLocale } from '../utils/decorators';
 import Dropdown from './Dropdown';
 import Section from '../layout/Section';
 import Chunk from '../layout/Chunk';
+import Flex from '../layout/Flex';
+import FlexItem from '../layout/FlexItem';
 import Button from '../forms/Button';
 
 const dropdownContent = (
@@ -26,10 +28,29 @@ storiesOf('Dropdown', module)
 	.addDecorator(decorateWithLocale)
 	.addWithInfo(
 		'Basic Dropdown component',
-		'Closed by default',
+		'Aligned right by default',
+		() => (
+			<InfoWrapper>
+				<Flex justify='flexEnd'>
+					<FlexItem shrink>
+						<Dropdown
+							trigger={
+								<Button small>Open</Button>
+							}
+							content={dropdownContent}
+						/>
+					</FlexItem>
+				</Flex>
+			</InfoWrapper>
+		)
+	)
+	.addWithInfo(
+		'Left aligned dropdown',
+		'Use the `align` prop to change alignment to left',
 		() => (
 			<InfoWrapper>
 				<Dropdown
+					align='left'
 					trigger={
 						<Button small>Open</Button>
 					}

--- a/src/interactive/dropdown.story.jsx
+++ b/src/interactive/dropdown.story.jsx
@@ -34,6 +34,7 @@ storiesOf('Dropdown', module)
 				<Flex justify='flexEnd'>
 					<FlexItem shrink>
 						<Dropdown
+							align='right'
 							trigger={
 								<Button small>Open</Button>
 							}

--- a/src/interactive/dropdown.story.jsx
+++ b/src/interactive/dropdown.story.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { storiesOf } from '@kadira/storybook';
+import { InfoWrapper } from '../utils/storyComponents';
+import { decorateWithLocale } from '../utils/decorators';
+import Dropdown from './Dropdown';
+import Section from '../layout/Section';
+import Chunk from '../layout/Chunk';
+import Button from '../forms/Button';
+
+const dropdownContent = (
+	<Section>
+		<Chunk>
+			<h2 className='text--big text--bold'>Dropdown content</h2>
+		</Chunk>
+		<Chunk>
+			<p>
+				This is a basic dropdown component.
+				It accepts a `content` prop with which you
+				can pass arbitrary JSX content.
+			</p>
+		</Chunk>
+	</Section>
+);
+
+storiesOf('Dropdown', module)
+	.addDecorator(decorateWithLocale)
+	.addWithInfo(
+		'Basic Dropdown component',
+		'Closed by default',
+		() => (
+			<InfoWrapper>
+				<Dropdown
+					trigger={
+						<Button small>Open</Button>
+					}
+					content={dropdownContent}
+				/>
+			</InfoWrapper>
+		)
+	);

--- a/src/interactive/dropdown.story.jsx
+++ b/src/interactive/dropdown.story.jsx
@@ -8,7 +8,7 @@ import Chunk from '../layout/Chunk';
 import Button from '../forms/Button';
 
 const dropdownContent = (
-	<Section>
+	<Section noSeparator>
 		<Chunk>
 			<h2 className='text--big text--bold'>Dropdown content</h2>
 		</Chunk>

--- a/src/interactive/dropdown.story.jsx
+++ b/src/interactive/dropdown.story.jsx
@@ -10,7 +10,7 @@ import FlexItem from '../layout/FlexItem';
 import Button from '../forms/Button';
 
 const dropdownContent = (
-	<Section noSeparator>
+	<Section className='border--none'>
 		<Chunk>
 			<h2 className='text--big text--bold'>Dropdown content</h2>
 		</Chunk>

--- a/src/interactive/dropdown.test.jsx
+++ b/src/interactive/dropdown.test.jsx
@@ -1,0 +1,194 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-addons-test-utils';
+import { Link } from 'react-router';
+import Popover from './Popover';
+import Button from '../forms/Button';
+
+let popover,
+	popoverEl,
+	triggerEl,
+	menuEl,
+	optionEls;
+
+const class_hidden = 'display--none';
+const MOCK_HANDLER = jest.genMockFunction();
+
+const popoverComponent = (
+	<Popover
+		trigger={
+			<Button>Open</Button>
+		}
+		menuItems={[
+			<Link to='somepath1/' onClick={MOCK_HANDLER}>First option</Link>,
+			<Link to='somepath2/' onClick={MOCK_HANDLER}>Second option</Link>,
+			<Link to='somepath3/' onClick={MOCK_HANDLER}>Third option</Link>,
+		]}
+	/>
+);
+
+const getIsActive = (menuEl) => {
+	return !menuEl.classList.contains(class_hidden);
+};
+
+describe('Popover', function() {
+
+	beforeEach(() => {
+		popover = TestUtils.renderIntoDocument(popoverComponent);
+		popoverEl = ReactDOM.findDOMNode(popover);
+		triggerEl = ReactDOM.findDOMNode(
+			TestUtils.findRenderedDOMComponentWithClass(popover, 'popover-trigger')
+		);
+		menuEl = ReactDOM.findDOMNode(
+			TestUtils.findRenderedDOMComponentWithClass(popover, 'popover-container--menu')
+		);
+		optionEls = TestUtils.scryRenderedDOMComponentsWithClass(popover, 'popover-menu-option-target')
+			.map((option) => ReactDOM.findDOMNode(option));
+	});
+
+	afterEach(() => {
+		popover = null;
+		popoverEl = null;
+		triggerEl = null;
+		menuEl = null;
+		optionEls = null;
+	});
+
+	it('exists; menu hidden by default', () => {
+		expect(popoverEl).not.toBeNull();
+		expect(getIsActive(menuEl)).toBe(false);
+	});
+
+	describe('focusCheck', () => {
+		it('should be active if focus is on menu items', () => {
+			popover.openMenu();
+			popover.focusCheck();
+			expect(popover.state.isActive).toBe(true);
+		});
+		it('should close menu if focus not on items', () => {
+			popover.openMenu();
+			document.activeElement.blur();
+			popover.focusCheck();
+			expect(popover.state.isActive).toBe(false);
+		});
+	});
+
+	it('menu appears on trigger click', () => {
+		expect(getIsActive(menuEl)).toBe(false);
+		TestUtils.Simulate.click(triggerEl);
+		expect(getIsActive(menuEl)).toBe(true);
+	});
+
+	describe('onBlur', () => {
+		it('should add timeout when `blur`ed', () => {
+			spyOn(window, 'setTimeout');
+			popover.onBlur();
+			expect(window.setTimeout).toHaveBeenCalled();
+		});
+	});
+
+	describe('onKeyDown', () => {
+		it('menu is keyboard navigable with `escape` key', () => {
+			const firstOption = optionEls[0];
+
+			popover.openMenu();
+
+			TestUtils.Simulate.keyDown(firstOption, {key: 'Escape'});
+			expect(getIsActive(menuEl)).toBe(false);
+		});
+		it('menu is keyboard navigable with `enter` key', () => {
+			TestUtils.Simulate.keyDown(triggerEl, {key: 'Enter'});
+			expect(getIsActive(menuEl)).toBe(true);
+		});
+	});
+
+	describe('onKeyDownMenuItem', () => {
+		let firstOption,
+			secondOption;
+
+		beforeEach(() => {
+			firstOption = optionEls[0];
+			secondOption = optionEls[1];
+			popover.openMenu();
+		});
+
+		it('menu is keyboard navigable with arrows `Down`', () => {
+			TestUtils.Simulate.keyDown(firstOption, {key: 'ArrowDown'});
+			expect(document.activeElement).toBe(secondOption);
+		});
+		it('menu is keyboard navigable with arrows `Up`', () => {
+			TestUtils.Simulate.keyDown(firstOption, {key: 'ArrowUp'});
+			expect(document.activeElement).toBe(firstOption);
+		});
+		it('menu is keyboard navigable with arrows `Enter`', () => {
+			TestUtils.Simulate.keyDown(firstOption, {key: 'Enter'});
+			expect(MOCK_HANDLER).toHaveBeenCalled();
+		});
+	});
+
+	describe('updateFocusBy', () => {
+		it('should increase the selectedIndex state for positive delta', () => {
+			expect(popover.state.selectedIndex).toBe(0);
+			popover.updateFocusBy(1);
+			expect(popover.state.selectedIndex).toBe(1);
+		});
+		it('should not increase the selectedIndex state for zero delta', () => {
+			expect(popover.state.selectedIndex).toBe(0);
+			popover.updateFocusBy(0);
+			expect(popover.state.selectedIndex).toBe(0);
+		});
+		it('should decrease the selectedIndex state for negative delta', () => {
+			popover.updateFocusBy(1);
+			expect(popover.state.selectedIndex).toBe(1);
+			popover.updateFocusBy(-1);
+			expect(popover.state.selectedIndex).toBe(0);
+		});
+	});
+
+	describe('openMenu', () => {
+		it('should set the component state to active', () => {
+			expect(popover.state.isActive).toBe(false);
+			popover.openMenu();
+			expect(popover.state.isActive).toBe(true);
+		});
+	});
+
+	describe('closeMenu', () => {
+		it('should set the component state to inactive', () => {
+			popover.openMenu();
+			expect(popover.state.isActive).toBe(true);
+			popover.closeMenu();
+			expect(popover.state.isActive).toBe(false);
+		});
+	});
+
+	describe('Alignment Style', () => {
+		describe('align right', () => {
+			const popoverItem = (
+				<Popover
+					trigger={<Button>Open</Button>}
+					align='right'
+					menuItems={[]}
+				/>
+			);
+
+			popover = TestUtils.renderIntoDocument(popoverItem);
+			menuEl = TestUtils.findRenderedDOMComponentWithClass(popover, 'popover-container--menu');
+			expect(menuEl.classList).toContain('popover-container--horizontal-right');
+		});
+
+		describe('align left', () => {
+			const popoverItem = (
+				<Popover
+					trigger={<Button>Open</Button>}
+					align='left'
+					menuItems={[]}
+				/>
+			);
+
+			popover = TestUtils.renderIntoDocument(popoverItem);
+			menuEl = TestUtils.findRenderedDOMComponentWithClass(popover, 'popover-container--menu');
+			expect(menuEl.classList).toContain('popover-container--horizontal-left');
+		});
+	});
+});

--- a/src/interactive/dropdown.test.jsx
+++ b/src/interactive/dropdown.test.jsx
@@ -32,14 +32,20 @@ const getContent = (component) =>
 		'dropdown-content'
 	);
 
+const getIsOpen = (content) =>
+	content.classList.contains('display--block')
+	&& !content.classList.contains('display--none');
+
+
 describe('Dropdown', () => {
-	const component = TestUtils.renderIntoDocument(
+	const dropdownJSX = (
 		<Dropdown
 			align='right'
 			trigger={dropdownTrigger}
 			content={dropdownContent}
 		/>
 	);
+	const component = TestUtils.renderIntoDocument(dropdownJSX);
 
 	it('renders into DOM', () => {
 		expect(getDropdownFn(component)).not.toThrow();
@@ -48,29 +54,6 @@ describe('Dropdown', () => {
 	it('should hide dropdown content by default', () => {
 		const content = getContent(component);
 		expect(content.classList).toContain('display--none');
-	});
-
-	it('shold show dropdown when trigger is clicked', () => {
-		const content = getContent(component);
-		const trigger = getTrigger(component);
-
-		expect(content.classList).toContain('display--none');
-
-		TestUtils.Simulate.click(trigger);
-		expect(content.classList).toContain('display--block');
-		expect(content.classList).not.toContain('display--none');
-	});
-
-	it('should close the dropdown on ESC key', () => {
-		const content = getContent(component);
-		const trigger = getTrigger(component);
-
-		// content will be open from last test
-		expect(content.classList).toContain('display--block');
-
-		TestUtils.Simulate.keyDown(trigger, {key: 'Escape'});
-		expect(content.classList).toContain('display--none');
-		expect(content.classList).not.toContain('display--block');
 	});
 
 	describe('right aligned dropdown', () => {
@@ -90,5 +73,49 @@ describe('Dropdown', () => {
 			const content = getContent(rightDropdown);
 			expect(content.classList).toContain('dropdown-content--right');
 		});
+	});
+
+	describe('open and close', () => {
+		let closedComponent,
+			content,
+			trigger;
+
+		beforeEach(() => {
+			closedComponent = TestUtils.renderIntoDocument(dropdownJSX);
+			content = getContent(closedComponent);
+			trigger = getTrigger(closedComponent);
+		});
+		afterEach(() => {
+			closedComponent = null;
+			content = null;
+			trigger = null;
+		});
+
+		it('shold show dropdown when trigger is clicked', () => {
+			expect(getIsOpen(content)).toBeFalsy();
+			TestUtils.Simulate.click(trigger);
+			expect(getIsOpen(content)).toBeTruthy();
+		});
+
+		it('should close the dropdown on ESC key', () => {
+			// open it first
+			// dropdowns do not support default open by design
+			TestUtils.Simulate.click(trigger);
+			expect(getIsOpen(content)).toBeTruthy();
+
+			closedComponent.onBodyKeyDown({ key: 'Escape'});
+			expect(getIsOpen(content)).toBeFalsy();
+		});
+
+		it('should close when clicking outside of the dropdown content', () => {
+			// open it first
+			// dropdowns do not support default open by design
+			TestUtils.Simulate.click(trigger);
+			expect(getIsOpen(content)).toBeTruthy();
+
+			closedComponent.onBodyClick({ target: '<div />'});
+			expect(getIsOpen(content)).toBeFalsy();
+		});
+
 	});
 });

--- a/src/interactive/dropdown.test.jsx
+++ b/src/interactive/dropdown.test.jsx
@@ -35,7 +35,7 @@ const getContent = (component) =>
 describe('Dropdown', () => {
 	const component = TestUtils.renderIntoDocument(
 		<Dropdown
-			align="right"
+			align='right'
 			trigger={dropdownTrigger}
 			content={dropdownContent}
 		/>
@@ -76,7 +76,7 @@ describe('Dropdown', () => {
 	describe('right aligned dropdown', () => {
 		const rightDropdown = TestUtils.renderIntoDocument(
 			<Dropdown
-				align="right"
+				align='right'
 				trigger={dropdownTrigger}
 				content={dropdownContent}
 			/>

--- a/src/interactive/dropdown.test.jsx
+++ b/src/interactive/dropdown.test.jsx
@@ -1,194 +1,94 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
-import { Link } from 'react-router';
-import Popover from './Popover';
+import Section from '../layout/Section';
+import Chunk from '../layout/Chunk';
 import Button from '../forms/Button';
 
-let popover,
-	popoverEl,
-	triggerEl,
-	menuEl,
-	optionEls;
+import Dropdown from './Dropdown';
 
-const class_hidden = 'display--none';
-const MOCK_HANDLER = jest.genMockFunction();
-
-const popoverComponent = (
-	<Popover
-		trigger={
-			<Button>Open</Button>
-		}
-		menuItems={[
-			<Link to='somepath1/' onClick={MOCK_HANDLER}>First option</Link>,
-			<Link to='somepath2/' onClick={MOCK_HANDLER}>Second option</Link>,
-			<Link to='somepath3/' onClick={MOCK_HANDLER}>Third option</Link>,
-		]}
-	/>
+const dropdownContent = (
+	<Section noSeparator>
+		<Chunk>
+			<h2 className='text--big text--bold'>Dropdown content</h2>
+		</Chunk>
+	</Section>
+);
+const dropdownTrigger = (
+	<Button small>Open</Button>
 );
 
-const getIsActive = (menuEl) => {
-	return !menuEl.classList.contains(class_hidden);
-};
+const getDropdownFn = (component) => () =>
+	TestUtils.findRenderedComponentWithType(component, Dropdown);
 
-describe('Popover', function() {
+const getTrigger = (component) =>
+	TestUtils.findRenderedDOMComponentWithClass(
+		component,
+		'dropdown-trigger'
+	);
 
-	beforeEach(() => {
-		popover = TestUtils.renderIntoDocument(popoverComponent);
-		popoverEl = ReactDOM.findDOMNode(popover);
-		triggerEl = ReactDOM.findDOMNode(
-			TestUtils.findRenderedDOMComponentWithClass(popover, 'popover-trigger')
+const getContent = (component) =>
+	TestUtils.findRenderedDOMComponentWithClass(
+		component,
+		'dropdown-content'
+	);
+
+describe('Dropdown', () => {
+	const component = TestUtils.renderIntoDocument(
+		<Dropdown
+			align="right"
+			trigger={dropdownTrigger}
+			content={dropdownContent}
+		/>
+	);
+
+	it('renders into DOM', () => {
+		expect(getDropdownFn(component)).not.toThrow();
+	});
+
+	it('should hide dropdown content by default', () => {
+		const content = getContent(component);
+		expect(content.classList).toContain('display--none');
+	});
+
+	it('shold show dropdown when trigger is clicked', () => {
+		const content = getContent(component);
+		const trigger = getTrigger(component);
+
+		expect(content.classList).toContain('display--none');
+
+		TestUtils.Simulate.click(trigger);
+		expect(content.classList).toContain('display--block');
+		expect(content.classList).not.toContain('display--none');
+	});
+
+	it('should close the dropdown on ESC key', () => {
+		const content = getContent(component);
+		const trigger = getTrigger(component);
+
+		// content will be open from last test
+		expect(content.classList).toContain('display--block');
+
+		TestUtils.Simulate.keyDown(trigger, {key: 'Escape'});
+		expect(content.classList).toContain('display--none');
+		expect(content.classList).not.toContain('display--block');
+	});
+
+	describe('right aligned dropdown', () => {
+		const rightDropdown = TestUtils.renderIntoDocument(
+			<Dropdown
+				align="right"
+				trigger={dropdownTrigger}
+				content={dropdownContent}
+			/>
 		);
-		menuEl = ReactDOM.findDOMNode(
-			TestUtils.findRenderedDOMComponentWithClass(popover, 'popover-container--menu')
-		);
-		optionEls = TestUtils.scryRenderedDOMComponentsWithClass(popover, 'popover-menu-option-target')
-			.map((option) => ReactDOM.findDOMNode(option));
-	});
 
-	afterEach(() => {
-		popover = null;
-		popoverEl = null;
-		triggerEl = null;
-		menuEl = null;
-		optionEls = null;
-	});
-
-	it('exists; menu hidden by default', () => {
-		expect(popoverEl).not.toBeNull();
-		expect(getIsActive(menuEl)).toBe(false);
-	});
-
-	describe('focusCheck', () => {
-		it('should be active if focus is on menu items', () => {
-			popover.openMenu();
-			popover.focusCheck();
-			expect(popover.state.isActive).toBe(true);
-		});
-		it('should close menu if focus not on items', () => {
-			popover.openMenu();
-			document.activeElement.blur();
-			popover.focusCheck();
-			expect(popover.state.isActive).toBe(false);
-		});
-	});
-
-	it('menu appears on trigger click', () => {
-		expect(getIsActive(menuEl)).toBe(false);
-		TestUtils.Simulate.click(triggerEl);
-		expect(getIsActive(menuEl)).toBe(true);
-	});
-
-	describe('onBlur', () => {
-		it('should add timeout when `blur`ed', () => {
-			spyOn(window, 'setTimeout');
-			popover.onBlur();
-			expect(window.setTimeout).toHaveBeenCalled();
-		});
-	});
-
-	describe('onKeyDown', () => {
-		it('menu is keyboard navigable with `escape` key', () => {
-			const firstOption = optionEls[0];
-
-			popover.openMenu();
-
-			TestUtils.Simulate.keyDown(firstOption, {key: 'Escape'});
-			expect(getIsActive(menuEl)).toBe(false);
-		});
-		it('menu is keyboard navigable with `enter` key', () => {
-			TestUtils.Simulate.keyDown(triggerEl, {key: 'Enter'});
-			expect(getIsActive(menuEl)).toBe(true);
-		});
-	});
-
-	describe('onKeyDownMenuItem', () => {
-		let firstOption,
-			secondOption;
-
-		beforeEach(() => {
-			firstOption = optionEls[0];
-			secondOption = optionEls[1];
-			popover.openMenu();
+		it('renders left-aligned dropdown to DOM', () => {
+			expect(getDropdownFn(rightDropdown)).not.toThrow();
 		});
 
-		it('menu is keyboard navigable with arrows `Down`', () => {
-			TestUtils.Simulate.keyDown(firstOption, {key: 'ArrowDown'});
-			expect(document.activeElement).toBe(secondOption);
-		});
-		it('menu is keyboard navigable with arrows `Up`', () => {
-			TestUtils.Simulate.keyDown(firstOption, {key: 'ArrowUp'});
-			expect(document.activeElement).toBe(firstOption);
-		});
-		it('menu is keyboard navigable with arrows `Enter`', () => {
-			TestUtils.Simulate.keyDown(firstOption, {key: 'Enter'});
-			expect(MOCK_HANDLER).toHaveBeenCalled();
-		});
-	});
-
-	describe('updateFocusBy', () => {
-		it('should increase the selectedIndex state for positive delta', () => {
-			expect(popover.state.selectedIndex).toBe(0);
-			popover.updateFocusBy(1);
-			expect(popover.state.selectedIndex).toBe(1);
-		});
-		it('should not increase the selectedIndex state for zero delta', () => {
-			expect(popover.state.selectedIndex).toBe(0);
-			popover.updateFocusBy(0);
-			expect(popover.state.selectedIndex).toBe(0);
-		});
-		it('should decrease the selectedIndex state for negative delta', () => {
-			popover.updateFocusBy(1);
-			expect(popover.state.selectedIndex).toBe(1);
-			popover.updateFocusBy(-1);
-			expect(popover.state.selectedIndex).toBe(0);
-		});
-	});
-
-	describe('openMenu', () => {
-		it('should set the component state to active', () => {
-			expect(popover.state.isActive).toBe(false);
-			popover.openMenu();
-			expect(popover.state.isActive).toBe(true);
-		});
-	});
-
-	describe('closeMenu', () => {
-		it('should set the component state to inactive', () => {
-			popover.openMenu();
-			expect(popover.state.isActive).toBe(true);
-			popover.closeMenu();
-			expect(popover.state.isActive).toBe(false);
-		});
-	});
-
-	describe('Alignment Style', () => {
-		describe('align right', () => {
-			const popoverItem = (
-				<Popover
-					trigger={<Button>Open</Button>}
-					align='right'
-					menuItems={[]}
-				/>
-			);
-
-			popover = TestUtils.renderIntoDocument(popoverItem);
-			menuEl = TestUtils.findRenderedDOMComponentWithClass(popover, 'popover-container--menu');
-			expect(menuEl.classList).toContain('popover-container--horizontal-right');
-		});
-
-		describe('align left', () => {
-			const popoverItem = (
-				<Popover
-					trigger={<Button>Open</Button>}
-					align='left'
-					menuItems={[]}
-				/>
-			);
-
-			popover = TestUtils.renderIntoDocument(popoverItem);
-			menuEl = TestUtils.findRenderedDOMComponentWithClass(popover, 'popover-container--menu');
-			expect(menuEl.classList).toContain('popover-container--horizontal-left');
+		it('applies correct alignment className to dropdown content', () => {
+			const content = getContent(rightDropdown);
+			expect(content.classList).toContain('dropdown-content--right');
 		});
 	});
 });


### PR DESCRIPTION
Added a generic dropdown component that can accept arbitrary JSX content (for use in the `mup-web` header). We plan on refactoring `Popover` to use this component to eliminate some duplicated logic, but that will come in a later iteration.

#### Screenshots (if applicable)

![screen shot 2017-06-07 at 3 10 10 pm](https://user-images.githubusercontent.com/231252/26896626-7642ae3a-4b93-11e7-9201-59c6fc095662.png)
![screen shot 2017-06-07 at 3 10 24 pm](https://user-images.githubusercontent.com/231252/26896627-7642ea80-4b93-11e7-89c8-94873ea76d71.png)
