### PR TITLE
Number Input - Minor fixes

### DIFF
--- a/src/forms/NumberInput.jsx
+++ b/src/forms/NumberInput.jsx
@@ -42,6 +42,12 @@ class NumberInput extends React.Component {
 		return newValue;
 	}
 
+	componentWillUpdate(nextProps, nextState) {
+		if (this.props.onChange && nextState.value !== this.state.value) {
+			this.props.onChange({ target: { name: nextProps.name, value: nextState.value }});
+		}
+	}
+
 	onBlur(e) {
 		const formControls = [
 			this.fauxInputEl,
@@ -57,18 +63,10 @@ class NumberInput extends React.Component {
 		const { value } = e.target;
 
 		this.setState(() => ({ value }));
-		if (this.props.onChange) {
-			this.props.onChange(e);
-		}
 	}
 
 	onFocus(e) {
 		this.fauxInputEl.classList.add(FOCUSED_INPUT_CLASS);
-	}
-
-	incrementAction(e) {
-		e.preventDefault();
-		this.setState(() => ({ value: this._updateValueByStep(true) }));
 	}
 
 	onKeyDown(e) {
@@ -77,6 +75,11 @@ class NumberInput extends React.Component {
 		if (e.key.toLowerCase() === 'e') {
 			e.preventDefault();
 		}
+	}
+
+	incrementAction(e) {
+		e.preventDefault();
+		this.setState(() => ({ value: this._updateValueByStep(true) }));
 	}
 
 	decrementAction(e) {
@@ -216,7 +219,10 @@ NumberInput.propTypes = {
 	required: PropTypes.bool,
 	step: PropTypes.number,
 	disabled: PropTypes.bool,
-	value: PropTypes.number,
+	value: PropTypes.oneOfType([
+		PropTypes.string,
+		PropTypes.number,
+	]),
 };
 
 export default NumberInput;

--- a/src/forms/NumberInput.jsx
+++ b/src/forms/NumberInput.jsx
@@ -16,9 +16,7 @@ export const INCREMENT_BTN_CLASS = 'incrementButton';
 class NumberInput extends React.Component {
 	constructor(props) {
 		super(props);
-		this.state = {
-			value: props.value || '',
-		};
+		this.state = { value: props.value };
 
 		this._updateValueByStep = this._updateValueByStep.bind(this);
 		this.decrementAction = this.decrementAction.bind(this);
@@ -67,11 +65,13 @@ class NumberInput extends React.Component {
 		this.fauxInputEl.classList.add(FOCUSED_INPUT_CLASS);
 	}
 
-	incrementAction() {
+	incrementAction(e) {
+		e.preventDefault();
 		this.setState(() => ({ value: this._updateValueByStep(true) }));
 	}
 
-	decrementAction() {
+	decrementAction(e) {
+		e.preventDefault();
 		this.setState(() => ({ value: this._updateValueByStep(false) }));
 	}
 
@@ -205,7 +205,8 @@ NumberInput.propTypes = {
 	onChange: PropTypes.func,
 	required: PropTypes.bool,
 	step: PropTypes.number,
-	disabled: PropTypes.bool
+	disabled: PropTypes.bool,
+	value: PropTypes.number,
 };
 
 export default NumberInput;

--- a/src/forms/NumberInput.jsx
+++ b/src/forms/NumberInput.jsx
@@ -24,6 +24,7 @@ class NumberInput extends React.Component {
 		this.onBlur = this.onBlur.bind(this);
 		this.onChange = this.onChange.bind(this);
 		this.onFocus = this.onFocus.bind(this);
+		this.onKeyDown = this.onKeyDown.bind(this);
 	}
 
 	_updateValueByStep(isIncreasing) {
@@ -68,6 +69,14 @@ class NumberInput extends React.Component {
 	incrementAction(e) {
 		e.preventDefault();
 		this.setState(() => ({ value: this._updateValueByStep(true) }));
+	}
+
+	onKeyDown(e) {
+		// Disable the 'e' or 'E' values because we don't
+		// support scientific notation at the moment
+		if (e.key.toLowerCase() === 'e') {
+			e.preventDefault();
+		}
 	}
 
 	decrementAction(e) {
@@ -148,6 +157,7 @@ class NumberInput extends React.Component {
 								onBlur={this.onBlur}
 								onFocus={this.onFocus}
 								onChange={this.onChange}
+								onKeyDown={this.onKeyDown}
 								disabled={disabled}
 								{...other} />
 						</FlexItem>

--- a/src/forms/numberInput.test.jsx
+++ b/src/forms/numberInput.test.jsx
@@ -123,6 +123,14 @@ describe('NumberInput', function() {
 			expect(parseFloat(inputEl.value)).toEqual(newValue);
 		});
 
+		it('should not update its value when new value is `e` or `E`', function() {
+			expect(parseFloat(inputEl.value)).toEqual(VALUE);
+			TestUtils.Simulate.keyDown(inputEl, { key: 'e' });
+			expect(parseFloat(inputEl.value)).toEqual(VALUE);
+			TestUtils.Simulate.keyDown(inputEl, { key: 'E' });
+			expect(parseFloat(inputEl.value)).toEqual(VALUE);
+		});
+
 		it('should call onChange and setState with input change', function() {
 			const newValue = new Number(VALUE) + new Number(STEP_ATTR);
 			const changeSpy = spyOn(NumberInput.prototype, 'onChange').and.callThrough();

--- a/src/forms/numberInput.test.jsx
+++ b/src/forms/numberInput.test.jsx
@@ -271,7 +271,7 @@ describe('NumberInput', function() {
 			);
 
 			expect(numberInputComponent.state.value).toEqual(VALUE);
-			numberInputComponent.incrementAction();
+			numberInputComponent.incrementAction({ preventDefault: () => {} });
 			expect(numberInputComponent.state.value).toEqual(newValue);
 		});
 
@@ -287,7 +287,7 @@ describe('NumberInput', function() {
 			);
 
 			expect(numberInputComponent.state.value).toEqual(VALUE);
-			numberInputComponent.decrementAction();
+			numberInputComponent.decrementAction({ preventDefault: () => {} });
 			expect(numberInputComponent.state.value).toEqual(newValue);
 		});
 	});


### PR DESCRIPTION
#### Description
This PR fixes some issues with the `NumberInput` component. We don't want to support `e` or `E` input values, we want to trigger `onChange` whenever the plus or minus signs get triggered, and we want to display the default value prop.

#### Related issues
Fixes https://meetup.atlassian.net/browse/MW-1153