### PR TITLE
Textarea - Update autosized height on changed values

### DIFF
--- a/src/forms/Textarea.jsx
+++ b/src/forms/Textarea.jsx
@@ -50,6 +50,7 @@ class Textarea extends React.Component {
 	 */
 	componentWillReceiveProps(nextProps) {
 		this.overrideValue(nextProps);
+		autosize.update(this.textarea);
 	}
 
 	/**
@@ -150,7 +151,6 @@ Textarea.propTypes = {
 	]),
 	labelClassName: PropTypes.string,
 	required: PropTypes.bool,
-	autoHeight: PropTypes.bool,
 	minHeight: PropTypes.number,
 	maxHeight: PropTypes.number,
 	onChange: PropTypes.func,

--- a/src/forms/textarea.test.jsx
+++ b/src/forms/textarea.test.jsx
@@ -7,6 +7,10 @@ jest.mock('autosize', () => {
 	return jest.fn();
 });
 
+// Mock out the autosize update function
+const mockAutosize = require('autosize');
+mockAutosize.update = jest.fn();
+
 const onChange = jest.fn();
 
 describe('Textarea', function() {


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/MW-1356

#### Description
This PR fixes a bug where the textarea doesn't resize on form submission. This is because the autosize library only listens to onChange events and not value changes.

