### PR TITLE
set flex basis for IE to auto

### DIFF
--- a/assets/scss/components/_flex.scss
+++ b/assets/scss/components/_flex.scss
@@ -77,6 +77,7 @@ Breakpoints        | Direction       | Description
 	@include flexParent('column', false);
 	height: 100%;
 	> .flex-item {
+		-ms-flex-preferred-size: auto;
 		width: 100%;
 		padding-left: 0;
 	}


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-63

#### Description
Changes `-ms-preferred-size` from `0px` to `auto` for column-oriented flexbox; prevents height calculation bug in IE11 where flex items were collapsing when in column orientation.

The `-ms-preferred-size` is the IE version of `flex-basis`. Width calculation from a basis of `0px` is fine, but IE11 has issues with flex child height inside an indeterminate height container. This change is limited to `column` oriented flex children.

#### Screenshots (if applicable)

#### BEFORE
![screen shot 2017-06-19 at 1 35 56 pm](https://user-images.githubusercontent.com/231252/27303235-1c75c198-5508-11e7-9432-ba7a04042d6d.png)

#### AFTER
![screen shot 2017-06-19 at 3 53 23 pm](https://user-images.githubusercontent.com/231252/27303238-20f50ecc-5508-11e7-8f31-a40aa2095faf.png)

