### PR TITLE
use body click listener instead of blur event to avoid Safari issue

### DIFF
--- a/src/interactive/Popover.jsx
+++ b/src/interactive/Popover.jsx
@@ -118,7 +118,7 @@ class Popover extends React.Component {
 
 	onBodyClick(e) {
 		const isNotPopoverClick = [
-			this.contentRef,
+			this.menuRef,
 			this.triggerRef
 		].every(ref => !ref.contains(e.target));
 
@@ -186,7 +186,7 @@ class Popover extends React.Component {
 
 				<nav>
 					<ul
-						ref={(el) => this.contentRef = el}
+						ref={(el) => this.menuRef = el}
 						className={classNames.menu}
 						role='menu'
 						aria-hidden={!isActive}

--- a/src/interactive/Popover.jsx
+++ b/src/interactive/Popover.jsx
@@ -117,12 +117,12 @@ class Popover extends React.Component {
 	}
 
 	onBodyClick(e) {
-		const isNotPopoverClick = [
+		const isPopoverClick = [
 			this.menuRef,
 			this.triggerRef
-		].every(ref => !ref.contains(e.target));
+		].includes(e.target);
 
-		if (isNotPopoverClick) {
+		if (!isPopoverClick) {
 			this.closeMenu();
 		}
 	}

--- a/src/interactive/Popover.jsx
+++ b/src/interactive/Popover.jsx
@@ -46,16 +46,6 @@ class Popover extends React.Component {
 		this.setState({ isActive: false });
 	}
 
-	focusCheck() {
-		const focusedOptionClass = document.activeElement.parentNode.classList;
-		// don't close the popover if we're moving focus to an menu item
-		if (focusedOptionClass && focusedOptionClass.contains(POPOVER_MENU_CLASS)) {
-			return;
-		}
-
-		this.closeMenu();
-	}
-
 	onClick(e) {
 		this.openMenu();
 	}

--- a/src/interactive/Popover.jsx
+++ b/src/interactive/Popover.jsx
@@ -20,7 +20,7 @@ class Popover extends React.Component {
 			'onKeyDown',
 			'onKeyDownMenuItem',
 			'onClick',
-			'onBlur'
+			'onBodyClick'
 		);
 
 		this.state = {
@@ -54,15 +54,6 @@ class Popover extends React.Component {
 		}
 
 		this.closeMenu();
-	}
-
-	onBlur() {
-		// On blur, browsers always focus `<body>` before moving focus
-		// to the next actual focused element.
-		//
-		// This zero-length timeout ensures the browser will return the
-		// actual focused element instead of `<body>`
-		window.setTimeout(() => this.focusCheck(), 0);
 	}
 
 	onClick(e) {
@@ -135,6 +126,25 @@ class Popover extends React.Component {
 		return this.menuItems;
 	}
 
+	onBodyClick(e) {
+		const isNotPopoverClick = [
+			this.contentRef,
+			this.triggerRef
+		].every(ref => !ref.contains(e.target));
+
+		if (isNotPopoverClick) {
+			this.closeMenu();
+		}
+	}
+
+	componentDidMount() {
+		document.body.addEventListener('click', this.onBodyClick);
+	}
+
+	componentWillUnmount() {
+		document.body.removeEventListener('click', this.onBodyClick);
+	}
+
 	render() {
 		const isActive = this.state.isActive;
 		const {
@@ -172,11 +182,11 @@ class Popover extends React.Component {
 				className={classNames.popover}
 				aria-haspopup='true'
 				onKeyDown={this.onKeyDown}
-				onBlur={this.onBlur}
 				{...other}
 			>
 
 				<div
+					ref={(el) => this.triggerRef = el}
 					className={classNames.trigger}
 					tabIndex='0'
 					onClick={this.onClick}
@@ -186,6 +196,7 @@ class Popover extends React.Component {
 
 				<nav>
 					<ul
+						ref={(el) => this.contentRef = el}
 						className={classNames.menu}
 						role='menu'
 						aria-hidden={!isActive}

--- a/src/interactive/popover.story.jsx
+++ b/src/interactive/popover.story.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Link } from 'react-router';
 import { storiesOf, action } from '@kadira/storybook';
 import { InfoWrapper } from '../utils/storyComponents';
-import { decorateWithLocale } from '../utils/decorators';
 import Popover from './Popover';
 import Button from '../forms/Button';
 
@@ -11,7 +10,6 @@ const logSelection = e => {
 };
 
 storiesOf('Popover', module)
-	.addDecorator(decorateWithLocale)
 	.addWithInfo(
 		'default - Button trigger with Link menu items',
 		'This is the basic usage with the component. ',

--- a/src/interactive/popover.test.jsx
+++ b/src/interactive/popover.test.jsx
@@ -140,6 +140,22 @@ describe('Popover', function() {
 		});
 	});
 
+	describe('keyboard navigation', () => {
+
+		it('should open the popover on Enter', () => {
+			popover.onKeyDown({ key: 'Enter' });
+			expect(popover.state.isActive).toBe(true);
+		});
+
+		it('should close the popover on ESC', () => {
+			popover.openMenu();
+			expect(popover.state.isActive).toBe(true);
+
+			popover.onKeyDown({ key: 'Escape' });
+			expect(popover.state.isActive).toBe(false);
+		});
+	});
+
 	describe('Alignment Style', () => {
 		describe('align right', () => {
 			const popoverItem = (

--- a/src/interactive/popover.test.jsx
+++ b/src/interactive/popover.test.jsx
@@ -59,20 +59,6 @@ describe('Popover', function() {
 		expect(getIsActive(menuEl)).toBe(false);
 	});
 
-	describe('focusCheck', () => {
-		it('should be active if focus is on menu items', () => {
-			popover.openMenu();
-			popover.focusCheck();
-			expect(popover.state.isActive).toBe(true);
-		});
-		it('should close menu if focus not on items', () => {
-			popover.openMenu();
-			document.activeElement.blur();
-			popover.focusCheck();
-			expect(popover.state.isActive).toBe(false);
-		});
-	});
-
 	it('menu appears on trigger click', () => {
 		expect(getIsActive(menuEl)).toBe(false);
 		TestUtils.Simulate.click(triggerEl);

--- a/src/interactive/popover.test.jsx
+++ b/src/interactive/popover.test.jsx
@@ -65,14 +65,6 @@ describe('Popover', function() {
 		expect(getIsActive(menuEl)).toBe(true);
 	});
 
-	describe('onBlur', () => {
-		it('should add timeout when `blur`ed', () => {
-			spyOn(window, 'setTimeout');
-			popover.onBlur();
-			expect(window.setTimeout).toHaveBeenCalled();
-		});
-	});
-
 	describe('onKeyDown', () => {
 		it('menu is keyboard navigable with `escape` key', () => {
 			const firstOption = optionEls[0];


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/MW-1386

#### Description
To close the Popover when a user clicks outside of it, Popover was using a `setTimeout` `0` because most browsers set the `document.activeElement` to `body` for an instant before reporting the actual focused element. **Safari is not most browsers**. 

A more stable approach is to attach a click listener to `body` on component mount ala `Dropdown`.
