### PR TITLE
Optionally hide text-protection scrim on Stripes with bg img

### DIFF
--- a/assets/scss/components/_stripe.scss
+++ b/assets/scss/components/_stripe.scss
@@ -115,6 +115,12 @@ and sets a background image using a URL passed into the
 
 }
 
+.stripe--noScrim {
+	&:before {
+		display: none;
+	}
+}
+
 .stripe-aboveScrim {
 	position: relative;
 }

--- a/src/interactive/Modal.jsx
+++ b/src/interactive/Modal.jsx
@@ -104,6 +104,7 @@ class Modal extends React.Component {
 			heroBgColor,
 			heroBgImage,
 			heroContent,
+			hideHeroScrim,
 			inverted,
 			closeArea,
 			...other
@@ -166,6 +167,7 @@ class Modal extends React.Component {
 						<Stripe
 							backgroundImage={heroBgImage}
 							inverted={inverted}
+							hideScrim={hideHeroScrim}
 							style={heroStyles}
 						>
 							{closeElement}
@@ -187,6 +189,7 @@ Modal.propTypes = {
 	heroBgColor: PropTypes.string,
 	heroBgImage: PropTypes.string,
 	heroContent: PropTypes.element,
+	hideHeroScrim: PropTypes.bool,
 	inverted: PropTypes.bool,
 	onDismiss: PropTypes.func.isRequired,
 	closeArea: PropTypes.bool,

--- a/src/interactive/modal.story.jsx
+++ b/src/interactive/modal.story.jsx
@@ -121,6 +121,39 @@ storiesOf('Modal', module)
 		)
 	)
 	.addWithInfo(
+		'has hero - image (no scrim)',
+		'This is the component with an extended header and no text-protection scrim.',
+		() => (
+			<div style={wrapperStyle}>
+				<InfoWrapper>
+					<Modal
+						hideHeroScrim
+						onDismiss={onDismiss}
+						heroBgImage='http://cds.arbys.com/images/menu/1024x557_RoastBeefGyro_silo_tan.jpg'
+						heroContent={
+							<Section>
+								<h1 className='text--display align--center'>I can be your hero</h1>
+							</Section>
+						}
+					>
+						<Stripe><Section>
+							<h2 className='align--center'>This is a modal!</h2>
+							<div className='row align--center margin--top'>
+								<div className='row-item'>
+									<Button onClick={onDismiss} fullWidth>Cancel</Button>
+								</div>
+								<div className='row-item'>
+									<Button onClick={action('Confirmed!')} primary fullWidth>Confirm</Button>
+								</div>
+							</div>
+						</Section></Stripe>
+					</Modal>
+					<div style={iconSpriteStyle} dangerouslySetInnerHTML={{__html: iconSprite}} />
+				</InfoWrapper>
+			</div>
+		)
+	)
+	.addWithInfo(
 		'fullscreen',
 		'Full screen modals are set with the `fullscreen` boolean prop',
 		() => (

--- a/src/interactive/modal.test.js
+++ b/src/interactive/modal.test.js
@@ -12,6 +12,7 @@ import Modal, {
 import {
 	STRIPE_INVERTED_CLASS,
 	STRIPE_HERO_CLASS,
+	STRIPE_NOSCRIM_CLASS
 } from '../layout/Stripe';
 
 describe('Modal', () => {
@@ -130,6 +131,19 @@ describe('Modal hero header', () => {
 
 	it('displays the hero content', () => {
 		expect(() => TestUtils.findRenderedDOMComponentWithClass(modal, HERO_CONTENT_CLASS)).not.toThrow();
+	});
+
+	it('should hide text protection scrim when specified', () => {
+		const modalNoScrim = TestUtils.renderIntoDocument(
+			<Modal
+				hideHeroScrim
+				heroBgImage={bgImage}
+				heroContent={heroContentHtml}
+				onDismiss={(e) => {}}
+			>
+				{content}
+			</Modal>);
+		expect(() => TestUtils.findRenderedDOMComponentWithClass(modalNoScrim, STRIPE_NOSCRIM_CLASS)).not.toThrow();
 	});
 
 });

--- a/src/layout/Stripe.jsx
+++ b/src/layout/Stripe.jsx
@@ -7,6 +7,7 @@ export const STRIPE_CLASS = 'stripe';
 export const STRIPE_COLLECTION_CLASS = 'stripe--collection';
 export const STRIPE_INVERTED_CLASS = 'stripe--inverted';
 export const STRIPE_HERO_CLASS = 'stripe--withBGImg';
+export const STRIPE_NOSCRIM_CLASS = 'stripe--noScrim';
 
 /**
  * Design System Component: Provides `stripe` styled container for components
@@ -21,6 +22,7 @@ class Stripe extends React.Component {
 			backgroundImage,
 			collection,
 			inverted,
+			hideScrim,
 			...other
 		} = this.props;
 
@@ -29,7 +31,9 @@ class Stripe extends React.Component {
 			{
 				[STRIPE_COLLECTION_CLASS]: collection,
 				[`${STRIPE_INVERTED_CLASS} inverted`]: inverted,
-				[`${STRIPE_HERO_CLASS} inverted`]: backgroundImage
+				[`${STRIPE_HERO_CLASS}`]: backgroundImage, // [`${STRIPE_HERO_CLASS} inverted`]
+				[STRIPE_NOSCRIM_CLASS]: hideScrim
+
 			},
 			className
 		);
@@ -44,7 +48,7 @@ class Stripe extends React.Component {
 				className={classNames}
 				style={styles}
 				{...other}>
-				{ backgroundImage ?
+				{ backgroundImage && !hideScrim ?
 					(
 						<div className='stripe-aboveScrim'>
 							{children}
@@ -61,7 +65,8 @@ Stripe.propTypes = {
 	backgroundImage: PropTypes.string,
 	collection: PropTypes.bool,
 	inverted: PropTypes.bool,
-	hero: PropTypes.bool
+	hero: PropTypes.bool,
+	hideScrim: PropTypes.bool
 };
 
 export default Stripe;

--- a/src/layout/Stripe.jsx
+++ b/src/layout/Stripe.jsx
@@ -31,7 +31,7 @@ class Stripe extends React.Component {
 			{
 				[STRIPE_COLLECTION_CLASS]: collection,
 				[`${STRIPE_INVERTED_CLASS} inverted`]: inverted,
-				[`${STRIPE_HERO_CLASS}`]: backgroundImage, // [`${STRIPE_HERO_CLASS} inverted`]
+				[`${STRIPE_HERO_CLASS}`]: backgroundImage,
 				[STRIPE_NOSCRIM_CLASS]: hideScrim
 
 			},

--- a/src/layout/stripe.story.jsx
+++ b/src/layout/stripe.story.jsx
@@ -28,9 +28,19 @@ storiesOf('Stripe', module)
 							<p>Stripes go full-width and are used to separate distinct regions of a view</p>
 						</Stripe>
 
-						<Stripe backgroundImage='https://placekitten.com/g/600/600'>
+						<Stripe
+							inverted
+							backgroundImage='https://placekitten.com/g/600/600'>
 							<div style={{zIndex: '1'}}>
 								<h3 className='text--sectionTitle'>Stripe with bg photo</h3>
+								<p>Stripes go full-width and are used to separate distinct regions of a view</p>
+							</div>
+						</Stripe>
+						<Stripe
+							hideScrim
+							backgroundImage='https://s-media-cache-ak0.pinimg.com/originals/10/55/e7/1055e79a0519191212035a61ed530800.jpg'>
+							<div style={{zIndex: '1'}}>
+								<h3 className='text--sectionTitle'>Stripe with bg photo, no scrim</h3>
 								<p>Stripes go full-width and are used to separate distinct regions of a view</p>
 							</div>
 						</Stripe>

--- a/src/layout/stripe.test.jsx
+++ b/src/layout/stripe.test.jsx
@@ -7,6 +7,7 @@ import Stripe, {
 	STRIPE_COLLECTION_CLASS,
 	STRIPE_INVERTED_CLASS,
 	STRIPE_HERO_CLASS,
+	STRIPE_NOSCRIM_CLASS
 } from './Stripe';
 
 describe('Stripe', function() {
@@ -70,7 +71,7 @@ describe('Stripe', function() {
 		let stripeImg,
 			stripeNode;
 		beforeEach(() => {
-			stripeImg = TestUtils.renderIntoDocument(<Stripe backgroundImage={src} />);
+			stripeImg = TestUtils.renderIntoDocument(<Stripe hideScrim backgroundImage={src} />);
 			stripeNode = ReactDOM.findDOMNode(stripeImg);
 		});
 		afterEach(() => {
@@ -85,6 +86,9 @@ describe('Stripe', function() {
 		});
 		it('should set backgroundImage style', () => {
 			expect(stripeNode.style.backgroundImage).toEqual(`url(${src})`);
+		});
+		it('should hide text protection scrim when specified', () => {
+			expect(stripeNode.classList).toContain(STRIPE_NOSCRIM_CLASS);
 		});
 	});
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3685,14 +3685,14 @@ js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
-js-yaml@3.6.1, js-yaml@^3.4.3, js-yaml@^3.5.1:
+js-yaml@3.6.1, js-yaml@^3.5.1:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.6.1.tgz#6e5fe67d8b205ce4d22fad05b7781e8dadcc4b30"
   dependencies:
     argparse "^1.0.7"
     esprima "^2.6.0"
 
-js-yaml@^3.7.0, js-yaml@~3.7.0:
+js-yaml@^3.4.3, js-yaml@^3.7.0, js-yaml@~3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
   dependencies:


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-324

#### Description
Adds a prop to `<Stripe>` and `<Modal>` (for the hero header) that allows engineers to hide the text protection scrim that used to automatically get added to a `<Stripe>` that has `backgroundImage` prop.

**This is a breaking change**, because any `<Stripe>` that has a `backgroundImage` prop but not an `inverted` prop will show black text and icons on top of the image and scrim.

This issue came up while building the [Event Home preview page](https://www.meetup.com/account/preview/).

#### Screenshots (if applicable)

