### PR TITLE
Added the ability to keep grid item heights consistent

### DIFF
--- a/assets/scss/components/_gridList.scss
+++ b/assets/scss/components/_gridList.scss
@@ -58,12 +58,17 @@ grid.
 
 The following classes are optional variants:
 
-Class                         | Description
------------------------------ | ------------------------------
-`.gridList--photoGrid`        | Optimizes list item spacing for a grid of photos
-`.gridList--has[n]`           | Adjusts number of columns (ie. `.gridList--has4` creates a 4 column grid for all screen sizes)
-`.atMedium_gridList--has[n]`  | Sets number of columns for medium breakpoint and up (ie. `.atMedium_gridList--has6`)
-`.atLarge_gridList--has[n]`   | Sets number of columns for large breakpoint and up (ie. `.atLarge_gridList--has10`)
+Class                                     | Description
+----------------------------------------- | ------------------------------
+`.gridList--photoGrid`                    | Optimizes list item spacing for a grid of photos
+`.gridList--autoheight`                   | Makes the height of each list item consistent
+`.gridList--has[n]`                       | Adjusts number of columns (ie. `.gridList--has4` creates a 4 column grid for all screen sizes)
+`.atMedium_gridList--has[n]`              | Sets number of columns for medium breakpoint and up (ie. `.atMedium_gridList--has6`)
+`.atLarge_gridList--has[n]`               | Sets number of columns for large breakpoint and up (ie. `.atLarge_gridList--has10`)
+`.gridList--autoheight--has[n]`           | Adjusts number of columns (ie. `.gridList--autoheight--has4` creates a 4 column grid for all screen sizes)
+`.atMedium_gridList--autoheight--has[n]`  | Sets number of columns for medium breakpoint and up (ie. `.atMedium_gridList--autoheight--has6`)
+`.atLarge_gridList--autoheight--has[n]`   | Sets number of columns for large breakpoint and up (ie. `.atLarge_gridList--autoheight--has10`)
+
 
 */
 .gridList--photoGrid {
@@ -86,6 +91,35 @@ Class                         | Description
 	@include _bpModifier(gridList, has#{$col}) {
 		> .gridList-item {
 			width: percentage(1 / $col);
+		}
+	}
+}
+
+.gridList--autoheight {
+	@include responsiveVarContext--base() {
+		margin-left: -#{$base};
+
+		> .gridList-item {
+			width: auto;
+		}
+			&:first-child {
+				padding-left: $base;
+			}
+	}
+}
+
+// Autoheight - small/default
+@each $col in $glColumns {
+	.gridList--autoheight--has#{$col} > .gridList-item {
+		flex: 0 0 percentage(1 / $col);
+	}
+}
+
+// Autoheight - larger breakpoints
+@each $col in $glColumns {
+	@include _bpModifier(gridList--autoheight, has#{$col}) {
+		> .gridList-item {
+			flex: 0 0 percentage(1 / $col);
 		}
 	}
 }

--- a/assets/scss/components/_gridList.scss
+++ b/assets/scss/components/_gridList.scss
@@ -61,13 +61,13 @@ The following classes are optional variants:
 Class                                     | Description
 ----------------------------------------- | ------------------------------
 `.gridList--photoGrid`                    | Optimizes list item spacing for a grid of photos
-`.gridList--autoheight`                   | Makes the height of each list item consistent
+`.gridList--autoHeight`                   | Makes the height of each list item consistent
 `.gridList--has[n]`                       | Adjusts number of columns (ie. `.gridList--has4` creates a 4 column grid for all screen sizes)
 `.atMedium_gridList--has[n]`              | Sets number of columns for medium breakpoint and up (ie. `.atMedium_gridList--has6`)
 `.atLarge_gridList--has[n]`               | Sets number of columns for large breakpoint and up (ie. `.atLarge_gridList--has10`)
-`.gridList--autoheight--has[n]`           | Adjusts number of columns (ie. `.gridList--autoheight--has4` creates a 4 column grid for all screen sizes)
-`.atMedium_gridList--autoheight--has[n]`  | Sets number of columns for medium breakpoint and up (ie. `.atMedium_gridList--autoheight--has6`)
-`.atLarge_gridList--autoheight--has[n]`   | Sets number of columns for large breakpoint and up (ie. `.atLarge_gridList--autoheight--has10`)
+`.gridList--autoHeight--has[n]`           | Adjusts number of columns (ie. `.gridList--autoHeight--has4` creates a 4 column grid for all screen sizes)
+`.atMedium_gridList--autoHeight--has[n]`  | Sets number of columns for medium breakpoint and up (ie. `.atMedium_gridList--autoHeight--has6`)
+`.atLarge_gridList--autoHeight--has[n]`   | Sets number of columns for large breakpoint and up (ie. `.atLarge_gridList--autoHeight--has10`)
 
 
 */
@@ -95,7 +95,7 @@ Class                                     | Description
 	}
 }
 
-.gridList--autoheight {
+.gridList--autoHeight {
 	@include responsiveVarContext--base() {
 		margin-left: -#{$base};
 
@@ -108,16 +108,16 @@ Class                                     | Description
 	}
 }
 
-// Autoheight - small/default
+// autoHeight - small/default
 @each $col in $glColumns {
-	.gridList--autoheight--has#{$col} > .gridList-item {
+	.gridList--autoHeight--has#{$col} > .gridList-item {
 		flex: 0 0 percentage(1 / $col);
 	}
 }
 
-// Autoheight - larger breakpoints
+// autoHeight - larger breakpoints
 @each $col in $glColumns {
-	@include _bpModifier(gridList--autoheight, has#{$col}) {
+	@include _bpModifier(gridList--autoHeight, has#{$col}) {
 		> .gridList-item {
 			flex: 0 0 percentage(1 / $col);
 		}

--- a/src/layout/GridList.jsx
+++ b/src/layout/GridList.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
 
-export const GRID_AUTOHEIGHT_CLASS = 'gridList--autoheight';
+export const GRID_AUTOHEIGHT_CLASS = 'gridList--autoHeight';
 
 /**
  * @module GridList
@@ -13,7 +13,7 @@ class GridList extends React.Component {
 			className,
 			columns,
 			items,
-			autoheight,
+			autoHeight,
 			...other
 		} = this.props;
 
@@ -27,7 +27,7 @@ class GridList extends React.Component {
 			className
 		);
 
-		const autoheightClassNames = cx(
+		const autoHeightClassNames = cx(
 			'flex flex--wrap gridList',
 			GRID_AUTOHEIGHT_CLASS,
 			{
@@ -41,13 +41,13 @@ class GridList extends React.Component {
 		const listItemClassNames = cx(
 			'gridList-item',
 			{
-				['flex-item']: autoheight
+				['flex-item']: autoHeight
 			}
 		);
 
 		return (
 			<ul
-				className={autoheight ? autoheightClassNames : classNames}
+				className={autoHeight ? autoHeightClassNames : classNames}
 				{...other}
 			>
 				{items.map((item, key) =>
@@ -59,7 +59,7 @@ class GridList extends React.Component {
 }
 
 GridList.propTypes = {
-	autoheight: PropTypes.bool,
+	autoHeight: PropTypes.bool,
 	columns: PropTypes.shape({
 		default: PropTypes.number.isRequired,
 		medium: PropTypes.number,

--- a/src/layout/GridList.jsx
+++ b/src/layout/GridList.jsx
@@ -2,6 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
 
+export const GRID_AUTOHEIGHT_CLASS = 'gridList--autoheight';
+
 /**
  * @module GridList
  */
@@ -11,6 +13,7 @@ class GridList extends React.Component {
 			className,
 			columns,
 			items,
+			autoheight,
 			...other
 		} = this.props;
 
@@ -24,13 +27,31 @@ class GridList extends React.Component {
 			className
 		);
 
+		const autoheightClassNames = cx(
+			'flex flex--wrap gridList',
+			GRID_AUTOHEIGHT_CLASS,
+			{
+				[`${GRID_AUTOHEIGHT_CLASS}--has${columns.default}`]: !!columns.default,
+				[`atMedium_${GRID_AUTOHEIGHT_CLASS}--has${columns.medium}`]: !!columns.medium,
+				[`atLarge_${GRID_AUTOHEIGHT_CLASS}--has${columns.large}`]: !!columns.large
+			},
+			className
+		);
+
+		const listItemClassNames = cx(
+			'gridList-item',
+			{
+				['flex-item']: autoheight
+			}
+		);
+
 		return (
 			<ul
-				className={classNames}
+				className={autoheight ? autoheightClassNames : classNames}
 				{...other}
 			>
 				{items.map((item, key) =>
-					<li key={key} className='gridList-item'>{item}</li>
+					<li key={key} className={listItemClassNames}>{item}</li>
 				)}
 			</ul>
 		);
@@ -38,6 +59,7 @@ class GridList extends React.Component {
 }
 
 GridList.propTypes = {
+	autoheight: PropTypes.bool,
 	columns: PropTypes.shape({
 		default: PropTypes.number.isRequired,
 		medium: PropTypes.number,

--- a/src/layout/gridList.story.jsx
+++ b/src/layout/gridList.story.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { InfoWrapper } from '../utils/storyComponents';
 import { storiesOf } from '@kadira/storybook';
+import { MOCK_MEMBER } from 'meetup-web-mocks/lib/api';
 import GridList from './GridList';
 
 const boxStyles = {
@@ -13,6 +14,28 @@ const boxStyles = {
 	justifyContent : 'center',
 	outline: '1px dotted red',
 	padding: '20px',
+};
+
+const TestMember = (props) => {
+	return (
+		<div className='flex flex--column flex--center align--center card display--flex'>
+			<div className='flex-item flex-item--shrink'>
+				<div className="chunk">
+					<span className='avatar avatar--person' role='img' style={{backgroundImage: props.member.photo.photo_link}}>{props.member.name}</span>
+				</div>
+			</div>
+
+			<div className='flex-item flex-item--shrink'>
+				<div className="chunk">
+					<p>{props.member.name}</p>
+					<p className="text--small text--secondary">You're both members of FAFF</p>
+					{props.secondLine &&
+						<p className="text--small text--secondary">{props.secondLine}</p>
+					}
+				</div>
+			</div>
+		</div>
+	);
 };
 
 storiesOf('GridList', module)
@@ -41,6 +64,28 @@ storiesOf('GridList', module)
 			</InfoWrapper>
 		))
 	.addWithInfo(
+		'Static autoheight grid',
+		'GridList where items are the same height with columns fixed at 3 for all breakpoints',
+		() => (
+			<InfoWrapper>
+				<GridList
+					autoheight
+					columns={{
+						default: 3
+					}}
+					style={{maxWidth: '1100px', margin: '0 auto', width: '100%' }}
+					items={[
+						<TestMember member={MOCK_MEMBER} />,
+						<TestMember member={MOCK_MEMBER} secondLine='This is a second line' />,
+						<TestMember member={MOCK_MEMBER} />,
+						<TestMember member={MOCK_MEMBER} secondLine='This is a second line' />,
+						<TestMember member={MOCK_MEMBER} />,
+						<TestMember member={MOCK_MEMBER} />
+					]}
+				/>
+			</InfoWrapper>
+		))
+	.addWithInfo(
 		'Responsive grid',
 		'Responsive GridList that increases number of columns for larger breakpoints',
 		() => (
@@ -62,6 +107,30 @@ storiesOf('GridList', module)
 						<div style={boxStyles}>GridItem</div>,
 						<div style={boxStyles}>GridItem</div>,
 						<div style={boxStyles}>GridItem</div>
+					]}
+				/>
+			</InfoWrapper>
+		))
+	.addWithInfo(
+		'Responsive autoheight grid',
+		'Responsive GridList where items are the same height, and that increases number of columns for larger breakpoints',
+		() => (
+			<InfoWrapper>
+				<GridList
+					autoheight
+					columns={{
+						default: 2,
+						medium: 4,
+						large: 6
+					}}
+					style={{maxWidth: '1100px', margin: '0 auto', width: '100%' }}
+					items={[
+						<TestMember member={MOCK_MEMBER} />,
+						<TestMember member={MOCK_MEMBER} secondLine='This is a second line' />,
+						<TestMember member={MOCK_MEMBER} />,
+						<TestMember member={MOCK_MEMBER} secondLine='This is a second line' />,
+						<TestMember member={MOCK_MEMBER} />,
+						<TestMember member={MOCK_MEMBER} secondLine='This is a second line' />
 					]}
 				/>
 			</InfoWrapper>

--- a/src/layout/gridList.story.jsx
+++ b/src/layout/gridList.story.jsx
@@ -64,12 +64,12 @@ storiesOf('GridList', module)
 			</InfoWrapper>
 		))
 	.addWithInfo(
-		'Static autoheight grid',
+		'Static autoHeight grid',
 		'GridList where items are the same height with columns fixed at 3 for all breakpoints',
 		() => (
 			<InfoWrapper>
 				<GridList
-					autoheight
+					autoHeight
 					columns={{
 						default: 3
 					}}
@@ -112,12 +112,12 @@ storiesOf('GridList', module)
 			</InfoWrapper>
 		))
 	.addWithInfo(
-		'Responsive autoheight grid',
+		'Responsive autoHeight grid',
 		'Responsive GridList where items are the same height, and that increases number of columns for larger breakpoints',
 		() => (
 			<InfoWrapper>
 				<GridList
-					autoheight
+					autoHeight
 					columns={{
 						default: 2,
 						medium: 4,

--- a/src/layout/gridList.test.jsx
+++ b/src/layout/gridList.test.jsx
@@ -24,7 +24,7 @@ const JSX_GridListStatic = (
 
 const JSX_AutoheightGridListStatic = (
 	<GridList
-		autoheight
+		autoHeight
 		columns={{
 			default: 3
 		}}
@@ -69,7 +69,7 @@ const JSX_GridListResponsive = (
 
 const JSX_AutoheightGridListResponsive = (
 	<GridList
-		autoheight
+		autoHeight
 		columns={{
 			default: responsiveColsDefault,
 			medium: responsiveColsMedium,
@@ -106,12 +106,12 @@ describe('Static GridList', function() {
 		expect(glItems.length).not.toBe(0);
 	});
 
-	it('sets correct autoheight grid class', function() {
+	it('sets correct autoHeight grid class', function() {
 		const glClassList = TestUtils.scryRenderedDOMComponentsWithTag(autoheightGridList, 'UL')[0].className;
 		expect(glClassList).toContain(GRID_AUTOHEIGHT_CLASS);
 	});
 
-	it('wraps autoheight gridList items with element containing className "flex-item"', function() {
+	it('wraps autoHeight gridList items with element containing className "flex-item"', function() {
 		const glItems = TestUtils.scryRenderedDOMComponentsWithClass(autoheightGridList, 'flex-item');
 		expect(glItems.length).not.toBe(0);
 	});
@@ -149,17 +149,17 @@ describe('Responsive GridList', function() {
 		expect(glClassList).toContain(largeClass);
 	});
 
-	it('sets correct autoheight default columns class', function() {
+	it('sets correct autoHeight default columns class', function() {
 		const defaultClass = `${GRID_AUTOHEIGHT_CLASS}--has${responsiveColsDefault}`;
 		expect(autoheightGLClassList).toContain(defaultClass);
 	});
 
-	it('sets correct autoheight medium breakpoint columns class', function() {
+	it('sets correct autoHeight medium breakpoint columns class', function() {
 		const mediumClass = `atMedium_${GRID_AUTOHEIGHT_CLASS}--has${responsiveColsMedium}`;
 		expect(autoheightGLClassList).toContain(mediumClass);
 	});
 
-	it('sets correct autoheight large breakpoint columns class', function() {
+	it('sets correct autoHeight large breakpoint columns class', function() {
 		const largeClass = `atLarge_${GRID_AUTOHEIGHT_CLASS}--has${responsiveColsLarge}`;
 		expect(autoheightGLClassList).toContain(largeClass);
 	});

--- a/src/layout/gridList.test.jsx
+++ b/src/layout/gridList.test.jsx
@@ -1,9 +1,30 @@
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
 import GridList from './GridList';
+import { GRID_AUTOHEIGHT_CLASS } from './GridList';
 
 const JSX_GridListStatic = (
 	<GridList
+		columns={{
+			default: 3
+		}}
+		items={[
+			<div>GridItem</div>,
+			<div>GridItem</div>,
+			<div>GridItem</div>,
+			<div>GridItem</div>,
+			<div>GridItem</div>,
+			<div>GridItem</div>,
+			<div>GridItem</div>,
+			<div>GridItem</div>,
+			<div>GridItem</div>
+		]}
+	/>
+);
+
+const JSX_AutoheightGridListStatic = (
+	<GridList
+		autoheight
 		columns={{
 			default: 3
 		}}
@@ -46,32 +67,71 @@ const JSX_GridListResponsive = (
 	/>
 );
 
-let gridList;
+const JSX_AutoheightGridListResponsive = (
+	<GridList
+		autoheight
+		columns={{
+			default: responsiveColsDefault,
+			medium: responsiveColsMedium,
+			large: responsiveColsLarge
+		}}
+		items={[
+			<div>GridItem</div>,
+			<div>GridItem</div>,
+			<div>GridItem</div>,
+			<div>GridItem</div>,
+			<div>GridItem</div>,
+			<div>GridItem</div>,
+			<div>GridItem</div>,
+			<div>GridItem</div>,
+			<div>GridItem</div>
+		]}
+	/>
+);
+
+let gridList, autoheightGridList;
 
 describe('Static GridList', function() {
 	beforeEach(() => {
 		gridList = TestUtils.renderIntoDocument(JSX_GridListStatic);
+		autoheightGridList = TestUtils.renderIntoDocument(JSX_AutoheightGridListStatic);
 	});
 	afterEach(() => {
 		gridList = null;
+		autoheightGridList = null;
 	});
 
 	it('wraps gridList items with element containing className "gridList-item"', function() {
 		const glItems = TestUtils.scryRenderedDOMComponentsWithClass(gridList, 'gridList-item');
 		expect(glItems.length).not.toBe(0);
 	});
+
+	it('sets correct autoheight grid class', function() {
+		const glClassList = TestUtils.scryRenderedDOMComponentsWithTag(autoheightGridList, 'UL')[0].className;
+		expect(glClassList).toContain(GRID_AUTOHEIGHT_CLASS);
+	});
+
+	it('wraps autoheight gridList items with element containing className "flex-item"', function() {
+		const glItems = TestUtils.scryRenderedDOMComponentsWithClass(autoheightGridList, 'flex-item');
+		expect(glItems.length).not.toBe(0);
+	});
+
 });
 
 describe('Responsive GridList', function() {
-	let glClassList;
+	let glClassList, autoheightGLClassList;
 
 	beforeEach(() => {
 		gridList = TestUtils.renderIntoDocument(JSX_GridListResponsive);
+		autoheightGridList = TestUtils.renderIntoDocument(JSX_AutoheightGridListResponsive);
 		glClassList = TestUtils.scryRenderedDOMComponentsWithTag(gridList, 'UL')[0].className;
+		autoheightGLClassList = TestUtils.scryRenderedDOMComponentsWithTag(autoheightGridList, 'UL')[0].className;
 	});
 	afterEach(() => {
 		gridList = null;
+		autoheightGridList = null;
 		glClassList = null;
+		autoheightGLClassList = null;
 	});
 
 	it('sets correct default columns class', function() {
@@ -87,5 +147,20 @@ describe('Responsive GridList', function() {
 	it('sets correct large breakpoint columns class', function() {
 		const largeClass = `atLarge_gridList--has${responsiveColsLarge}`;
 		expect(glClassList).toContain(largeClass);
+	});
+
+	it('sets correct autoheight default columns class', function() {
+		const defaultClass = `${GRID_AUTOHEIGHT_CLASS}--has${responsiveColsDefault}`;
+		expect(autoheightGLClassList).toContain(defaultClass);
+	});
+
+	it('sets correct autoheight medium breakpoint columns class', function() {
+		const mediumClass = `atMedium_${GRID_AUTOHEIGHT_CLASS}--has${responsiveColsMedium}`;
+		expect(autoheightGLClassList).toContain(mediumClass);
+	});
+
+	it('sets correct autoheight large breakpoint columns class', function() {
+		const largeClass = `atLarge_${GRID_AUTOHEIGHT_CLASS}--has${responsiveColsLarge}`;
+		expect(autoheightGLClassList).toContain(largeClass);
 	});
 });


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-348

#### Description
Sometimes we need gridlist items to be the same height. This PR lets you use flexbox for gridlist layout. This came from Chris' designs for showing a sample of members in cards on group home.

#### Screenshots (if applicable)
<img width="1122" alt="screen shot 2017-07-17 at 12 21 05 pm" src="https://user-images.githubusercontent.com/2313998/28278261-7e0dbd64-6aea-11e7-8b83-5f0042294d8b.png">

