### PR TITLE
Antialias primary button type

### DIFF
--- a/assets/scss/components/_button.scss
+++ b/assets/scss/components/_button.scss
@@ -249,6 +249,8 @@ Class                   | Description
 		$hoverColor: transparentize($C_accent, .2),
 		$activeColor: transparentize($C_accent, .4)
 	);
+	-moz-osx-font-smoothing: grayscale;
+	-webkit-font-smoothing: antialiased;
 	.inverted & {
 		@include buttonColor(
 			$bgColor: $C_contentBG,


### PR DESCRIPTION
#### Description
Not related to any specific issues. I changed primary button text from subpixel antialiasing to regular antialiasing. The subpixel antialiasing was causing the white type to appear bolder on the red background. Now the type actually appears like "Medium" weight instead of "Semibold" weight, and better matches the default (secondary) buttons.

Before:
<img width="362" alt="screen shot 2017-07-28 at 12 02 11 pm" src="https://user-images.githubusercontent.com/2313998/28725832-b78d471c-738c-11e7-8d9f-47661d051424.png">

After:
<img width="361" alt="screen shot 2017-07-28 at 12 02 02 pm" src="https://user-images.githubusercontent.com/2313998/28725824-b258b178-738c-11e7-8c24-e8d5b7fed3c4.png">