### PR TITLE
Added bordered button varian

### DIFF
--- a/assets/scss/components/_button.scss
+++ b/assets/scss/components/_button.scss
@@ -271,9 +271,9 @@ Class                   | Description
 
 	.inverted & {
 		@include buttonColor(
-			$bgColor: $C_textSecondary,
-			$hoverColor: lighten(transparentize($C_textSecondary, .2), 12%),
-			$activeColor: lighten(transparentize($C_textSecondary, .2), 23%)
+			$bgColor: rgba(46, 62, 72, .6),
+			$hoverColor: lighten(transparentize(rgba(46, 62, 72, .6), .2), 12%),
+			$activeColor: lighten(transparentize(rgba(46, 62, 72, .6), .2), 23%)
 		);
 		border: 1px solid $C_borderInverted;
 

--- a/assets/scss/components/_button.scss
+++ b/assets/scss/components/_button.scss
@@ -75,6 +75,14 @@ Applies button color-related styles using a mixin.
 	@include color-all($textColor);
 	background: $bgColor;
 
+	&:hover {
+		transition: all 0.4s $animate_easeOutQuad;
+		svg {
+			transition: fill 0.4s $animate_easeOutQuad;
+		}
+	}
+
+
 	&:hover,
 	&:focus {
 		background: $hoverColor;

--- a/assets/scss/components/_button.scss
+++ b/assets/scss/components/_button.scss
@@ -37,7 +37,6 @@ _(The `extend` directive can cause ugly cascade problems)_
 	@include justify-content(center);
 	@include align-items(center);
 	@include transition(background .15s);
-	@include standardBorder(none);
 	box-sizing: border-box;
 	-webkit-appearance: none;
 	border-radius: $defaultRadius;
@@ -255,6 +254,33 @@ Class                   | Description
 			$hoverColor: transparentize($C_contentBG, .2),
 			$activeColor: transparentize($C_contentBG, .4)
 		);
+	}
+}
+
+.button--bordered {
+	@include buttonColor(
+		$bgColor: $C_contentBG,
+		$hoverColor: #F6F7F8, //TODO: change to $C_collectionBG once `swarm-constants` is available
+		$activeColor: darken(#F6F7F8, 3%)
+	);
+	border: 1px solid $C_border;
+
+	&:hover, &:focus {
+		border-color: $C_textHint;
+	}
+
+	.inverted & {
+		@include buttonColor(
+			$bgColor: $C_textSecondary,
+			$hoverColor: lighten(transparentize($C_textSecondary, .2), 12%),
+			$activeColor: lighten(transparentize($C_textSecondary, .2), 23%)
+		);
+		border: 1px solid $C_borderInverted;
+
+		&:hover, &:focus {
+			border-color: $C_borderDarkInverted, .1;
+		}
+
 	}
 }
 

--- a/assets/scss/util/_vars.scss
+++ b/assets/scss/util/_vars.scss
@@ -2,3 +2,4 @@
 // shadow for "interactive" elements,
 // like popover or dropdown menus
 $interactiveShadow: 0 2px 2px 0 $C_border,0 3px 1px -2px $C_separator,0 1px 5px 0 $C_border;
+$animate_easeOutQuad: cubic-bezier(0.165, 0.84, 0.44, 1);

--- a/src/forms/Button.jsx
+++ b/src/forms/Button.jsx
@@ -28,6 +28,7 @@ class Button extends React.PureComponent {
 			primary,
 			right,
 			small,
+			bordered,
 			...other
 		} = this.props;
 
@@ -39,6 +40,7 @@ class Button extends React.PureComponent {
 					'button--primary': primary,
 					'button--small': small,
 					'button--reset': reset,
+					'button--bordered': bordered,
 				},
 				className
 			),

--- a/src/forms/button.story.jsx
+++ b/src/forms/button.story.jsx
@@ -39,6 +39,24 @@ storiesOf('Button', module)
 			<Button onClick={action('clicked')} disabled>Button Label</Button>
 		</Inverted>
 	))
+	.add('Bordered', () => (
+		<div
+			className='stripe stripe--collection'
+			style={{
+				height: '100%',
+				width: '100%',
+				display: 'flex',
+				justifyContent: 'center',
+				alignItems: 'center',
+			}}>
+			<Button onClick={action('clicked')} bordered>Button Label</Button>
+		</div>
+	))
+	.add('Bordered - inverted', () => (
+		<Inverted>
+			<Button onClick={action('clicked')} bordered>Button Label</Button>
+		</Inverted>
+	))
 	.add('Reset', () => (
 		<Button onClick={action('clicked')} reset>Button Label</Button>
 	))

--- a/src/forms/button.test.jsx
+++ b/src/forms/button.test.jsx
@@ -38,6 +38,7 @@ describe('Button', () => {
 			'primary',
 			'fullWidth',
 			'small',
+			'bordered'
 		];
 
 		variantTest(Button, BUTTON_CLASS, variants);


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-374

#### Description
Added a variant to <Button> that provides a background and light grey border. We've been seeing this style used on event and group home, typically for buttons that are on top of a the light grey (#f5f6f7) background.

#### Screenshots (if applicable)
<img width="209" alt="screen shot 2017-07-31 at 9 50 53 am" src="https://user-images.githubusercontent.com/2313998/28780718-cc7c2e36-75d5-11e7-9d21-b5c7e470fb49.png">
<img width="223" alt="screen shot 2017-07-31 at 9 51 01 am" src="https://user-images.githubusercontent.com/2313998/28780725-cf154a06-75d5-11e7-9879-103f3b794094.png">

