### PR TITLE
Added borders between menu items in popovers

### DIFF
--- a/assets/scss/components/_popover.scss
+++ b/assets/scss/components/_popover.scss
@@ -36,7 +36,13 @@ $view-minWidth: 320px;
 }
 
 .popover-menu-option {
+	border-top: 1px solid $C_border;
 	cursor: pointer;
+
+	&:first-child {
+		border-top: none;
+	}
+
 	& > a,
 	& > span,
 	& > div,


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-366

#### Description
Added borders between menu items in popovers

#### Screenshots (if applicable)
<img width="169" alt="screen shot 2017-08-02 at 12 29 07 pm" src="https://user-images.githubusercontent.com/2313998/28883974-37b9de74-777e-11e7-8cf5-abdcfb6c6643.png">

