### PR TITLE
Set Icon fill color on without adding CSS

### DIFF
--- a/src/media/Icon.jsx
+++ b/src/media/Icon.jsx
@@ -38,11 +38,16 @@ export const getIconShape = (shape, size) => {
  */
 class Icon extends React.PureComponent {
 	render() {
-		const { className, shape, size, ...other } = this.props;
+		const { className, shape, size, color, style, ...other } = this.props;
 
 		const classNames = cx(ICON_CLASS, `svg--${shape}`, className);
 
 		const sizeVal = MEDIA_SIZES[size];
+
+		const allStyles = style || {};
+		if (color) {
+			allStyles.fill = color;
+		}
 
 		return (
 			<span className={classNames}>
@@ -53,6 +58,7 @@ class Icon extends React.PureComponent {
 					viewBox={`0 0 ${sizeVal} ${sizeVal}`}
 					className='svg-icon valign--middle'
 					role='img'
+					style={allStyles}
 					{...other}
 				>
 					<use xlinkHref={`#icon-${getIconShape(shape, size)}`} />

--- a/src/media/icon.story.jsx
+++ b/src/media/icon.story.jsx
@@ -46,6 +46,9 @@ storiesOf('Icon', module)
 	.add('XX-Large', () => (
 		<Icon shape={ICON_NAME} size='xxl' />
 	))
+	.add('Passed color', () => (
+		<Icon shape={ICON_NAME} color='#F13959' />
+	))
 	.addWithInfo(
 		'Loading indicator',
 		'The `updates` icon is animated by default.',

--- a/src/media/icon.test.jsx
+++ b/src/media/icon.test.jsx
@@ -101,4 +101,18 @@ describe('Icon', () => {
 			expect(actual).toBe(expected);
 		});
 	});
+
+	describe('renders color override', () => {
+		it('does NOT render a --small shape variant meetup m logo', () => {
+			const fillColor = '#ff0000';
+			const icon = TestUtils.renderIntoDocument(
+				<Icon
+					shape='chevron-down'
+					color={fillColor} />
+			);
+			const svgEl = ReactDOM.findDOMNode(icon).querySelector('svg');
+
+			expect(svgEl.style.fill).toContain(fillColor);
+		});
+	});
 });


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-365

#### Description
Sets SVG fill color without depending on CSS. This issue came up during Group Home development - Kristin could have used the `<Button>` component to render the social media buttons at the bottom of the description if we had a way to color icons.
I think this PR in combination with a JS distribution of color values from `swarm-constants` could help us reduce CSS bloat - but I'd love to hear if anybody disagrees with this approach :)

#### Screenshots (if applicable)

