### PR TITLE
Popover menu item text wraps too easily

### DIFF
--- a/assets/scss/components/_popover.scss
+++ b/assets/scss/components/_popover.scss
@@ -26,13 +26,13 @@ $view-minWidth: 320px;
 	box-shadow: $popoverShadow;
 	max-height: $block-6;
 	position: absolute;
-	width: $view-minWidth;
+	max-width: $view-minWidth;
 	z-index: 1;
 	text-align: left !important;
 }
 
 .popover-container--menu {
-	width: $block-4;
+	min-width: $block-4;
 }
 
 .popover-menu-option {

--- a/src/interactive/popover.story.jsx
+++ b/src/interactive/popover.story.jsx
@@ -34,7 +34,7 @@ storiesOf('Popover', module)
 				trigger={<div>Open</div>}
 				menuItems={[
 					<span className='first-option' onClick={logSelection}>First option</span>,
-					<span className='second-option' onClick={logSelection}>Second option</span>,
+					<span className='second-option' onClick={logSelection}>Second option is super duper long</span>,
 					<span className='third-option' onClick={logSelection}>Third option</span>,
 				]}
 			/>


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-346

#### Description
Changed popover to use min and max width to avoid weird text wrapping

#### Screenshots (if applicable)

