### PR TITLE
Wc 76/update sasstools new colors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 1.1.$(CI_BUILD_NUMBER)
+VERSION ?= 2.0.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "storybook-addon-i18n-tools": "1.0.0",
     "style-loader": "0.18.2",
     "swarm-icons": "1.3.129",
-    "swarm-sasstools": "1.7.78",
+    "swarm-sasstools": "1.7.80",
     "webpack": "2.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "storybook-addon-i18n-tools": "1.0.0",
     "style-loader": "0.18.2",
     "swarm-icons": "1.3.129",
-    "swarm-sasstools": "1.7.62",
+    "swarm-sasstools": "1.7.78",
     "webpack": "2.6.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6186,9 +6186,9 @@ swarm-icons@1.3.129:
   version "1.3.129"
   resolved "https://registry.yarnpkg.com/swarm-icons/-/swarm-icons-1.3.129.tgz#55344c71dcbcb8cabe5bfec6384dd6758ab0a81e"
 
-swarm-sasstools@1.7.78:
-  version "1.7.78"
-  resolved "https://registry.yarnpkg.com/swarm-sasstools/-/swarm-sasstools-1.7.78.tgz#e00c5078505dc4293d6d130439f91fbc76628079"
+swarm-sasstools@1.7.80:
+  version "1.7.80"
+  resolved "https://registry.yarnpkg.com/swarm-sasstools/-/swarm-sasstools-1.7.80.tgz#5fe245a02b0d1a3223f9f0a5b58f0851e5f92f67"
   dependencies:
     bourbon "4.2.3"
     sass-rem "^1.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@alrra/travis-scripts@3.0.1":
+"@alrra/travis-scripts@3.0.1", "@alrra/travis-scripts@^3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@alrra/travis-scripts/-/travis-scripts-3.0.1.tgz#45d5b9357317b6cc5553dfd99931843ae0b0e53a"
 
@@ -2841,7 +2841,7 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-gh-pages@1.0.0:
+gh-pages@1.0.0, gh-pages@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/gh-pages/-/gh-pages-1.0.0.tgz#4a46f4c25439f7a2b7e6835504d4a49e949f04ca"
   dependencies:
@@ -4150,10 +4150,6 @@ math-expression-evaluator@^1.2.14:
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
-
-meetup-swatches@3.2.5:
-  version "3.2.5"
-  resolved "https://registry.yarnpkg.com/meetup-swatches/-/meetup-swatches-3.2.5.tgz#46ff0ffbe22fdf56267bbd05016e00466560efdd"
 
 meetup-web-mocks@1.0.194:
   version "1.0.194"
@@ -6179,17 +6175,24 @@ svgo@^0.7.0:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
+swarm-constants@0.1.10:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/swarm-constants/-/swarm-constants-0.1.10.tgz#da79df2de48f1f24f855bd5cf31d01c95fa009a2"
+  dependencies:
+    "@alrra/travis-scripts" "^3.0.1"
+    gh-pages "^1.0.0"
+
 swarm-icons@1.3.129:
   version "1.3.129"
   resolved "https://registry.yarnpkg.com/swarm-icons/-/swarm-icons-1.3.129.tgz#55344c71dcbcb8cabe5bfec6384dd6758ab0a81e"
 
-swarm-sasstools@1.7.62:
-  version "1.7.62"
-  resolved "https://registry.yarnpkg.com/swarm-sasstools/-/swarm-sasstools-1.7.62.tgz#08f064b2fc84e0dc3d2b44ac3aaf0f6ab2e02f64"
+swarm-sasstools@1.7.78:
+  version "1.7.78"
+  resolved "https://registry.yarnpkg.com/swarm-sasstools/-/swarm-sasstools-1.7.78.tgz#e00c5078505dc4293d6d130439f91fbc76628079"
   dependencies:
     bourbon "4.2.3"
-    meetup-swatches "3.2.5"
     sass-rem "^1.2.4"
+    swarm-constants "0.1.10"
 
 symbol-observable@^1.0.1, symbol-observable@^1.0.3:
   version "1.0.4"


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-76

#### Description
Updates `swarm-sasstools`, which pulls colors from `swarm-constants` instead of `meetup-swatches`.

Marked as a **breaking change** because consumer apps may need to remap some older swatches color var names to new standard colors from `swarm-constants`.

