### PR TITLE
SelectInput - Cleans up error when value not provided 🎪

### DIFF
--- a/src/forms/SelectInput.jsx
+++ b/src/forms/SelectInput.jsx
@@ -98,7 +98,7 @@ SelectInput.propTypes = {
 	value: (props, propName, componentName) => {
 		const validValues = props.options.map(opt => opt.value);
 
-		if (!validValues.includes(props[propName])) {
+		if (props[propName] && !validValues.includes(props[propName])) {
 			return new Error(`${propName} prop supplied to ${componentName} does not match any supplied options values`);
 		}
 	},

--- a/src/forms/__snapshots__/selectInput.test.jsx.snap
+++ b/src/forms/__snapshots__/selectInput.test.jsx.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SelectInput basic renders into the DOM 1`] = `
+<div>
+  <label
+    className="label--field"
+  >
+    Test select
+  </label>
+  <select
+    className=""
+    name="testSelect"
+    onChange={[Function]}
+    value="1"
+  >
+    <option
+      value="1"
+    >
+      One
+    </option>
+    <option
+      value="2"
+    >
+      Two
+    </option>
+    <option
+      value="3"
+    >
+      Three
+    </option>
+  </select>
+</div>
+`;


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/MW-1726

#### Description
This PR adds a check in the custom prop validator for the `value` prop if it is defined before throwing an error. This cleans up a error in the browser console when that prop is not provided.


#### Screenshots (if applicable)
![screen shot 2017-08-07 at 2 44 00 pm](https://user-images.githubusercontent.com/2153230/29041639-a5f3f008-7b81-11e7-95a5-66f870742558.png)
