### PR TITLE
Sds 411 popover render bug

### DIFF
--- a/assets/scss/components/_popover.scss
+++ b/assets/scss/components/_popover.scss
@@ -33,6 +33,10 @@ $view-minWidth: 320px;
 
 .popover-container--menu {
 	min-width: $block-4;
+
+	&.visibility--a11yShow {
+		position:absolute;
+	}
 }
 
 .popover-menu-option {

--- a/src/interactive/Popover.jsx
+++ b/src/interactive/Popover.jsx
@@ -160,10 +160,10 @@ class Popover extends React.Component {
 				'popover-container',
 				'popover-container--menu',
 				{
-					'trans-fadeIn--short': !isActive,
+					'trans-fadeIn': !isActive,
 					'opacity--0': !isActive,
+					'trans-fadeOut': isActive,
 					'opacity--1': isActive,
-					'trans-fadeOut--short': isActive,
 					'popover-container--horizontal-left': (align === 'left'),
 					'popover-container--horizontal-right': (align === 'right')
 				}
@@ -186,7 +186,6 @@ class Popover extends React.Component {
 				>
 					{trigger}
 				</div>
-
 				<nav>
 					<ul
 						ref={(el) => this.menuRef = el}
@@ -194,7 +193,7 @@ class Popover extends React.Component {
 						role='menu'
 						aria-hidden={!isActive}
 					>
-						{this.renderMenuItems()}
+						{isActive && this.renderMenuItems()}
 					</ul>
 				</nav>
 			</div>

--- a/src/interactive/Popover.jsx
+++ b/src/interactive/Popover.jsx
@@ -162,8 +162,10 @@ class Popover extends React.Component {
 				{
 					'trans-fadeIn': !isActive,
 					'opacity--0': !isActive,
+					'visibility--a11yHide': !isActive,
 					'trans-fadeOut': isActive,
 					'opacity--1': isActive,
+					'visibility--a11yShow': isActive,
 					'popover-container--horizontal-left': (align === 'left'),
 					'popover-container--horizontal-right': (align === 'right')
 				}
@@ -193,7 +195,7 @@ class Popover extends React.Component {
 						role='menu'
 						aria-hidden={!isActive}
 					>
-						{isActive && this.renderMenuItems()}
+						{this.renderMenuItems()}
 					</ul>
 				</nav>
 			</div>


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-411

#### Description
Links were being rendered, with `opacity--0`, for the popover menu., and were still clickable.
This fix uses the `a11y` classes  to position the menu offscreen. 

I needed to make an adjustment to the a11y `static` positioning.

(**another solution could be not to render the menu items if `!isActive`.)


