### PR TITLE
Wc 82 time input redux

### DIFF
--- a/src/forms/DateTimePicker.jsx
+++ b/src/forms/DateTimePicker.jsx
@@ -267,7 +267,7 @@ class DateTimePicker extends React.Component {
 						/>
 						{ !dateOnly &&
 								<TimeInput name={timeInputName}
-									onChangeCallback={this.setTime}
+									onChange={this.setTime}
 									onFocus={onFocus}
 									onBlur={onBlur}
 									value={this.getTime()}

--- a/src/forms/TimeInput.jsx
+++ b/src/forms/TimeInput.jsx
@@ -56,6 +56,7 @@ class TimeInput extends React.Component {
 					value={value}
 					className={classNames}
 					required={required}
+					onChange={this.onChange}
 					ref={ input => this.inputEl = input }
 					{...other}
 				/>

--- a/src/forms/TimeInput.jsx
+++ b/src/forms/TimeInput.jsx
@@ -21,7 +21,9 @@ class TimeInput extends React.Component {
 	*	which may be provided by a parent component such as DateTimePicker
 	*/
 	onChange(e) {
-		this.props.onChange && this.props.onChange(e.target.value);
+		this.props.onChange && this.props.onChange(e.target.value); // redux-form provides an onChange prop
+
+		// onChangeCallback currently provided by a parent component eg DateTimePicker
 		this.props.onChangeCallback && this.props.onChangeCallback(e.target.value);
 	}
 
@@ -85,7 +87,8 @@ TimeInput.propTypes = {
 		PropTypes.element
 	]),
 	required: PropTypes.bool,
-	onChangeCallback: PropTypes.func,
+	onChange: PropTypes.func,			// redux-form provides an onChange prop
+	onChangeCallback: PropTypes.func, 	// currently provided by a parent component eg DateTimePicker
 };
 
 export default TimeInput;

--- a/src/forms/TimeInput.jsx
+++ b/src/forms/TimeInput.jsx
@@ -9,14 +9,16 @@ class TimeInput extends React.Component {
 
 	constructor(props) {
 		super(props);
-		// onChange comment
+
 		this.onChange = this.onChange.bind(this);
 	}
 
 	/**
 	* @function onChange
 	* @param e Event Object
-	* @description ...
+	* @description called when the input changes, in turn calls the onChange
+	* 	handler prop, if there is one (eg supplied by redux-form) and an onChangeCallback
+	*	which may be provided by a parent component such as DateTimePicker
 	*/
 	onChange(e) {
 		this.props.onChange && this.props.onChange(e.target.value);
@@ -46,6 +48,14 @@ class TimeInput extends React.Component {
 			'label--field',
 			{ required }
 		);
+
+		const errorId = `${id}-error`;
+
+		if (error) {
+			other['aria-invalid'] = true;
+			other['aria-describedby'] = errorId;
+		}
+
 		return (
 			<span>
 				{ label && <label htmlFor={id} className={labelClassNames}>{label}</label> }
@@ -60,7 +70,7 @@ class TimeInput extends React.Component {
 					ref={ input => this.inputEl = input }
 					{...other}
 				/>
-				{ error && <p className='text--error'>{error}</p> }
+				{ error && <p id={errorId} className='text--error'>{error}</p> }
 			</span>
 		);
 

--- a/src/forms/TimeInput.jsx
+++ b/src/forms/TimeInput.jsx
@@ -9,26 +9,31 @@ class TimeInput extends React.Component {
 
 	constructor(props) {
 		super(props);
-		this.state = {
-			value: this.props.value || ''
-		};
+		// onChange comment
 		this.onChange = this.onChange.bind(this);
 	}
 
+	/**
+	* @function onChange
+	* @param e Event Object
+	* @description ...
+	*/
 	onChange(e) {
-		this.setState({ value: e.target.value });
+		this.props.onChange && this.props.onChange(e.target.value);
 		this.props.onChangeCallback && this.props.onChangeCallback(e.target.value);
 	}
 
 	render() {
 		const {
-			onChangeCallback,	// eslint-disable-line no-unused-vars
 			id,
 			label,
 			name,
 			className,
 			required,
-			value,		// eslint-disable-line no-unused-vars
+			value,
+			error,
+			onChange,			// eslint-disable-line no-unused-vars
+			onChangeCallback, 	// eslint-disable-line no-unused-vars
 			...other
 		} = this.props;
 
@@ -48,13 +53,13 @@ class TimeInput extends React.Component {
 					id={id}
 					type='time'
 					name={name}
-					value={this.state.value}
+					value={value}
 					className={classNames}
-					onChange={this.onChange}
 					required={required}
 					ref={ input => this.inputEl = input }
 					{...other}
 				/>
+				{ error && <p className='text--error'>{error}</p> }
 			</span>
 		);
 
@@ -62,14 +67,14 @@ class TimeInput extends React.Component {
 }
 
 TimeInput.propTypes = {
-	onChangeCallback: PropTypes.func,
 	name: PropTypes.string.isRequired,
 	error: PropTypes.string,
 	label: PropTypes.oneOfType([
 		PropTypes.string,
 		PropTypes.element
 	]),
-	required: PropTypes.bool
+	required: PropTypes.bool,
+	onChangeCallback: PropTypes.func,
 };
 
 export default TimeInput;

--- a/src/forms/TimeInput.jsx
+++ b/src/forms/TimeInput.jsx
@@ -17,14 +17,10 @@ class TimeInput extends React.Component {
 	* @function onChange
 	* @param e Event Object
 	* @description called when the input changes, in turn calls the onChange
-	* 	handler prop, if there is one (eg supplied by redux-form) and an onChangeCallback
-	*	which may be provided by a parent component such as DateTimePicker
+	* 	handler prop, if there is one provided (eg supplied by redux-form or DateTimePicker)
 	*/
 	onChange(e) {
-		this.props.onChange && this.props.onChange(e.target.value); // redux-form provides an onChange prop
-
-		// onChangeCallback currently provided by a parent component eg DateTimePicker
-		this.props.onChangeCallback && this.props.onChangeCallback(e.target.value);
+		this.props.onChange && this.props.onChange(e.target.value);
 	}
 
 	render() {
@@ -87,8 +83,7 @@ TimeInput.propTypes = {
 		PropTypes.element
 	]),
 	required: PropTypes.bool,
-	onChange: PropTypes.func,			// redux-form provides an onChange prop
-	onChangeCallback: PropTypes.func, 	// currently provided by a parent component eg DateTimePicker
+	onChange: PropTypes.func,			// redux-form or DateTimePicker provides an onChange prop
 };
 
 export default TimeInput;

--- a/src/forms/TimeInput.jsx
+++ b/src/forms/TimeInput.jsx
@@ -33,7 +33,6 @@ class TimeInput extends React.Component {
 			value,
 			error,
 			onChange,			// eslint-disable-line no-unused-vars
-			onChangeCallback, 	// eslint-disable-line no-unused-vars
 			...other
 		} = this.props;
 

--- a/src/forms/__snapshots__/timeInput.test.jsx.snap
+++ b/src/forms/__snapshots__/timeInput.test.jsx.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TimeInput renders a time html input with expected props 1`] = `
+<span>
+  <input
+    className="input--time"
+    name="time"
+    onChange={[Function]}
+    required={true}
+    type="time"
+    value="22:00"
+  />
+</span>
+`;

--- a/src/forms/redux-form/TimeInput.jsx
+++ b/src/forms/redux-form/TimeInput.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import TimeInput from '../TimeInput';
+
+/**
+ * This component wraps the standard TimeInput for use with redux-form.
+ * It deconstructs props that redux-form sets and re-sets them on TimeInput.
+ * @param {object} props React component props
+ * @return {React.Component} TimeInput
+ */
+const ReduxFormTimeInput = props => {
+	const { input, meta, ...other } = props;
+
+	return <TimeInput {...input} error={meta.error} {...other} />;
+};
+
+ReduxFormTimeInput.displayName = 'ReduxFormTimeInput';
+
+export default ReduxFormTimeInput;

--- a/src/forms/redux-form/__snapshots__/timeInput.test.jsx.snap
+++ b/src/forms/redux-form/__snapshots__/timeInput.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`redux-form TimeInput renders a TextInput component with expected attributes from mock data 1`] = `
+exports[`redux-form TimeInput renders a TimeInput component with expected attributes from mock data 1`] = `
 <TimeInput
   error="Now approaching midnight!!?"
   label="What time is it?"

--- a/src/forms/redux-form/__snapshots__/timeInput.test.jsx.snap
+++ b/src/forms/redux-form/__snapshots__/timeInput.test.jsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`redux-form TimeInput renders a TextInput component with expected attributes from mock data 1`] = `
+<TimeInput
+  error="Now approaching midnight!!?"
+  label="What time is it?"
+  name="partytime"
+  required={true}
+  value="22:00"
+/>
+`;

--- a/src/forms/redux-form/timeInput.test.jsx
+++ b/src/forms/redux-form/timeInput.test.jsx
@@ -4,7 +4,9 @@ import ReduxFormTimeInput from './TimeInput';
 
 describe('redux-form TimeInput', function() {
 
-	const formAttrs = {
+	// props given in the structure that
+	// redux form would
+	const reduxFormProps = {
 		input: {
 			label: 'What time is it?',
 			name: 'partytime',
@@ -17,7 +19,7 @@ describe('redux-form TimeInput', function() {
 	};
 
 	it('renders a TimeInput component with expected attributes from mock data', () => {
-		const component = shallow(<ReduxFormTimeInput {...formAttrs} />);
+		const component = shallow(<ReduxFormTimeInput {...reduxFormProps} />);
 
 		expect(component).toMatchSnapshot();
 	});

--- a/src/forms/redux-form/timeInput.test.jsx
+++ b/src/forms/redux-form/timeInput.test.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import ReduxFormTimeInput from './TimeInput';
+
+describe('redux-form TimeInput', function() {
+
+	const formAttrs = {
+		input: {
+			label: 'What time is it?',
+			name: 'partytime',
+			value: '22:00',
+			required: true
+		},
+		meta: {
+			error: 'Now approaching midnight!!?'
+		}
+	};
+
+	it('renders a TimeInput component with expected attributes from mock data', () => {
+		const component = shallow(<ReduxFormTimeInput {...formAttrs} />);
+
+		expect(component).toMatchSnapshot();
+	});
+});

--- a/src/forms/timeInput.test.jsx
+++ b/src/forms/timeInput.test.jsx
@@ -10,14 +10,12 @@ describe('TimeInput', function() {
 		onChangeSpy;
 
 	const onChangePropMock = jest.fn(),
-		callbackMock = jest.fn(),
 		newTime = '23:00';
 
 	const props = {
 		name: 'time',
 		value: '22:00',
 		onChange: onChangePropMock,
-		onChangeCallback: callbackMock,
 		required: true
 	};
 
@@ -45,11 +43,6 @@ describe('TimeInput', function() {
 	it('calls onChange prop when value is changed', function() {
 		component.instance().onChange({ target: { value: newTime } });
 		expect(onChangePropMock).toHaveBeenCalled();
-	});
-
-	it('calls datepicker callback, if one is provided, when value is changed', function() {
-		component.instance().onChange({ target: { value: newTime } });
-		expect(callbackMock).toHaveBeenCalledWith(newTime);
 	});
 
 });

--- a/src/forms/timeInput.test.jsx
+++ b/src/forms/timeInput.test.jsx
@@ -6,73 +6,51 @@ import TimeInput from './TimeInput';
 describe('TimeInput', function() {
 
 	let component,
-		inputEl;
+		inputEl,
+		onChangeSpy;
 
-	const timeValue = '22:00',
+	const onChangePropMock = jest.fn(),
+		callbackMock = jest.fn(),
 		newTime = '23:00';
 
-	const callbackSpy = jest.fn(),
-		onChangeMock = jest.fn();
+	const props = {
+		name: 'time',
+		value: '22:00',
+		onChange: onChangePropMock,
+		onChangeCallback: callbackMock,
+		required: true
+	};
 
 	beforeEach(() => {
-		component = shallow(
-			<TimeInput
-				name='time'
-				value={timeValue}
-				onChange={onChangeMock}
-				required />
-		);
+		onChangeSpy = jest.spyOn(TimeInput.prototype, 'onChange');
+		component = shallow(<TimeInput {...props} />);
 		inputEl = component.find('input');
 	});
 
 	afterEach(() => {
 		component = null;
 		inputEl = null;
+		onChangeSpy.mockClear();
 	});
 
 	it('renders a time html input with expected props', function() {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('takes a value in HH:mm format', function() {
-		expect(inputEl.prop('value')).toEqual(timeValue);
+	it('calls internal onChange when value is changed', function() {
+		inputEl.simulate('change', { target: { value: newTime } });
+		expect(onChangeSpy).toHaveBeenCalled();
 	});
 
-	describe('TimeInput onChange', () => {
-		let onChangeSpy;
-
-		beforeEach(() => {
-			onChangeSpy = jest.spyOn(TimeInput.prototype, 'onChange');
-
-			inputEl = shallow(<TimeInput
-				name='time'
-				value={timeValue}
-				onChange={onChangeMock}
-				onChangeCallback={callbackSpy}
-				required />
-			).find('input');
-		});
-
-		afterEach(() => {
-			inputEl = null;
-			onChangeSpy.mockClear();
-		});
-
-		it('calls internal onChange when value is changed', function() {
-			inputEl.simulate('change', { target: { value: newTime } });
-			expect(onChangeSpy).toHaveBeenCalled();
-		});
-
-		it('calls onChange prop when value is changed', function() {
-			inputEl.simulate('change', { target: { value: newTime } });
-			expect(onChangeMock).toHaveBeenCalled();
-		});
-
-		it('calls datepicker callback with value if one is provided', function() {
-			inputEl.simulate('change', { target: { value: newTime } });
-			expect(callbackSpy).toHaveBeenCalledWith(newTime);
-		});
+	it('calls onChange prop when value is changed', function() {
+		component.instance().onChange({ target: { value: newTime } });
+		expect(onChangePropMock).toHaveBeenCalled();
 	});
+
+	it('calls datepicker callback with value if one is provided', function() {
+		inputEl.simulate('change', { target: { value: newTime } });
+		expect(callbackMock).toHaveBeenCalledWith(newTime);
+	});
+
 });
-
 

--- a/src/forms/timeInput.test.jsx
+++ b/src/forms/timeInput.test.jsx
@@ -1,58 +1,77 @@
+
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import { shallow } from 'enzyme';
 import TimeInput from './TimeInput';
 
 describe('TimeInput', function() {
 
-	let timeInputComponent,
-		timeInputEl;
+	let component,
+		inputEl;
 
 	const timeValue = '22:00',
-		newTime = '23:00',
-		callbackSpy = jest.fn();
+		newTime = '23:00';
+
+	const callbackSpy = jest.fn(),
+		onChangeMock = jest.fn();
 
 	beforeEach(() => {
-		timeInputComponent = TestUtils.renderIntoDocument(
-			<TimeInput name='time' value={timeValue} onChangeCallback={callbackSpy} required />);
-		timeInputEl = TestUtils.findRenderedDOMComponentWithTag(timeInputComponent, 'input');
+		component = shallow(
+			<TimeInput
+				name='time'
+				value={timeValue}
+				onChange={onChangeMock}
+				required />
+		);
+		inputEl = component.find('input');
 	});
 
 	afterEach(() => {
-		timeInputComponent = null;
-		timeInputEl = null;
+		component = null;
+		inputEl = null;
 	});
 
-	it('exists', function() {
-		expect(timeInputEl).not.toBeNull();
+	it('renders a time html input with expected props', function() {
+		expect(component).toMatchSnapshot();
 	});
 
 	it('takes a value in HH:mm format', function() {
-		expect(timeInputEl.value).toEqual(timeValue);
+		expect(inputEl.prop('value')).toEqual(timeValue);
 	});
 
-	it('sets state with its value', function() {
-		expect(timeInputComponent.state).toEqual({ value: timeValue });
-	});
+	describe('TimeInput onChange', () => {
+		let onChangeSpy;
 
-	it('should have a required attribute when specified', () => {
-		expect(timeInputEl.attributes.required).not.toBeNull();
-	});
+		beforeEach(() => {
+			onChangeSpy = jest.spyOn(TimeInput.prototype, 'onChange');
 
-	it('calls onChange and sets state when value is changed', function() {
-		const onChangeSpy = spyOn(TimeInput.prototype, 'onChange').and.callThrough();
-		const setStateSpy = spyOn(TimeInput.prototype, 'setState');
-		timeInputComponent = TestUtils.renderIntoDocument(
-			<TimeInput name='time' value={timeValue} onChangeCallback={callbackSpy} />);
-		timeInputEl = TestUtils.findRenderedDOMComponentWithTag(timeInputComponent, 'input');
+			inputEl = shallow(<TimeInput
+				name='time'
+				value={timeValue}
+				onChange={onChangeMock}
+				onChangeCallback={callbackSpy}
+				required />
+			).find('input');
+		});
 
-		TestUtils.Simulate.change(timeInputEl, { target: { value: newTime } });
-		expect(onChangeSpy).toHaveBeenCalled();
-		expect(setStateSpy).toHaveBeenCalledWith({ value: newTime });
-	});
+		afterEach(() => {
+			inputEl = null;
+			onChangeSpy.mockClear();
+		});
 
-	it('calls a callback with value if one is provided', function() {
-		TestUtils.Simulate.change(timeInputEl, { target: { value: newTime } });
-		expect(callbackSpy).toHaveBeenCalledWith(newTime);
+		it('calls internal onChange when value is changed', function() {
+			inputEl.simulate('change', { target: { value: newTime } });
+			expect(onChangeSpy).toHaveBeenCalled();
+		});
+
+		it('calls onChange prop when value is changed', function() {
+			inputEl.simulate('change', { target: { value: newTime } });
+			expect(onChangeMock).toHaveBeenCalled();
+		});
+
+		it('calls datepicker callback with value if one is provided', function() {
+			inputEl.simulate('change', { target: { value: newTime } });
+			expect(callbackSpy).toHaveBeenCalledWith(newTime);
+		});
 	});
 });
 

--- a/src/forms/timeInput.test.jsx
+++ b/src/forms/timeInput.test.jsx
@@ -47,8 +47,8 @@ describe('TimeInput', function() {
 		expect(onChangePropMock).toHaveBeenCalled();
 	});
 
-	it('calls datepicker callback with value if one is provided', function() {
-		inputEl.simulate('change', { target: { value: newTime } });
+	it('calls datepicker callback, if one is provided, when value is changed', function() {
+		component.instance().onChange({ target: { value: newTime } });
 		expect(callbackMock).toHaveBeenCalledWith(newTime);
 	});
 


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-82

#### Description
Time input currently manages its own state and updates it to work with DateTimePicker, but this adds complexity to the component and makes it difficult to work with redux form.

In prep for working with redux form, we should create a redux form wrapper and remove state inside time input and opt for its value coming from props.


#### Screenshots (if applicable)
![screen shot 2017-08-23 at 10 50 35 am](https://user-images.githubusercontent.com/92090/29622263-f1d98e94-87f0-11e7-855e-d4a4b388e11a.png)

