### PR TITLE
Wc 86 textinput storybook fix

### DIFF
--- a/src/forms/TextInput.jsx
+++ b/src/forms/TextInput.jsx
@@ -58,8 +58,9 @@ const TextInput = (props) => {
 				{...other}
 			/>
 
-			{ error && <p className='text--error'>{error}</p> }
+			{ maxLength && <p className='text--caption align--right'>{value.length} / {maxLength}</p> }
 
+			{ error && <p className='text--error'>{error}</p> }
 			{children}
 		</div>
 	);

--- a/src/forms/TextInput.jsx
+++ b/src/forms/TextInput.jsx
@@ -58,9 +58,8 @@ const TextInput = (props) => {
 				{...other}
 			/>
 
-			{ maxLength && <p className='text--caption align--right'>{value.length} / {maxLength}</p> }
-
 			{ error && <p className='text--error'>{error}</p> }
+
 			{children}
 		</div>
 	);

--- a/src/forms/textInput.story.jsx
+++ b/src/forms/textInput.story.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { InfoWrapper } from '../utils/storyComponents';
 import TextInput from './TextInput';
 import Button from './Button';
 import { storiesOf } from '@kadira/storybook';
@@ -92,6 +93,29 @@ storiesOf('TextInput', module)
 			</form>
 		);
 	})
+	.addWithInfo(
+		'with char counter if you provide maxLength',
+		`Note: updating field with charcounter relies on parent to give value, 
+			thats why you cant interact with the field in this story`,
+		() => {
+			const rules = {
+				maxLength: 20,
+				pattern:'.{5,10}'
+			};
+			return (
+				<InfoWrapper>
+					<div className='span--25'>
+						<TextInput
+							label='Your name'
+							id='fullname'
+							name='name'
+							value='how long is this'
+							{...rules} />
+					</div>
+				</InfoWrapper>
+			);
+		}
+	)
 	.add('has a pattern for min length', () => {
 		const rules = {
 			pattern:'.{5,10}'

--- a/src/forms/textInput.story.jsx
+++ b/src/forms/textInput.story.jsx
@@ -20,7 +20,7 @@ storiesOf('TextInput', module)
 				label='Your name'
 				id='fullname'
 				name='name'
-				value='Phife Dawg'
+				defaultValue='Phife Dawg'
 				placeholder='Not your email' />
 		</div>
 	)
@@ -31,7 +31,7 @@ storiesOf('TextInput', module)
 				label='Your name'
 				id='fullname'
 				name='name'
-				value='Cannot focus'
+				defaultValue='Cannot focus'
 				disabled />
 		</div>
 	)
@@ -42,6 +42,7 @@ storiesOf('TextInput', module)
 				label='Your name'
 				id='fullname'
 				name='name'
+				defaultValue='#$%!$%!'
 				error='Not so fast. You have an error.' />
 		</div>
 	)
@@ -91,22 +92,6 @@ storiesOf('TextInput', module)
 			</form>
 		);
 	})
-	.add('with char counter (maxLength)', () => {
-		const rules = {
-			maxLength: 10,
-			pattern:'.{5,10}'
-		};
-		return (
-			<div className='span--50'>
-				<TextInput
-					label='Your name'
-					id='fullname'
-					name='name'
-					value=''
-					{...rules} />
-			</div>
-		);
-	})
 	.add('has a pattern for min length', () => {
 		const rules = {
 			pattern:'.{5,10}'
@@ -117,7 +102,7 @@ storiesOf('TextInput', module)
 					label='Your name'
 					id='fullname'
 					name='name'
-					value='>5'
+					defaultValue='>5'
 					{...rules} />
 				<Button
 					contrast


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-86

#### Description
TextInput stories that have a value are non-interactive (you cant type in the field). defaultValue should be passed when possible. 
The exception is the charcounter story, that needs a value (usually given by parent) to display the `value.length`. I put a note in the infowrapper as to why this is non-interactive.
