### PR TITLE
Added the option to pass custom class names to gridlist items

### DIFF
--- a/src/layout/GridList.jsx
+++ b/src/layout/GridList.jsx
@@ -15,6 +15,7 @@ class GridList extends React.Component {
 			items,
 			autoHeight,
 			autoHeightWithWrap,
+			itemClassNames,
 			...other
 		} = this.props;
 
@@ -43,7 +44,8 @@ class GridList extends React.Component {
 		const listItemClassNames = cx(
 			'gridList-item',
 			{
-				['flex-item']: autoHeight
+				['flex-item']: autoHeight,
+				[itemClassNames]: itemClassNames
 			}
 		);
 
@@ -68,7 +70,8 @@ GridList.propTypes = {
 		medium: PropTypes.number,
 		large: PropTypes.number
 	}),
-	items: PropTypes.arrayOf(PropTypes.element).isRequired
+	items: PropTypes.arrayOf(PropTypes.element).isRequired,
+	itemClassNames: PropTypes.string
 };
 
 export default GridList;

--- a/src/layout/gridList.story.jsx
+++ b/src/layout/gridList.story.jsx
@@ -64,6 +64,31 @@ storiesOf('GridList', module)
 			</InfoWrapper>
 		))
 	.addWithInfo(
+		'GridList items with custom class names',
+		'GridList where items require a custom class for more flexible styling',
+		() => (
+			<InfoWrapper>
+				<GridList
+					columns={{
+						default: 3
+					}}
+					style={{padding: '20px'}}
+					itemClassNames='flush--all'
+					items={[
+						<div style={boxStyles}>GridItem</div>,
+						<div style={boxStyles}>GridItem</div>,
+						<div style={boxStyles}>GridItem</div>,
+						<div style={boxStyles}>GridItem</div>,
+						<div style={boxStyles}>GridItem</div>,
+						<div style={boxStyles}>GridItem</div>,
+						<div style={boxStyles}>GridItem</div>,
+						<div style={boxStyles}>GridItem</div>,
+						<div style={boxStyles}>GridItem</div>
+					]}
+				/>
+			</InfoWrapper>
+		))
+	.addWithInfo(
 		'Static autoHeight grid',
 		'GridList where items are the same height with columns fixed at 3 for all breakpoints',
 		() => (

--- a/src/layout/gridList.test.jsx
+++ b/src/layout/gridList.test.jsx
@@ -133,7 +133,9 @@ const JSX_AutoheightWithWrapGridListResponsive = (
 	/>
 );
 
-let gridList, gridListCustomClassNames, autoheightGridList;
+let gridList,
+	gridListCustomClassNames,
+	autoheightGridList;
 
 describe('Static GridList', function() {
 	beforeEach(() => {

--- a/src/layout/gridList.test.jsx
+++ b/src/layout/gridList.test.jsx
@@ -3,11 +3,33 @@ import TestUtils from 'react-addons-test-utils';
 import GridList from './GridList';
 import { GRID_AUTOHEIGHT_CLASS } from './GridList';
 
+const glItemCustomClassName = 'flush--all';
+
 const JSX_GridListStatic = (
 	<GridList
 		columns={{
 			default: 3
 		}}
+		items={[
+			<div>GridItem</div>,
+			<div>GridItem</div>,
+			<div>GridItem</div>,
+			<div>GridItem</div>,
+			<div>GridItem</div>,
+			<div>GridItem</div>,
+			<div>GridItem</div>,
+			<div>GridItem</div>,
+			<div>GridItem</div>
+		]}
+	/>
+);
+
+const JSX_GridListCustomClassNames = (
+	<GridList
+		columns={{
+			default: 3
+		}}
+		itemClassNames={glItemCustomClassName}
 		items={[
 			<div>GridItem</div>,
 			<div>GridItem</div>,
@@ -111,20 +133,27 @@ const JSX_AutoheightWithWrapGridListResponsive = (
 	/>
 );
 
-let gridList, autoheightGridList;
+let gridList, gridListCustomClassNames, autoheightGridList;
 
 describe('Static GridList', function() {
 	beforeEach(() => {
 		gridList = TestUtils.renderIntoDocument(JSX_GridListStatic);
+		gridListCustomClassNames = TestUtils.renderIntoDocument(JSX_GridListCustomClassNames);
 		autoheightGridList = TestUtils.renderIntoDocument(JSX_AutoheightGridListStatic);
 	});
 	afterEach(() => {
 		gridList = null;
+		gridListCustomClassNames = null;
 		autoheightGridList = null;
 	});
 
 	it('wraps gridList items with element containing className "gridList-item"', function() {
 		const glItems = TestUtils.scryRenderedDOMComponentsWithClass(gridList, 'gridList-item');
+		expect(glItems.length).not.toBe(0);
+	});
+
+	it('wraps gridList items with element containing custom className when specified', function() {
+		const glItems = TestUtils.scryRenderedDOMComponentsWithClass(gridListCustomClassNames, glItemCustomClassName);
 		expect(glItems.length).not.toBe(0);
 	});
 


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-418
Needed for https://meetup.atlassian.net/browse/MW-1845

#### Description
Added a prop for passing custom class names to GridList items

#### Screenshots (if applicable)

