### PR TITLE
Added flexStart as a valid value for the justify prop

### DIFF
--- a/src/layout/Flex.jsx
+++ b/src/layout/Flex.jsx
@@ -18,7 +18,8 @@ export const VALID_SPACE = {
 	center: 'center',
 	spaceAround: 'spaceAround',
 	spaceBetween: 'spaceBetween',
-	flexEnd: 'flexEnd'
+	flexEnd: 'flexEnd',
+	flexStart: 'flexStart'
 };
 
 export const DIRECTION_ROW = 'row';


### PR DESCRIPTION
#### Related issues
https://meetup.atlassian.net/browse/MW-1845

#### Description
`flexStart` wasn't being recognized as a valid value for the `justify` prop, causing React to complain. I discovered this while building the footer

#### Screenshots (if applicable)

