### PR TITLE
Wc 89 readd flatpickr scss import

### DIFF
--- a/assets/scss/components/_all.scss
+++ b/assets/scss/components/_all.scss
@@ -26,6 +26,7 @@
 @import "accordion";
 @import "avatar";
 @import "button";
+@import "calendar";
 @import "checkbox";
 @import "dateDisplay";
 @import "dropdown";
@@ -36,4 +37,5 @@
 @import "popover";
 @import "tabs";
 @import "togglePill";
+
 

--- a/assets/scss/components/_calendar.scss
+++ b/assets/scss/components/_calendar.scss
@@ -1,0 +1,1 @@
+@import "~flatpickr/dist/flatpickr"; 


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-89

#### Description
accidentally threw out the flatpickr partial in the scss of datetime picker.
readding a partial for calendar.

