### PR TITLE
Fixed story for non-dismissable toast

### DIFF
--- a/src/interactive/toast.story.jsx
+++ b/src/interactive/toast.story.jsx
@@ -54,8 +54,11 @@ storiesOf('Toast', module)
 	)
 	.add('don\'t automatically dismiss', () =>
 		(<Toaster
-			autodismiss={false}
-			toasts={toastArray}
+			toasts={[
+				<Toast autodismiss={false}>
+					Your toast is ready
+				</Toast>
+			]}
 		/>)
 	)
 	.add('don\'t allow dismissal', () =>


### PR DESCRIPTION
Wasn't passing a Toast with the `autodismiss` prop set to `false` in the "don't automatically dismiss" story