### PR TITLE
Button hover shadows

### DIFF
--- a/assets/scss/components/_button.scss
+++ b/assets/scss/components/_button.scss
@@ -271,12 +271,14 @@ Class                   | Description
 		$hoverColor: $C_lightGray,
 		$activeColor: darken($C_lightGray, 3%)
 	);
+	@include shadowOnHover(true);
 	border: 1px solid $C_border;
 
 	&:hover, &:focus {
 		border-color: $C_textHint;
 	}
 
+	$C_borderedHoverBase: transparentize($C_textPrimary, .4);
 	.inverted & {
 		@include buttonColor(
 			$bgColor: $C_textSecondary,
@@ -290,6 +292,10 @@ Class                   | Description
 		}
 
 	}
+}
+
+.button--hasHoverShadow {
+	@include shadowOnHover();
 }
 
 //

--- a/assets/scss/components/_button.scss
+++ b/assets/scss/components/_button.scss
@@ -296,6 +296,10 @@ Class                   | Description
 
 .button--hasHoverShadow {
 	@include shadowOnHover();
+	&.button--disabled,
+	&[disabled] {
+		box-shadow: none;
+	}
 }
 
 //

--- a/assets/scss/components/_button.scss
+++ b/assets/scss/components/_button.scss
@@ -253,8 +253,8 @@ Class                   | Description
 .button--primary {
 	@include buttonColor(
 		$bgColor: $C_accent,
-		$hoverColor: transparentize($C_accent, .2),
-		$activeColor: transparentize($C_accent, .4)
+		$hoverColor: darken($C_accent, 10%),
+		$activeColor: darken($C_accent, 15%)
 	);
 	.inverted & {
 		@include buttonColor(
@@ -268,14 +268,14 @@ Class                   | Description
 .button--bordered {
 	@include buttonColor(
 		$bgColor: $C_contentBG,
-		$hoverColor: $C_lightGray,
-		$activeColor: darken($C_lightGray, 3%)
+		$hoverColor: $C_contentBG,
+		$activeColor: $C_lightGray
 	);
-	@include shadowOnHover(true);
+	@include shadowOnHover();
 	border: 1px solid $C_border;
 
 	&:hover, &:focus {
-		border-color: $C_textHint;
+		border-color: transparent;
 	}
 
 	$C_borderedHoverBase: transparentize($C_textPrimary, .4);
@@ -289,6 +289,7 @@ Class                   | Description
 
 		&:hover, &:focus {
 			border-color: $C_borderDarkInverted, .1;
+			transform: translateY(0);
 		}
 
 	}

--- a/src/forms/Button.jsx
+++ b/src/forms/Button.jsx
@@ -10,9 +10,6 @@ export const BUTTON_LABEL_CLASS = 'button-label';
 export const BUTTON_ICON_CLASS = 'button-icon';
 
 /**
- * SQ2 Button component
- * @see {@link https://github.com/meetup/sassquatch2/blob/develop/sass/ui-components/_buttons.scss}
- * @see {@link http://meetup.github.io/sassquatch2/ui_components.html#buttons}
  * @module Button
  */
 class Button extends React.PureComponent {
@@ -29,6 +26,7 @@ class Button extends React.PureComponent {
 			right,
 			small,
 			bordered,
+			hasHoverShadow,
 			...other
 		} = this.props;
 
@@ -41,6 +39,8 @@ class Button extends React.PureComponent {
 					'button--small': small,
 					'button--reset': reset,
 					'button--bordered': bordered,
+					'button--hasHoverShadow': hasHoverShadow
+
 				},
 				className
 			),

--- a/src/forms/button.story.jsx
+++ b/src/forms/button.story.jsx
@@ -13,7 +13,7 @@ import Icon from '../media/Icon';
 storiesOf('Button', module)
 	.addDecorator(decorateWithLocale)
 	.addWithInfo(
-		'default',
+		'Default',
 		'This is the basic usage with the component.',
 		() => (
 			<InfoWrapper>
@@ -21,18 +21,16 @@ storiesOf('Button', module)
 			</InfoWrapper>
 		)
 	)
-	.add('Disabled', () => (
-		<Button onClick={action('clicked')} disabled>Button Label</Button>
-	))
 	.add('Default - inverted', () => (
 		<Inverted>
 			<Button onClick={action('clicked')}>Button Label</Button>
 		</Inverted>
 	))
-	.add('Primary - inverted', () => (
-		<Inverted>
-			<Button onClick={action('clicked')}primary>Button Label</Button>
-		</Inverted>
+	.add('Default - with hover shadow', () => (
+		<Button onClick={action('clicked')} hasHoverShadow>Button Label</Button>
+	))
+	.add('Disabled', () => (
+		<Button onClick={action('clicked')} disabled hasHoverShadow>Button Label</Button>
 	))
 	.add('Disabled - inverted', () => (
 		<Inverted>
@@ -73,6 +71,14 @@ storiesOf('Button', module)
 	))
 	.add('Primary', () => (
 		<Button onClick={action('clicked')} primary>Button Label</Button>
+	))
+	.add('Primary - with hover shadow', () => (
+		<Button onClick={action('clicked')} primary hasHoverShadow>Button Label</Button>
+	))
+	.add('Primary - inverted', () => (
+		<Inverted>
+			<Button onClick={action('clicked')}primary>Button Label</Button>
+		</Inverted>
 	))
 	.add('Small', () => (
 		<Button onClick={action('clicked')} small>Button Label</Button>

--- a/src/forms/button.story.jsx
+++ b/src/forms/button.story.jsx
@@ -30,7 +30,7 @@ storiesOf('Button', module)
 		<Button onClick={action('clicked')} hasHoverShadow>Button Label</Button>
 	))
 	.add('Disabled', () => (
-		<Button onClick={action('clicked')} disabled hasHoverShadow>Button Label</Button>
+		<Button onClick={action('clicked')} disabled>Button Label</Button>
 	))
 	.add('Disabled - inverted', () => (
 		<Inverted>


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-406

#### Description
Button updates from design team - `<Button bordered>` always gets a shadow on hover, any other button can have a shadow on hover using the `hasHoverShadow` prop, `[disabled]` buttons never get hover shadows.

#### Screenshots (if applicable)
![btnhovershadow](https://user-images.githubusercontent.com/2313998/30120734-b89dfc3e-92f7-11e7-8ff8-bc03b976fa2b.png)

