### PR TITLE
fix for safari on ios

### DIFF
--- a/assets/scss/components/_popover.scss
+++ b/assets/scss/components/_popover.scss
@@ -8,6 +8,10 @@ $view-minWidth: 320px;
 	position: relative;
 }
 
+.clickable {
+	cursor: pointer;
+}
+
 .popover-trigger {
 	cursor: pointer;
 	&--active {

--- a/src/interactive/Popover.jsx
+++ b/src/interactive/Popover.jsx
@@ -128,6 +128,10 @@ class Popover extends React.Component {
 	}
 
 	componentDidMount() {
+		// fix for safari on ios
+		if( navigator.userAgent.match(/(iPad|iPhone|iPod)/i) ) {
+			document.body.classList.add('clickable');
+		};
 		document.body.addEventListener('click', this.onBodyClick);
 	}
 

--- a/src/interactive/popover.test.jsx
+++ b/src/interactive/popover.test.jsx
@@ -185,4 +185,30 @@ describe('Popover', function() {
 			expect(menuEl.classList).toContain('popover-container--horizontal-left');
 		});
 	});
+	describe('Body', () => {
+		it('is clickable in safari', () => {
+			jest.clearAllMocks();
+			const body = window.document.body;
+			expect(body.getAttribute('class')).not.toEqual('clickable'); // include
+
+			// iPhone Safari user agent
+			const userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/603.1.23 (KHTML, like Gecko) Version/10.0 Mobile/14E5239e Safari/602.1';
+			const original_ua = window.navigator.userAgent;
+			Object.defineProperty(window.navigator, 'userAgent', {value: userAgent, configurable: true});
+
+			const popover = TestUtils.renderIntoDocument(popoverComponent);
+			const closedMenuFn = jest.spyOn(popover, 'closeMenu');
+
+			expect(popover.closeMenu).not.toHaveBeenCalled();
+
+			// click on body
+			expect(body.getAttribute('class')).toEqual('clickable');
+			const clickEvent = new Event('click');
+			body.dispatchEvent(clickEvent);
+
+			expect(closedMenuFn).toHaveBeenCalled();
+
+			Object.defineProperty(window.navigator, 'userAgent', {value: original_ua});
+		});
+	});
 });


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/MW-1692

#### Description
Clicking out of popover menu was not working in Safari mobile because of an issue with Safari mobile where `click` events are not fired on typically non-interactive elements. Reference: https://developer.mozilla.org/en-US/docs/Web/Events/click#Safari_Mobile


#### Screenshots (if applicable)

