### PR TITLE
WC-74: Adding fixed position option for modals

### DIFF
--- a/assets/scss/components/_modal.scss
+++ b/assets/scss/components/_modal.scss
@@ -115,6 +115,10 @@ lays out as a dialog on background content on larger screens.
 	}
 }
 
+.view--modalFixed {
+	position: fixed;
+}
+
 /*doc
 ---
 title: Overlay Shim
@@ -154,4 +158,8 @@ _See `.view--modalSnap` demo page for example_
 	z-index: map-get($zindex-map, shade-content);
 	margin: auto;
 	width: 100%;
+}
+
+.overlayShim--fixed {
+	position: fixed;
 }

--- a/src/interactive/modal.story.jsx
+++ b/src/interactive/modal.story.jsx
@@ -55,6 +55,39 @@ storiesOf('Modal', module)
 		)
 	)
 	.addWithInfo(
+		'fixed',
+		'This is the basic usage with fixed position content.',
+		() => (
+			<div style={wrapperStyle}>
+				<InfoWrapper>
+					<div className='padding--all'>
+						<p>Throw down all the stuff in the kitchen i cry and cry and cry unless you pet me, and then maybe i cry just for fun. Ask for petting curl into a furry donut lick butt, or plan steps for world domination instantly break out into full speed gallop across the house for no reason pee in the shoe. Throw down all the stuff in the kitchen jump on human and sleep on her all night long be long in the bed, purr in the morning and then give a bite to every human around for not waking up request food, purr loud scratch the walls, the floor, the windows, the humans so meow and wack the mini furry mouse or plop down in the middle where everybody walks annoy owner until he gives you food say meow repeatedly until belly rubs, feels good poop in a handbag look delicious and drink the soapy mopping up water then puke giant foamy fur-balls. Sun bathe kitty kitty. Demand to be let outside at once, and expect owner to wait for me as i think about it spot something, big eyes, big eyes, crouch, shake butt, prepare to pounce favor packaging over toy and ask to go outside and ask to come inside and ask to go outside and ask to come inside, cereal boxes make for five star accommodation and mrow. Caticus cuteicus. Leave dead animals as gifts. I could pee on this if i had the energy stare at the wall, play with food and get confused by dust lick butt and make a weird face kick up litter so step on your keyboard while you're gaming and then turn in a circle yet the dog smells bad but roll over and sun my belly. Sit on human pose purrfectly to show my beauty. Always hungry small kitty warm kitty little balls of fur spot something, big eyes, big eyes, crouch, shake butt, prepare to pounce. Who's the baby pee in the shoe. Jump around on couch, meow constantly until given food, . Kitty ipsum dolor sit amet, shed everywhere shed everywhere stretching attack your ankles chase the red dot, hairball run catnip eat the grass sniff missing until dinner time, and sleep nap and find a way to fit in tiny box.</p>
+						<p>I just saw other cats inside the house and nobody ask me before using my litter box massacre a bird in the living room and then look like the cutest and most innocent animal on the planet for curl up and sleep on the freshly laundered towels. Cough hairball on conveniently placed pants chase imaginary bugs. Stares at human while pushing stuff off a table instead of drinking water from the cat bowl, make sure to steal water from the toilet so groom yourself 4 hours - checked, have your beauty sleep 18 hours - checked, be fabulous for the rest of the day - checked stare at ceiling make meme, make cute face. Who's the baby be a nyan cat, feel great about it, be annoying 24/7 poop rainbows in litter box all day, flop over, and eat plants, meow, and throw up because i ate plants poop on grasses. Licks your face meow go back to sleep owner brings food and water tries to pet on head, so scratch get sprayed by water because bad cat leave fur on owners clothes and show belly or jump five feet high and sideways when a shadow moves and mice. Hide when guests come over find empty spot in cupboard and sleep all day cough hairball on conveniently placed pants yet fall over dead (not really but gets sypathy). Chase the pig around the house.</p>
+						<p>Scratch at the door then walk away be a nyan cat, feel great about it, be annoying 24/7 poop rainbows in litter box all day or use lap as chair, so you call this cat food, or friends are not food. Kitty power. Lie on your belly and purr when you are asleep wake up wander around the house making large amounts of noise jump on top of your human's bed and fall asleep again slap kitten brother with paw lick face hiss at owner, pee a lot, and meow repeatedly scratch at fence purrrrrr eat muffins and poutine until owner comes back yet chirp at birds lies down . Steal the warm chair right after you get up. Plan steps for world domination hide at bottom of staircase to trip human, but stand in front of the computer screen cough furball. See owner, run in terror roll on the floor purring your whiskers off eat owner's food stare out the window. Have a lot of grump in yourself because you can't forget to be grumpy and not be like king grumpy cat throw down all the stuff in the kitchen lick plastic bags mesmerizing birds massacre a bird in the living room and then look like the cutest and most innocent animal on the planet but run outside as soon as door open so make meme, make cute face. Curl up and sleep on the freshly laundered towels gnaw the corn cob or kick up litter but make meme, make cute face eat plants, meow, and throw up because i ate plants for scratch the postman wake up lick paw wake up owner meow meow or run outside as soon as door open.</p>
+					</div>
+					<Modal
+						onDismiss={onDismiss}
+						fixed
+					>
+						<Stripe><Section>
+							<h2 className='align--center'>This is a modal!</h2>
+							<p>I'm some copy</p>
+							<div className='row align--center margin--top'>
+								<div className='row-item'>
+									<Button onClick={onDismiss} fullWidth>Cancel</Button>
+								</div>
+								<div className='row-item'>
+									<Button onClick={action('Confirmed!')} primary fullWidth>Confirm</Button>
+								</div>
+							</div>
+						</Section></Stripe>
+					</Modal>
+					<div style={iconSpriteStyle} dangerouslySetInnerHTML={{__html: iconSprite}} />
+				</InfoWrapper>
+			</div>
+		)
+	)
+	.addWithInfo(
 		'has hero - color',
 		'This is the component with an extended header.',
 		() => (

--- a/src/interactive/modal.test.js
+++ b/src/interactive/modal.test.js
@@ -151,13 +151,13 @@ describe('Modal hero header', () => {
 describe('Modal positioning', () => {
 
 	it('returns the default margin top if the user is not below the fold', () => {
-		const calculatedPosition = getModalPosition(0, 400, false, false);
+		const calculatedPosition = getModalPosition(0, 400, false, false, false);
 		expect(calculatedPosition).toBe(DEFAULT_MARGIN_TOP);
 	});
 
 	it('always returns 0px when full screen prop is set', () => {
-		const calculatedPositionAtTop = getModalPosition(0, 400, true, false);
-		const calculatedPositionBelowFold = getModalPosition(800, 400, true, false);
+		const calculatedPositionAtTop = getModalPosition(0, 400, true, false, false);
+		const calculatedPositionBelowFold = getModalPosition(800, 400, true, false, false);
 
 		expect(calculatedPositionAtTop).toBe('0px');
 		expect(calculatedPositionBelowFold).toBe('0px');
@@ -165,14 +165,25 @@ describe('Modal positioning', () => {
 
 	it('returns scroll position + MARGIN_TOP_OFFSET when modal is not full screen and user is below fold', () => {
 		const scrollPosition = 800;
-		const calculatedPosition = getModalPosition(scrollPosition, 400, false, false);
+		const calculatedPosition = getModalPosition(scrollPosition, 400, false, false, false);
 		expect(calculatedPosition).toBe(scrollPosition + MARGIN_TOP_OFFSET);
 	});
 
-	it('returns scroll position *without gutter* when modal is below fold and viewport is mobile size', () => {
+	it('returns scroll position + MARGIN_TOP_OFFSET when modal is not full screen and user is below fold', () => {
 		const scrollPosition = 800;
-		const calculatedPosition = getModalPosition(scrollPosition, 400, false, true);
+		const calculatedPosition = getModalPosition(scrollPosition, 400, false, false, false);
+		expect(calculatedPosition).toBe(scrollPosition + MARGIN_TOP_OFFSET);
+	});
+
+	it('returns scroll position when modal is below fold and viewport is mobile size && is set to be fixed position on desktop', () => {
+		const scrollPosition = 800;
+		const calculatedPosition = getModalPosition(scrollPosition, 400, false, false, true);
 		expect(calculatedPosition).toBe(scrollPosition);
+	});
+
+	it('returns scroll position when modal is below fold and viewport is mobile size && is set to be fixed position on desktop', () => {
+		const calculatedPosition = getModalPosition(4000, 400, false, true, false);
+		expect(calculatedPosition).toBe(DEFAULT_MARGIN_TOP);
 	});
 
 });


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-74

#### Description
- since i couldn't think of a reliable way of having modals fixed position yet scrollable I added this as an optional modal for when you need to be able to pull a modal out of the "flow" of the page to be fixed. Good example of this is cancel an event which is a modal inside of a `.card` which has a relative position on it this is causes modals to display inside of the card 😢 

#### Screenshots (if applicable)

#### What was happening:
<img width="605" alt="screen shot 2017-09-18 at 4 55 24 pm" src="https://user-images.githubusercontent.com/1933722/30564247-68c04236-9c92-11e7-90f4-42abf22e8db3.png">
#### Now:
<img width="577" alt="screen shot 2017-09-18 at 4 57 49 pm" src="https://user-images.githubusercontent.com/1933722/30564294-8f204dfe-9c92-11e7-96b6-c93df4897d52.png">
