### PR TITLE
AvatarMember - Support thumbnails on small avatars

### DIFF
--- a/src/media/AvatarMember.jsx
+++ b/src/media/AvatarMember.jsx
@@ -14,9 +14,9 @@ export const AVATAR_PERSON_NOPHOTO_CLASS = 'avatar--noPhoto';
  */
 class AvatarMember extends React.PureComponent {
 	render() {
-		const { member, org, fbFriend, className, small, ...other } = this.props;
+		const { member, org, fbFriend, className, big, large, xxlarge, ...other } = this.props;
 
-		const photoLink = small ? 'thumb_link' : 'photo_link';
+		const photoLink = big || large || xxlarge ? 'photo_link' : 'thumb_link';
 		const showNoPhoto = (member.photo || {})[photoLink] == undefined;
 
 		const classNames = cx(
@@ -36,7 +36,9 @@ class AvatarMember extends React.PureComponent {
 				alt={member.name}
 				src={showNoPhoto ? noPhotoImage : member.photo[photoLink]}
 				className={classNames}
-				small={small}
+				big={big}
+				large={large}
+				xxlarge={xxlarge}
 				{...other}
 			/>
 		);
@@ -44,7 +46,9 @@ class AvatarMember extends React.PureComponent {
 }
 
 AvatarMember.propTypes = {
-	small: PropTypes.bool,
+	big: PropTypes.bool,
+	large: PropTypes.bool,
+	xxlarge: PropTypes.bool,
 	member: PropTypes.object.isRequired,
 	org: PropTypes.bool,
 	fbFriend: PropTypes.bool,

--- a/src/media/AvatarMember.jsx
+++ b/src/media/AvatarMember.jsx
@@ -14,7 +14,8 @@ export const AVATAR_PERSON_NOPHOTO_CLASS = 'avatar--noPhoto';
  */
 class AvatarMember extends React.PureComponent {
 	render() {
-		const { member, org, fbFriend, className, big, large, xxlarge, ...other } = this.props;
+		const { member, org, fbFriend, className, ...other } = this.props;
+		const { big, large, xxlarge } = other;
 
 		const photoLink = big || large || xxlarge ? 'photo_link' : 'thumb_link';
 		const showNoPhoto = (member.photo || {})[photoLink] == undefined;
@@ -36,9 +37,6 @@ class AvatarMember extends React.PureComponent {
 				alt={member.name}
 				src={showNoPhoto ? noPhotoImage : member.photo[photoLink]}
 				className={classNames}
-				big={big}
-				large={large}
-				xxlarge={xxlarge}
 				{...other}
 			/>
 		);

--- a/src/media/AvatarMember.jsx
+++ b/src/media/AvatarMember.jsx
@@ -14,22 +14,17 @@ export const AVATAR_PERSON_NOPHOTO_CLASS = 'avatar--noPhoto';
  */
 class AvatarMember extends React.PureComponent {
 	render() {
-		const {
-			member,
-			org,
-			fbFriend,
-			className,
-			...other
-		} = this.props;
+		const { member, org, fbFriend, className, small, ...other } = this.props;
 
-		const showNoPhoto = (member.photo || {}).photo_link == undefined;
+		const photoLink = small ? 'thumb_link' : 'photo_link';
+		const showNoPhoto = (member.photo || {})[photoLink] == undefined;
 
 		const classNames = cx(
 			AVATAR_PERSON_CLASS,
 			{
 				[AVATAR_PERSON_ORG_CLASS]: org,
 				[AVATAR_PERSON_FB_CLASS]: fbFriend,
-				[AVATAR_PERSON_NOPHOTO_CLASS]: showNoPhoto
+				[AVATAR_PERSON_NOPHOTO_CLASS]: showNoPhoto,
 			},
 			className
 		);
@@ -39,20 +34,20 @@ class AvatarMember extends React.PureComponent {
 		return (
 			<Avatar
 				alt={member.name}
-				src={showNoPhoto ? noPhotoImage : member.photo.photo_link}
+				src={showNoPhoto ? noPhotoImage : member.photo[photoLink]}
 				className={classNames}
+				small={small}
 				{...other}
-			>
-			</Avatar>
+			/>
 		);
 	}
 }
 
 AvatarMember.propTypes = {
+	small: PropTypes.bool,
 	member: PropTypes.object.isRequired,
 	org: PropTypes.bool,
 	fbFriend: PropTypes.bool,
 };
 
 export default AvatarMember;
-

--- a/src/media/avatarmember.test.js
+++ b/src/media/avatarmember.test.js
@@ -1,47 +1,64 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import { shallow } from 'enzyme';
 import { MOCK_MEMBER } from 'meetup-web-mocks/lib/api';
-import AvatarMember, { AVATAR_PERSON_CLASS, AVATAR_PERSON_NOPHOTO_CLASS} from './AvatarMember';
+import AvatarMember, { AVATAR_PERSON_CLASS, AVATAR_PERSON_NOPHOTO_CLASS } from './AvatarMember';
+import Avatar from './Avatar';
 import Icon from './Icon';
 
 describe('AvatarMember', function() {
 	it('exists', function() {
-		const avatarMember = TestUtils.renderIntoDocument(<AvatarMember member={MOCK_MEMBER} />);
-		expect(() => TestUtils.findRenderedComponentWithType(avatarMember, AvatarMember)).not.toThrow();
+		const avatarMember = shallow(<AvatarMember member={MOCK_MEMBER} />);
+		expect(avatarMember.exists()).toBe(true);
 	});
 
 	it('applies avatar--person variant class', function() {
-		const avatarMember = TestUtils.renderIntoDocument(<AvatarMember member={MOCK_MEMBER} />);
-		expect(() => TestUtils.findRenderedDOMComponentWithClass(avatarMember, AVATAR_PERSON_CLASS)).not.toThrow();
+		const avatarMember = shallow(<AvatarMember member={MOCK_MEMBER} />);
+		expect(avatarMember.find(`.${AVATAR_PERSON_CLASS}`).exists()).toBe(true);
 	});
 
 	it('renders the noPhoto variant only when a photo is not present', function() {
 		const MOCK_MEMBER_NO_PHOTO = { ...MOCK_MEMBER };
 		MOCK_MEMBER_NO_PHOTO.photo = {};
 
-		const avatarMember = TestUtils.renderIntoDocument(<AvatarMember member={MOCK_MEMBER_NO_PHOTO} />);
-		expect(() => TestUtils.findRenderedDOMComponentWithClass(avatarMember, AVATAR_PERSON_NOPHOTO_CLASS)).not.toThrow();
+		const avatarMember = shallow(<AvatarMember member={MOCK_MEMBER_NO_PHOTO} />);
+		expect(avatarMember.find(`.${AVATAR_PERSON_NOPHOTO_CLASS}`).exists()).toBe(true);
+	});
+
+	it('should render member photo on regular size', () => {
+		const mockPhoto = 'photo image';
+		const mockMember = {
+			...MOCK_MEMBER,
+			photo: { ...MOCK_MEMBER.photo, photo_link: mockPhoto },
+		};
+		const avatarMember = shallow(<AvatarMember member={mockMember} />);
+		expect(avatarMember.find(Avatar).prop('src')).toBe(mockPhoto);
+	});
+
+	it('should render thumbnail photo on small size', () => {
+		const mockPhoto = 'thumb image';
+		const mockMember = {
+			...MOCK_MEMBER,
+			photo: { ...MOCK_MEMBER.photo, thumb_link: mockPhoto },
+		};
+		const avatarMember = shallow(<AvatarMember member={mockMember} small />);
+		expect(avatarMember.find(Avatar).prop('src')).toBe(mockPhoto);
 	});
 
 	it('should *not* render the noPhoto variant only when a photo is present', function() {
-		const avatarMember = TestUtils.renderIntoDocument(<AvatarMember member={MOCK_MEMBER} />);
-		expect(() => TestUtils.findRenderedDOMComponentWithClass(avatarMember, AVATAR_PERSON_NOPHOTO_CLASS)).toThrow();
-		expect(() => TestUtils.findRenderedComponentWithType(avatarMember, Icon)).toThrow();
+		const avatarMember = shallow(<AvatarMember member={MOCK_MEMBER} />);
+		expect(avatarMember.find(`.${AVATAR_PERSON_NOPHOTO_CLASS}`).exists()).toBe(false);
+		expect(avatarMember.find(Icon).exists()).toBe(false);
 	});
 
 	it('applies variant classes for each variant prop', function() {
-		const variants = [
-			'org',
-			'fbFriend',
-		];
+		const variants = ['org', 'fbFriend'];
 		variants.forEach(variant => {
 			const props = {
 				[variant]: true,
 				member: MOCK_MEMBER,
 			};
-			const avatarMember = TestUtils.renderIntoDocument(<AvatarMember {...props} />);
-			expect(() => TestUtils.findRenderedDOMComponentWithClass(avatarMember, `avatar--${variant}`)).not.toThrow();
+			const avatarMember = shallow(<AvatarMember {...props} />);
+			expect(avatarMember.find(`.avatar--${variant}`).exists()).toBe(true);
 		});
 	});
 });
-

--- a/src/media/avatarmember.test.js
+++ b/src/media/avatarmember.test.js
@@ -24,11 +24,21 @@ describe('AvatarMember', function() {
 		expect(avatarMember.find(`.${AVATAR_PERSON_NOPHOTO_CLASS}`).exists()).toBe(true);
 	});
 
-	it('should render member photo on regular size', () => {
+	it('should render member photo on large size', () => {
 		const mockPhoto = 'photo image';
 		const mockMember = {
 			...MOCK_MEMBER,
 			photo: { ...MOCK_MEMBER.photo, photo_link: mockPhoto },
+		};
+		const avatarMember = shallow(<AvatarMember member={mockMember} large />);
+		expect(avatarMember.find(Avatar).prop('src')).toBe(mockPhoto);
+	});
+
+	it('should render thumbnail photo on regular size', () => {
+		const mockPhoto = 'photo image';
+		const mockMember = {
+			...MOCK_MEMBER,
+			photo: { ...MOCK_MEMBER.photo, thumb_link: mockPhoto },
 		};
 		const avatarMember = shallow(<AvatarMember member={mockMember} />);
 		expect(avatarMember.find(Avatar).prop('src')).toBe(mockPhoto);
@@ -45,7 +55,11 @@ describe('AvatarMember', function() {
 	});
 
 	it('should *not* render the noPhoto variant only when a photo is present', function() {
-		const avatarMember = shallow(<AvatarMember member={MOCK_MEMBER} />);
+		const mockMember = {
+			...MOCK_MEMBER,
+			photo: { ...MOCK_MEMBER.photo, thumb_link: 'test image' },
+		};
+		const avatarMember = shallow(<AvatarMember member={mockMember} />);
 		expect(avatarMember.find(`.${AVATAR_PERSON_NOPHOTO_CLASS}`).exists()).toBe(false);
 		expect(avatarMember.find(Icon).exists()).toBe(false);
 	});


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-424

#### Description
This PR updates the `AvatarMember` component to support thumbnails on small sizes in order to optimize for the smaller sized images.

#### Screenshots
<img width="996" alt="screen shot 2017-09-22 at 2 46 47 pm" src="https://user-images.githubusercontent.com/2153230/30759619-e00c5090-9fa4-11e7-9d24-04a3f4870510.png">
