### PR TITLE
Fix <Flex> layout issues for older browsers

### DIFF
--- a/assets/scss/components/_flex.scss
+++ b/assets/scss/components/_flex.scss
@@ -77,7 +77,7 @@ Breakpoints        | Direction       | Description
 	@include flexParent('column', false);
 	height: 100%;
 	> .flex-item {
-		-ms-flex-preferred-size: auto;
+		@include flex-basis(auto);
 		width: 100%;
 		padding-left: 0;
 	}
@@ -88,6 +88,7 @@ Breakpoints        | Direction       | Description
 	height: auto;
 	> .flex-item {
 		@include responsiveVarContext--base() {
+			@include flex-basis(0);
 			padding-left: $base;
 		}
 		width: auto;

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "storybook-addon-i18n-tools": "1.0.0",
     "style-loader": "0.18.2",
     "swarm-icons": "1.3.183",
-    "swarm-sasstools": "1.7.117",
+    "swarm-sasstools": "1.7.128",
     "webpack": "2.6.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6376,24 +6376,25 @@ svgo@^0.7.0:
     jasmine-jquery "^2.1.1"
     jquery "^3.2.1"
 
-swarm-constants@0.1.16:
-  version "0.1.16"
-  resolved "https://registry.yarnpkg.com/swarm-constants/-/swarm-constants-0.1.16.tgz#af7476970d2cb8a749802bc7d28c04eaa497ff8d"
+swarm-constants@0.2.31:
+  version "0.2.31"
+  resolved "https://registry.yarnpkg.com/swarm-constants/-/swarm-constants-0.2.31.tgz#be86eb4076784ec2709ebbb404213639a84aef23"
   dependencies:
     "@alrra/travis-scripts" "^3.0.1"
     gh-pages "^1.0.0"
+    mkdirp "^0.5.1"
 
 swarm-icons@1.3.183:
   version "1.3.183"
   resolved "https://registry.yarnpkg.com/swarm-icons/-/swarm-icons-1.3.183.tgz#89b2033334f53003c1401499452eee1addecce4b"
 
-swarm-sasstools@1.7.117:
-  version "1.7.117"
-  resolved "https://registry.yarnpkg.com/swarm-sasstools/-/swarm-sasstools-1.7.117.tgz#69f416bc20b6e907ca48e9336007a83f99f3f721"
+swarm-sasstools@1.7.128:
+  version "1.7.128"
+  resolved "https://registry.yarnpkg.com/swarm-sasstools/-/swarm-sasstools-1.7.128.tgz#113fbb541266c6c520147b630c2cad99d2c85c55"
   dependencies:
     bourbon "4.2.3"
     sass-rem "^1.2.4"
-    swarm-constants "0.1.16"
+    swarm-constants "0.2.31"
 
 symbol-observable@^1.0.1, symbol-observable@^1.0.3, symbol-observable@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/MW-1983

#### Description
Corrects flexbox layout issues being seen in browsers like IE11 which still use follow some of the rules from an older flexbox spec

#### Screenshots (if applicable)
![smscreens](https://user-images.githubusercontent.com/2313998/30877312-4f3c3fe6-a2c7-11e7-86f4-c38d8315db10.png)
![lgscreens](https://user-images.githubusercontent.com/2313998/30880330-3d0e48e2-a2d0-11e7-9f61-06d7bbc5d0da.png)


