### PR TITLE
WC-105: Remove duplicate onClick in bindAll; Add preventDefault to onClick handler

### DIFF
--- a/src/interactive/Dropdown.jsx
+++ b/src/interactive/Dropdown.jsx
@@ -32,6 +32,10 @@ class Dropdown extends React.PureComponent {
 	onClick(e) {
 		e.preventDefault();
 		this.toggleContent();
+
+		if (this.props.onClick) {
+			this.props.onClick(e);
+		}
 	}
 
 	onKeyDown(e) {
@@ -76,6 +80,10 @@ class Dropdown extends React.PureComponent {
 			align, // eslint-disable-line no-unused-vars
 			...other
 		} = this.props;
+
+		// this.props.onClick is consumed in this.onClick
+		// Do not pass along to children
+		delete other.onClick;
 
 		const classNames = {
 			dropdown: cx(

--- a/src/interactive/Dropdown.jsx
+++ b/src/interactive/Dropdown.jsx
@@ -14,7 +14,6 @@ class Dropdown extends React.PureComponent {
 			'toggleContent',
 			'onClick',
 			'onKeyDown',
-			'onClick',
 			'onBodyClick',
 			'onBodyKeyDown'
 		);
@@ -31,6 +30,7 @@ class Dropdown extends React.PureComponent {
 	}
 
 	onClick(e) {
+		e.preventDefault();
 		this.toggleContent();
 	}
 


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-105

#### Description
I may have been the first to notice this because I have this component within a `form` element.