### PR TITLE
SDS-430: add validateBeforeTouched option to ReduxFormTextInput

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 3.0.$(CI_BUILD_NUMBER)
+VERSION ?= 3.1.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/src/forms/redux-form/TextInput.jsx
+++ b/src/forms/redux-form/TextInput.jsx
@@ -8,9 +8,10 @@ import TextInput from '../TextInput';
  * @return {Component} TextInput
  */
 const ReduxFormTextInput = props => {
-	const { meta, input, ...other } = props;
+	const { meta, input, validateAfterTouched, ...other } = props;
+	const error = (!validateAfterTouched || meta.touched) ? meta.error : null;
 
-	return <TextInput error={meta.error} {...input} {...other} />;
+	return <TextInput error={error} {...input} {...other} />;
 };
 
 ReduxFormTextInput.displayName = 'ReduxFormTextInput';

--- a/src/forms/redux-form/TextInput.jsx
+++ b/src/forms/redux-form/TextInput.jsx
@@ -8,8 +8,8 @@ import TextInput from '../TextInput';
  * @return {Component} TextInput
  */
 const ReduxFormTextInput = props => {
-	const { meta, input, validateAfterTouched, ...other } = props;
-	const error = (!validateAfterTouched || meta.touched) ? meta.error : null;
+	const { meta, input, validateBeforeTouched, ...other } = props;
+	const error = (validateBeforeTouched || meta.touched) ? meta.error : null;
 
 	return <TextInput error={error} {...input} {...other} />;
 };

--- a/src/forms/redux-form/__snapshots__/textInput.test.jsx.snap
+++ b/src/forms/redux-form/__snapshots__/textInput.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`redux-form TextInput renders a TextInput component with expected attributes from mock data 1`] = `
 <TextInput
-  error="Did you mean Batman and Robin?"
+  error={null}
   label="Super Hero"
   maxLength={20}
   name="superhero"

--- a/src/forms/redux-form/textInput.test.jsx
+++ b/src/forms/redux-form/textInput.test.jsx
@@ -4,6 +4,7 @@ import ReduxFormTextInput from './TextInput';
 
 describe('redux-form TextInput', function() {
 
+	const MOCK_ERROR = 'Did you mean Batman and Robin?';
 	const formAttrs = {
 		input: {
 			label: 'Super Hero',
@@ -13,7 +14,7 @@ describe('redux-form TextInput', function() {
 			required: true
 		},
 		meta: {
-			error: 'Did you mean Batman and Robin?'
+			error: MOCK_ERROR
 		}
 	};
 
@@ -21,7 +22,39 @@ describe('redux-form TextInput', function() {
 		const component = shallow(<ReduxFormTextInput {...formAttrs} />);
 
 		expect(component).toMatchSnapshot();
+	});
 
+	describe('validateAfterTouched', () => {
+		it('always renders the error when `validateAfterTouched` is not true', () => {
+			const component = shallow(<ReduxFormTextInput {...formAttrs} />);
+			expect(component.prop('error')).toBe(MOCK_ERROR);
+		});
+		describe('when true', () => {
+			it('does not render the error when touched is false', () => {
+				const props = {
+					...formAttrs,
+					meta: {
+						touched: false,
+						error: MOCK_ERROR
+					},
+					validateAfterTouched: true
+				};
+				const component = shallow(<ReduxFormTextInput {...props} />);
+				expect(component.prop('error')).toBe(null);
+			});
+			it('does render the error when touched is true', () => {
+				const props = {
+					...formAttrs,
+					meta: {
+						touched: true,
+						error: MOCK_ERROR
+					},
+					validateAfterTouched: true
+				};
+				const component = shallow(<ReduxFormTextInput {...props} />);
+				expect(component.prop('error')).toBe(MOCK_ERROR);
+			});
+		});
 	});
 
 });

--- a/src/forms/redux-form/textInput.test.jsx
+++ b/src/forms/redux-form/textInput.test.jsx
@@ -20,37 +20,34 @@ describe('redux-form TextInput', function() {
 
 	it('renders a TextInput component with expected attributes from mock data', () => {
 		const component = shallow(<ReduxFormTextInput {...formAttrs} />);
-
 		expect(component).toMatchSnapshot();
 	});
 
-	describe('validateAfterTouched', () => {
-		it('always renders the error when `validateAfterTouched` is not true', () => {
-			const component = shallow(<ReduxFormTextInput {...formAttrs} />);
-			expect(component.prop('error')).toBe(MOCK_ERROR);
-		});
+	describe('validateBeforeTouched', () => {
 		describe('when true', () => {
+			const props = {
+				...formAttrs,
+				meta: {
+					touched: false,
+					error: MOCK_ERROR
+				},
+				validateBeforeTouched: false
+			};
 			it('does not render the error when touched is false', () => {
-				const props = {
-					...formAttrs,
-					meta: {
-						touched: false,
-						error: MOCK_ERROR
-					},
-					validateAfterTouched: true
-				};
 				const component = shallow(<ReduxFormTextInput {...props} />);
 				expect(component.prop('error')).toBe(null);
 			});
 			it('does render the error when touched is true', () => {
-				const props = {
-					...formAttrs,
-					meta: {
-						touched: true,
-						error: MOCK_ERROR
-					},
-					validateAfterTouched: true
-				};
+				props.meta.touched = true;
+				props.validateBeforeTouched = false;
+
+				const component = shallow(<ReduxFormTextInput {...props} />);
+				expect(component.prop('error')).toBe(MOCK_ERROR);
+			});
+			it('always renders the error when validateBeforeTouched is true', () => {
+				props.meta.touched = false;
+				props.validateBeforeTouched = true;
+
 				const component = shallow(<ReduxFormTextInput {...props} />);
 				expect(component.prop('error')).toBe(MOCK_ERROR);
 			});


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-430

#### Description
For field-level validations, redux-form automatically validates on first render unless you check for validation on whether the field has been touched.

It seems as though this is intended behavior.
https://github.com/erikras/redux-form/issues/120
>This is the purpose of the touched flags. In most UI cases, you should only show an error if a field has been touched (gone to and then blurred). There is also a visited flag, which is set to true onFocus. There's a working example of how the flags work here.
>Does that help?

Docs for `meta.touched`: https://redux-form.com/7.0.4/docs/api/field.md/#-code-meta-touched-boolean-code-

This ticket is to adjust the current `ReduxFormTextInput` implementation to take a flag that, when passed in, does not show the initial validation error until after the field has been touched. This is to prevent having to check for this in all form implementations we have.

#### Screenshots (if applicable)
Add venue form on first load, with these fields being required:
![screen shot 2017-10-04 at 5 04 30 pm](https://user-images.githubusercontent.com/1224149/31199725-4f915e94-a926-11e7-9203-d92d01fee6e4.png)

