### PR TITLE
Accordion - added the ability to have a toggle control instead of icon

### DIFF
--- a/assets/scss/components/_accordion.scss
+++ b/assets/scss/components/_accordion.scss
@@ -7,6 +7,10 @@ $A_curve-fast-out-slow-in: cubic-bezier(0.4, 0, 0.2, 1);
 $A_curve-default: $A_curve-fast-out-slow-in;
 $A_duration: 0.2s;
 
+.accordion--hideFocus .accordionPanel-label:focus {
+	outline: 0;
+}
+
 .accordionPanel-animator {
 	overflow: hidden;
 	transition: height $A_duration $A_curve-default;
@@ -15,7 +19,8 @@ $A_duration: 0.2s;
 
 .accordionPanel-animator--collapse {
 	height: 0;
-	margin-bottom: 0 !important;
+	padding-bottom: 0 !important;
+	visibility: hidden;
 }
 
 .accordionPanel-label {

--- a/src/interactive/AccordionPanel.jsx
+++ b/src/interactive/AccordionPanel.jsx
@@ -6,6 +6,7 @@ import Chunk from '../layout/Chunk';
 import Flex from '../layout/Flex';
 import FlexItem from '../layout/FlexItem';
 import Icon from '../media/Icon';
+import TogglePill from '../forms/TogglePill';
 
 export const PANEL_CLASS = 'accordionPanel';
 export const ACTIVEPANEL_CLASS = 'accordionPanel--active';
@@ -79,13 +80,13 @@ class AccordionPanel extends React.Component {
 	 */
 	getIconShape() {
 		const {
-			iconShape,
-			iconShapeActive
+			indicatorIcon,
+			indicatorIconActive
 		} = this.props;
 
-		return this.state.isOpen && iconShapeActive ?
-			iconShapeActive :
-			iconShape;
+		return this.state.isOpen && indicatorIconActive ?
+			indicatorIconActive :
+			indicatorIcon;
 	}
 
 	render() {
@@ -94,12 +95,14 @@ class AccordionPanel extends React.Component {
 			label,
 			isOpen, // eslint-disable-line no-unused-vars
 			setClickedPanel, // eslint-disable-line no-unused-vars
-			iconAlign, // eslint-disable-line no-unused-vars
-			iconShape, // eslint-disable-line no-unused-vars
-			iconSize, // eslint-disable-line no-unused-vars
-			iconShapeActive, // eslint-disable-line no-unused-vars
+			indicatorAlign, // eslint-disable-line no-unused-vars
+			indicatorIcon, // eslint-disable-line no-unused-vars
+			indicatorIconActive, // eslint-disable-line no-unused-vars
+			indicatorIconSize,
+			indicatorSwitch,
 			classNamesActive,
 			className,
+			// isActive,
 			...other
 		} = this.props;
 
@@ -114,7 +117,7 @@ class AccordionPanel extends React.Component {
 			),
 			trigger: cx(
 				className,
-				'accordionPanel-label display--block span--100'
+				'accordionPanel-label display--block span--100 padding--bottom'
 			),
 			content: cx(
 				'accordionPanel-animator',
@@ -127,27 +130,27 @@ class AccordionPanel extends React.Component {
 		// create valid attribute name from trigger label
 		const ariaId = label.replace(/\s+/g, '').toLowerCase();
 
+		// console.log(this.props);
+
 		return(
 			<Flex
 				className={classNames.accordionPanel}
-				rowReverse={iconAlign === 'left' && 'all'}
+				rowReverse={indicatorAlign === 'left' && 'all'}
 				{...other}
 			>
 
 				<FlexItem>
-					<Chunk>
-						<button
-							role='tab'
-							id={`label-${ariaId}`}
-							aria-controls={`panel-${ariaId}`}
-							aria-expanded={this.state.isOpen}
-							aria-selected={this.state.isOpen}
-							className={classNames.trigger}
-							onClick={this._handleToggle}
-						>
-							{label}
-						</button>
-					</Chunk>
+					<button
+						role='tab'
+						id={`label-${ariaId}`}
+						aria-controls={`panel-${ariaId}`}
+						aria-expanded={this.state.isOpen}
+						aria-selected={this.state.isOpen}
+						className={classNames.trigger}
+						onClick={this._handleToggle}
+					>
+						{label}
+					</button>
 
 					<Chunk
 						role='tabpanel'
@@ -167,10 +170,23 @@ class AccordionPanel extends React.Component {
 
 				<FlexItem
 					className='accordionPanel-icon'
-					onClick={this._handleToggle}
+					onClick={!indicatorSwitch && this._handleToggle}
 					shrink
 				>
-					<Icon shape={this.getIconShape()} size={iconSize} />
+					{
+						!indicatorSwitch && indicatorIcon
+							? <Icon shape={this.getIconShape()} size={indicatorIconSize} />
+							: // TogglePill to be replaced by ToggleSwitch once https://github.com/meetup/meetup-web-components/pull/305 merges
+							<TogglePill
+								isActive={this.state.isOpen}
+								id={`${ariaId}-switch`}
+								name={ariaId}
+								value='toggle-pill'
+								onClick={this._handleToggle}
+							>
+								<span>{this.state.isOpen ? 'on' : 'off'}</span>
+							</TogglePill>
+					}
 				</FlexItem>
 
 			</Flex>
@@ -180,9 +196,9 @@ class AccordionPanel extends React.Component {
 
 AccordionPanel.defaultProps = {
 	isOpen: false,
-	iconAlign: 'right',
-	iconShape: 'chevron-down',
-	iconSize: 'xs'
+	indicatorAlign: 'right',
+	indicatorIcon: 'chevron-down',
+	indicatorIconSize: 'xs'
 };
 
 AccordionPanel.propTypes = {
@@ -192,10 +208,11 @@ AccordionPanel.propTypes = {
 	onClick: PropTypes.func,
 	label: PropTypes.string.isRequired,
 	className: PropTypes.string,
-	iconAlign: PropTypes.string,
-	iconShape: PropTypes.string,
-	iconShapeActive: PropTypes.string,
-	iconSize: PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl'])
+	indicatorAlign: PropTypes.string,
+	indicatorIcon: PropTypes.element,
+	indicatorIconActive: PropTypes.element,
+	indicatorIconSize: PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl']),
+	indicatorSwitch: PropTypes.bool
 };
 
 export default AccordionPanel;

--- a/src/interactive/AccordionPanel.jsx
+++ b/src/interactive/AccordionPanel.jsx
@@ -209,8 +209,8 @@ AccordionPanel.propTypes = {
 	label: PropTypes.string.isRequired,
 	className: PropTypes.string,
 	indicatorAlign: PropTypes.string,
-	indicatorIcon: PropTypes.element,
-	indicatorIconActive: PropTypes.element,
+	indicatorIcon: PropTypes.string,
+	indicatorIconActive: PropTypes.string,
 	indicatorIconSize: PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl']),
 	indicatorSwitch: PropTypes.bool
 };

--- a/src/interactive/AccordionPanelGroup.jsx
+++ b/src/interactive/AccordionPanelGroup.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import cx from 'classnames';
 
 export const ACCORDIONPANELGROUP_CLASS = 'accordionPanelGroup';
+
 /**
  * @module AccordionPanelGroup
  */
@@ -42,10 +43,10 @@ class AccordionPanelGroup extends React.Component {
 	clonePanel(accordionPanel, key, isOpen) {
 		const panelProps = {
 			key,
-			iconAlign: this.props.iconAlign,
-			iconSize: this.props.iconSize,
-			iconShape: this.props.iconShape,
-			iconShapeActive: this.props.iconShapeActive,
+			indicatorAlign: this.props.indicatorAlign,
+			indicatorIcon: this.props.indicatorIcon,
+			indicatorIconActive: this.props.indicatorIconActive,
+			indicatorSwitch: this.props.indicatorSwitch,
 			className: accordionPanel.props.className,
 			setClickedPanel: this.setClickedPanel,
 			isOpen: accordionPanel.props.isOpen
@@ -64,10 +65,10 @@ class AccordionPanelGroup extends React.Component {
 	render() {
 		const {
 			accordionPanels, // eslint-disable-line no-unused-vars
-			iconAlign, // eslint-disable-line no-unused-vars
-			iconShape, // eslint-disable-line no-unused-vars
-			iconSize, // eslint-disable-line no-unused-vars
-			iconShapeActive, // eslint-disable-line no-unused-vars
+			indicatorAlign, // eslint-disable-line no-unused-vars
+			indicatorIcon, // eslint-disable-line no-unused-vars
+			indicatorIconActive, // eslint-disable-line no-unused-vars
+			indicatorSwitch, // eslint-disable-line no-unused-vars
 			multiSelectable,
 			className,
 			...other
@@ -97,19 +98,20 @@ class AccordionPanelGroup extends React.Component {
 }
 
 AccordionPanelGroup.defaultProps = {
+	indicatorAlign: 'right',
+	indicatorIcon: 'chevron-down',
 	multiSelectable: true,
-	iconAlign: 'right',
-	iconShape: 'chevron-down',
-	iconSize: 'xs'
+	indicatorIconSize: 'xs'
 };
 
 AccordionPanelGroup.propTypes = {
 	accordionPanels: PropTypes.arrayOf(PropTypes.element).isRequired,
 	multiSelectable: PropTypes.bool,
-	iconAlign: PropTypes.string,
-	iconShape: PropTypes.string,
-	iconShapeActive: PropTypes.string,
-	iconSize: PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl'])
+	indicatorAlign: PropTypes.string,
+	indicatorIcon: PropTypes.element,
+	indicatorIconActive: PropTypes.element,
+	indicatorIconSize: PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl']),
+	indicatorSwitch: PropTypes.bool
 };
 
 export default AccordionPanelGroup;

--- a/src/interactive/AccordionPanelGroup.jsx
+++ b/src/interactive/AccordionPanelGroup.jsx
@@ -68,6 +68,7 @@ class AccordionPanelGroup extends React.Component {
 			indicatorAlign, // eslint-disable-line no-unused-vars
 			indicatorIcon, // eslint-disable-line no-unused-vars
 			indicatorIconActive, // eslint-disable-line no-unused-vars
+			indicatorIconSize, // eslint-disable-line no-unused-vars
 			indicatorSwitch, // eslint-disable-line no-unused-vars
 			multiSelectable,
 			className,
@@ -108,8 +109,8 @@ AccordionPanelGroup.propTypes = {
 	accordionPanels: PropTypes.arrayOf(PropTypes.element).isRequired,
 	multiSelectable: PropTypes.bool,
 	indicatorAlign: PropTypes.string,
-	indicatorIcon: PropTypes.element,
-	indicatorIconActive: PropTypes.element,
+	indicatorIcon: PropTypes.string,
+	indicatorIconActive: PropTypes.string,
 	indicatorIconSize: PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl']),
 	indicatorSwitch: PropTypes.bool
 };

--- a/src/interactive/accordion.story.jsx
+++ b/src/interactive/accordion.story.jsx
@@ -55,14 +55,14 @@ storiesOf('Accordion', module)
 		)
 	)
 	.addWithInfo(
-		'Custom icons',
+		'Custom icon indicator',
 		'Adds custom icons via AccordionPanelGroup props',
 		() => (
 			<InfoWrapper>
 				<div className='span--100 padding--all'>
 					<AccordionPanelGroup
-						iconShape='plus'
-						iconShapeActive='minus'
+						indicatorIcon='plus'
+						indicatorIconActive='minus'
 						accordionPanels={[
 							<AccordionPanel
 								label='First with custom icon'
@@ -98,13 +98,55 @@ storiesOf('Accordion', module)
 		)
 	)
 	.addWithInfo(
+		'ToggleSwitch indicator',
+		'Show the indicator as a switch',
+		() => (
+			<InfoWrapper>
+				<div className='span--100 padding--all'>
+					<AccordionPanelGroup
+						indicatorSwitch
+						accordionPanels={[
+							<AccordionPanel
+								label='First with switch'
+								panelContent={
+									<div className='runningText'>
+										<p>Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.</p>
+									</div>
+								} />,
+							<AccordionPanel
+								label='Second with switch'
+								panelContent={
+									<div>
+										<div className='runningText'>
+											<p>Any kind of content can go in here, even inputs.</p>
+										</div>
+										<div className='chunk'>
+											<label htmlFor='test-textinput'>I'm a label</label>
+											<input id='test-textinput' type='text' placeholder='Input placeholder' />
+										</div>
+									</div>
+								} />,
+							<AccordionPanel
+								label='Third with switch'
+								panelContent={
+									<div className='runningText'>
+										<p>Classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.</p>
+									</div>
+								} />,
+						]}/>
+					<div style={iconSpriteStyle} dangerouslySetInnerHTML={{__html: iconSprite}} />
+				</div>
+			</InfoWrapper>
+		)
+	)
+	.addWithInfo(
 		'Left-aligned icon',
 		'Aligns icons left using AccordionPanelGroup props',
 		() => (
 			<InfoWrapper>
 				<div className='span--100 padding--all'>
 					<AccordionPanelGroup
-						iconAlign='left'
+						indicatorAlign='left'
 						accordionPanels={[
 							<AccordionPanel
 								label='First with left icon'

--- a/src/interactive/accordion.test.jsx
+++ b/src/interactive/accordion.test.jsx
@@ -4,6 +4,7 @@ import TestUtils from 'react-addons-test-utils';
 import AccordionPanelGroup from './AccordionPanelGroup';
 import AccordionPanel, { ACTIVEPANEL_CLASS, PANEL_CLASS } from './AccordionPanel';
 import Icon from '../media/Icon';
+import TogglePill from '../forms/TogglePill'; // replace with ToggleSwitch
 
 describe('AccordionPanelGroup', function(){
 	let accordionPanelGroup,
@@ -88,7 +89,8 @@ describe('AccordionPanel', function() {
 	let panel,
 		openPanel,
 		panelCustomIcon,
-		panelLeftIcon;
+		panelLeftIcon,
+		panelSwitch;
 
 	const customIcon = 'plus';
 	const customIconActive = 'minus';
@@ -119,7 +121,7 @@ describe('AccordionPanel', function() {
 		panelLeftIcon = TestUtils.renderIntoDocument(
 			<AccordionPanel
 				label='First Section'
-				iconAlign='left'
+				indicatorAlign='left'
 				panelContent={
 					<div className='runningText'>
 						<p>Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.</p>
@@ -130,9 +132,21 @@ describe('AccordionPanel', function() {
 		panelCustomIcon = TestUtils.renderIntoDocument(
 			<AccordionPanel
 				label='First Section'
-				iconAlign='left'
-				iconShape={customIcon}
-				iconShapeActive={customIconActive}
+				indicatorAlign='left'
+				indicatorIcon={customIcon}
+				indicatorIconActive={customIconActive}
+				panelContent={
+					<div className='runningText'>
+						<p>Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.</p>
+					</div>
+				} />
+		);
+
+		panelSwitch = TestUtils.renderIntoDocument(
+			<AccordionPanel
+				label='First Section'
+				indicatorAlign='left'
+				indicatorSwitch
 				panelContent={
 					<div className='runningText'>
 						<p>Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.</p>
@@ -180,6 +194,20 @@ describe('AccordionPanel', function() {
 
 		const activeIconNode = TestUtils.scryRenderedDOMComponentsWithClass(panelCustomIcon, `svg--${customIconActive}`);
 		expect(activeIconNode.length).toBe(1);
+	});
+
+	it('should render a toggle switch', function(){
+		const node = TestUtils.scryRenderedComponentsWithType(panelSwitch, TogglePill); // replace with ToggleSwitch
+
+		expect(node.length).toBe(1);
+	});
+
+	it('changes state to be open when clicking toggle switch', function() {
+		const node = TestUtils.findRenderedDOMComponentWithTag(panelSwitch, 'input'); // replace with ToggleSwitch
+
+		expect(panelSwitch.state.isOpen).toBe(false);
+		TestUtils.Simulate.click(node);
+		expect(panelSwitch.state.isOpen).toBe(true);
 	});
 
 });

--- a/src/utils/WithToggleControl.jsx
+++ b/src/utils/WithToggleControl.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 /**
- * Provides boolean isChecked prop to wrapped component.
+ * Provides boolean isActive prop to wrapped component.
  * Prop name can also be customized if need be
  *
  * @param {React.element} ToggleComponent - the component to wrap
@@ -19,6 +19,13 @@ export default function withToggleControl(WrappedComponent) {
 			this.state = { isActive: props.isActive };
 			this.toggleActive = this.toggleBool.bind(this);
 		}
+
+		componentWillReceiveProps(nextProps) {
+			if (nextProps.isActive !== this.props.isActive) {
+				this.toggleActive();
+			}
+		}
+
 		toggleBool() {
 			this.setState({ isActive: !this.state.isActive });
 		}


### PR DESCRIPTION
re: Prelim label - Will remove once `<ToggleSwitch>` is merged and can be used here

#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-102

#### Description
Adds the ability to open and close panels with a toggle control instead of simply showing an icon

#### Screenshots (if applicable)
Will add when I replace `<TogglePill>` with the new `<ToggleSwitch>`
