### PR TITLE
Wc 106 redux form toggle

### DIFF
--- a/src/forms/redux-form/TogglePill.jsx
+++ b/src/forms/redux-form/TogglePill.jsx
@@ -21,8 +21,6 @@ const ReduxFormTogglePill = props => {
 		...other
 	} = props;
 
-	console.log(other, input);
-
 	return <TogglePill {...input} isActive={input.value == 'true' && !other.useRadio} {...other} />;
 };
 

--- a/src/forms/redux-form/TogglePill.jsx
+++ b/src/forms/redux-form/TogglePill.jsx
@@ -13,14 +13,17 @@ import TogglePill from '../TogglePill';
  * @return {Component} TogglePill
  */
 const ReduxFormTogglePill = props => {
+	// not adding meta error to TogglePill prop for now
+	// since TogglePills should function in a group with one error
 	const {
 		meta, // eslint-disable-line no-unused-vars
-		// not adding meta error to TogglePill prop for now
 		input,
 		...other
 	} = props;
 
-	return <TogglePill {...input} isActive={input.value == 'true'} {...other} />;
+	console.log(other, input);
+
+	return <TogglePill {...input} isActive={input.value == 'true' && !other.useRadio} {...other} />;
 };
 
 ReduxFormTogglePill.displayName = 'ReduxFormTogglePill';

--- a/src/forms/redux-form/TogglePill.jsx
+++ b/src/forms/redux-form/TogglePill.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import TogglePill from '../TogglePill';
+
+/**
+ * @param {Object} props - props passed in from parent and redux-form
+ * @description wraps standard TogglePill web component for use with redux-form
+ * deconstructs props that redux-forms sets and sets them on TextInput
+ * @return {Component} TogglePill
+ */
+const ReduxFormTogglePill = props => {
+	const {
+		meta, // eslint-disable-line no-unused-vars
+		// not adding meta error to TogglePill prop for now
+		input,
+		...other
+	} = props;
+
+	console.log('HELLO PROPS');
+	// const checkedProp = input.value == true ? 'checked' : '';
+
+	return <TogglePill {...input} isActive={!!input.value} {...other} />;
+};
+
+ReduxFormTogglePill.displayName = 'ReduxFormTogglePill';
+
+export default ReduxFormTogglePill;

--- a/src/forms/redux-form/TogglePill.jsx
+++ b/src/forms/redux-form/TogglePill.jsx
@@ -4,7 +4,12 @@ import TogglePill from '../TogglePill';
 /**
  * @param {Object} props - props passed in from parent and redux-form
  * @description wraps standard TogglePill web component for use with redux-form
- * deconstructs props that redux-forms sets and sets them on TextInput
+ * deconstructs props that redux-forms sets and sets them on TogglePill
+ * 
+ * NOTE: redux-form expects checkboxes value to be true/false and will set them as so
+ * https://github.com/erikras/redux-form/issues/2922, therefore using the value here to 
+ * set isActive
+ *  
  * @return {Component} TogglePill
  */
 const ReduxFormTogglePill = props => {
@@ -15,12 +20,10 @@ const ReduxFormTogglePill = props => {
 		...other
 	} = props;
 
-	console.log('HELLO PROPS');
-	// const checkedProp = input.value == true ? 'checked' : '';
-
-	return <TogglePill {...input} isActive={!!input.value} {...other} />;
+	return <TogglePill {...input} isActive={input.value == 'true'} {...other} />;
 };
 
 ReduxFormTogglePill.displayName = 'ReduxFormTogglePill';
 
 export default ReduxFormTogglePill;
+

--- a/src/forms/redux-form/__snapshots__/togglePill.test.jsx.snap
+++ b/src/forms/redux-form/__snapshots__/togglePill.test.jsx.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`redux-form TogglePill renders a TogglePill component with expected attributes from mock data 1`] = `
+<WithToggle
+  isActive={false}
+  label="Parenting"
+  name="parenting"
+  value={false}
+/>
+`;

--- a/src/forms/redux-form/togglePill.test.jsx
+++ b/src/forms/redux-form/togglePill.test.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import ReduxFormTogglePill from './TogglePill';
+
+describe('redux-form TogglePill', function() {
+
+	// props given in the structure that
+	// redux form would
+	const togglePillProps = {
+		input: {
+			label: 'Parenting',
+			name: 'parenting',
+			value: false, // as a checkbox, redux form will pass true / false for values
+		}
+	};
+
+	it('renders a TogglePill component with expected attributes from mock data', () => {
+		const component = shallow(<ReduxFormTogglePill {...togglePillProps} />);
+		expect(component).toMatchSnapshot();
+	});
+
+	it('renders a TogglePill with isActive prop as false when value is false', () => {
+		const component = mount(<ReduxFormTogglePill {...togglePillProps} />);
+		expect(component.find('TogglePill').prop('isActive')).toBe(false);
+	});
+
+	it('renders a TogglePill with isActive prop as true when value is true', () => {
+		togglePillProps.input.value = true;
+		const component = mount(<ReduxFormTogglePill {...togglePillProps} />);
+		expect(component.find('TogglePill').prop('isActive')).toBe(false);
+	});
+
+});
+


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-106

#### Description
The problem: Redux Form's implementation for checkboxes sets the value as `true` or `false`, unlike expected html behavior that separates `name`, `value`, and `checked`. 
https://github.com/erikras/redux-form/issues/2922

If we want our TogglePill's to be `checked`, we need to read the `input.value` prop from Redux Form (which is true or false), and pass that to `isActive`.

#### Screenshots (if applicable)

