### PR TITLE
SDS-435: Update selectinput to use `error` 

### DIFF
--- a/src/forms/SelectInput.jsx
+++ b/src/forms/SelectInput.jsx
@@ -35,6 +35,7 @@ class SelectInput extends React.Component {
 			label,
 			options,
 			name,
+			error,
 			errors,
 			required,
 			onChange, // eslint-disable-line no-unused-vars
@@ -43,7 +44,7 @@ class SelectInput extends React.Component {
 		} = this.props;
 
 		const classNames = cx(
-			{ 'field--error': errors && errors.length > 0 },
+			{ 'field--error': errors && errors.length > 0 || error },
 			className
 		);
 
@@ -75,7 +76,7 @@ class SelectInput extends React.Component {
 						)
 					}
 				</select>
-
+				{error && <p className='text--error'>{error}</p>}
 				{
 					errors && errors.length > 0 &&
 						errors.map((error, key) =>
@@ -95,6 +96,7 @@ SelectInput.propTypes = {
 		label: PropTypes.string.isRequired,
 		value: PropTypes.string.isRequired,
 	})).isRequired,
+	error: PropTypes.string,
 	errors: PropTypes.array,
 	label: PropTypes.oneOfType([
 		PropTypes.string,

--- a/src/forms/redux-form/SelectInput.jsx
+++ b/src/forms/redux-form/SelectInput.jsx
@@ -9,9 +9,7 @@ import SelectInput from '../SelectInput';
  */
 const ReduxFormSelectInput = props => {
 	const { meta, validateBeforeTouched, ...other } = props;
-
 	const error = (validateBeforeTouched || meta.touched) ? meta.error : null;
-
 	return <SelectInput error={error} {...other} />;
 };
 

--- a/src/forms/redux-form/selectInput.test.jsx
+++ b/src/forms/redux-form/selectInput.test.jsx
@@ -24,10 +24,10 @@ describe('redux-form SelectInput', () => {
 		expect(component).toMatchSnapshot();
 	});
 
-	it('does not render error if field is not touched and validateBeforeTouched is true', () => {
+	it('does not render error if field is not touched and validateBeforeTouched is false', () => {
 		const props = {
 			...formAttrs,
-			validateBeforeTouched: true,
+			validateBeforeTouched: false,
 			meta: {
 				...formAttrs.meta,
 				touched: false

--- a/src/forms/selectInput.story.jsx
+++ b/src/forms/selectInput.story.jsx
@@ -72,6 +72,20 @@ storiesOf('SelectInput', module)
 			</IntlProvider>
 		);
 	})
+	.add('single error', () =>
+		(<SelectInput
+			label='Select a name for your horse'
+			id='horsename'
+			name='horsename'
+			required
+			options={[
+				{ label: 'Geoffrey', value: 'geoffrey' },
+				{ label: 'Doctor Horse, MD Junior', value: 'drhorse' },
+				{ label: 'Mister Chompy', value: 'chompyhorse' }
+			]}
+			error={'I\'m a single lady, I\'m a single lady'}
+		/>)
+	)
 	.add('multiple errors', () =>
 		(<SelectInput
 			label='Select a name for your horse'

--- a/src/forms/selectInput.test.jsx
+++ b/src/forms/selectInput.test.jsx
@@ -38,6 +38,20 @@ describe('SelectInput basic', () => {
 	});
 });
 
+describe('Errors', () => {
+	it('shows a single error when a single error is passed in', () => {
+		const importantError = 'if you like it then you better put a ring on it';
+		const props = {
+			label: 'Bday',
+			name: 'Deluxe Edition',
+			options: testOptions,
+			error: importantError
+		};
+		const component = shallow(<SelectInput {...props} />);
+		expect(component.find('.text--error').text()).toEqual(importantError);
+	});
+});
+
 describe('SelectInput advanced', () => {
 	it('should set correct value in state on change', () => {
 		const newValue = '2';


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-435

#### Description
We love standardization. Also, we need this for ReduxForm.

#### Screenshots (if applicable)

![screen shot 2017-10-06 at 4 49 33 pm](https://user-images.githubusercontent.com/1224149/31298055-5d368c72-aab6-11e7-98fa-4f4c47d6b265.png)
