### PR TITLE
ReduXFormTogglePill should check true as bool

### DIFF
--- a/src/forms/redux-form/TogglePill.jsx
+++ b/src/forms/redux-form/TogglePill.jsx
@@ -21,7 +21,7 @@ const ReduxFormTogglePill = props => {
 		...other
 	} = props;
 
-	return <TogglePill {...input} isActive={input.value == 'true' && !other.useRadio} {...other} />;
+	return <TogglePill {...input} isActive={input.value === true && !other.useRadio} {...other} />;
 };
 
 ReduxFormTogglePill.displayName = 'ReduxFormTogglePill';

--- a/src/forms/redux-form/togglePill.test.jsx
+++ b/src/forms/redux-form/togglePill.test.jsx
@@ -27,7 +27,7 @@ describe('redux-form TogglePill', function() {
 	it('renders a TogglePill with isActive prop as true when value is true', () => {
 		togglePillProps.input.value = true;
 		const component = mount(<ReduxFormTogglePill {...togglePillProps} />);
-		expect(component.find('TogglePill').prop('isActive')).toBe(false);
+		expect(component.find('TogglePill').prop('isActive')).toBe(true);
 	});
 
 });


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-107

#### Description
the toggle pill should check that the `value === true` not `'true'` in order to set `isActive`. I assumed the value was going to be stringified, but it turns out its a bool.

*AFAIK no other code is using ReduxTogglePill yet except for my branch in PR, so I dont think this is a  breaking change*

#### Screenshots (if applicable)

