### PR TITLE
Popover `.inverted` bug fix

### DIFF
--- a/assets/scss/components/_popover.scss
+++ b/assets/scss/components/_popover.scss
@@ -51,6 +51,7 @@ $view-minWidth: 320px;
 	& > span,
 	& > div,
 	& > button {
+		color: $C_textPrimary;
 		display: block;
 		padding: $space-half $space;
 


### PR DESCRIPTION
#### Description
Popover menu options will always be colored `$C_textPrimary` by default