### PR TITLE
TextInput with icon

### DIFF
--- a/assets/scss/components/_forms.scss
+++ b/assets/scss/components/_forms.scss
@@ -50,7 +50,19 @@ input.field--reset:active {
 	.inverted & {
 		@include resetFieldStyles;
 	}
+}
 
+//
+// Styles for a field with an icon
+//
+.field--withIcon {
+	background-repeat: no-repeat;
+	background-position: $space center;
+
+	&:before {
+		content: "lololol";
+		display: block;
+	}
 }
 
 //

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "storybook-addon-i18n-tools": "1.0.0",
     "style-loader": "0.18.2",
     "swarm-icons": "1.3.183",
-    "swarm-sasstools": "1.7.131-beta",
+    "swarm-sasstools": "2.0.135",
     "webpack": "2.6.1"
   }
 }

--- a/src/forms/TextInput.jsx
+++ b/src/forms/TextInput.jsx
@@ -4,7 +4,6 @@ import cx from 'classnames';
 import { MEDIA_SIZES } from '../utils/designConstants';
 
 export const FIELD_WITH_ICON_CLASS = 'field--withIcon';
-export const DEFAULT_ICON_SIZE = 'xs';
 
 /**
  * @module TextInput

--- a/src/forms/TextInput.jsx
+++ b/src/forms/TextInput.jsx
@@ -1,6 +1,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
+import { MEDIA_SIZES } from '../utils/designConstants';
+
+export const FIELD_WITH_ICON_CLASS = 'field--withIcon';
+export const DEFAULT_ICON_SIZE = 'xs';
 
 /**
  * @module TextInput
@@ -23,12 +27,16 @@ const TextInput = (props) => {
 		maxLength,
 		pattern,
 		disabled,
+		iconShape,
 		...other
 	} = props;
 
 	const classNames = cx(
 		'span--100',
-		{ 'field--error': error },
+		{
+			'field--error': error,
+			[FIELD_WITH_ICON_CLASS]: iconShape
+		},
 		className
 	);
 
@@ -38,6 +46,18 @@ const TextInput = (props) => {
 		labelClassName
 	);
 
+	const iconSize = props.iconSize || 'xs';
+	const iconSuffix = (iconSize == 'xs' || iconSize == 's') ? '--small' : '';
+	const inputIcon = iconShape && require(`base64-image-loader!swarm-icons/dist/optimized/${iconShape}${iconSuffix}.svg`);
+
+	const paddingSize = parseInt(MEDIA_SIZES[iconSize], 10)+24; // #TODO :SDS: replace '32' with something like "$space * 1.5" from `swarm-constants`
+	const inputStyles = iconShape &&
+	{
+		backgroundImage: `url(${inputIcon})`,
+		backgroundSize: `${MEDIA_SIZES[iconSize]}px`,
+		paddingLeft: `${paddingSize}px`
+	};
+
 	return (
 		<div className="inputContainer">
 			{label &&
@@ -45,6 +65,7 @@ const TextInput = (props) => {
 					{label}
 				</label>
 			}
+
 			<input type={isSearch ? 'search' : 'text'}
 				name={name}
 				value={value}
@@ -56,6 +77,7 @@ const TextInput = (props) => {
 				pattern={pattern}
 				disabled={disabled}
 				id={id}
+				style={inputStyles}
 				{...other}
 			/>
 
@@ -86,6 +108,8 @@ TextInput.propTypes = {
 	isSearch: PropTypes.bool,
 	onChange: PropTypes.func,
 	disabled: PropTypes.bool,
+	iconShape: PropTypes.string,
+	iconSize: PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl'])
 };
 
 export default TextInput;

--- a/src/forms/textInput.story.jsx
+++ b/src/forms/textInput.story.jsx
@@ -93,6 +93,18 @@ storiesOf('TextInput', module)
 			</form>
 		);
 	})
+	.add('with icon', () => (
+		<div className='span--50'>
+			<TextInput
+				label='Your name'
+				id='fullname'
+				name='name'
+				defaultValue='Phife Dawg'
+				placeholder='Not your email'
+				iconShape='search' />
+		</div>
+	)
+	)
 	.addWithInfo(
 		'with char counter if you provide maxLength',
 		`Note: updating field with charcounter relies on parent to give value,

--- a/src/forms/textInput.test.jsx
+++ b/src/forms/textInput.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import TextInput from './TextInput';
+import TextInput, {FIELD_WITH_ICON_CLASS} from './TextInput';
 import { shallow, mount } from 'enzyme';
 
 describe('TextInput', function() {
@@ -46,6 +46,7 @@ describe('TextInput', function() {
 					onChange={onChange}
 					isSearch
 					disabled
+					iconShape='search'
 					{...formAttrs}
 				/>
 			).find('input');
@@ -81,6 +82,10 @@ describe('TextInput', function() {
 			expect(onChange).toHaveBeenCalledWith(eventData);
 		});
 
+		it('should show an icon when iconShape prop is specified', () => {
+			expect(inputEl.find(`.${FIELD_WITH_ICON_CLASS}`).exists()).toBe(true);
+		});
+
 	});
 
 	describe('dom checks, full rendering', () => {
@@ -112,5 +117,11 @@ describe('TextInput', function() {
 			const errorEl = component.find('.text--error').getDOMNode();
 			expect(errorEl.textContent).toEqual(ERROR_TEXT);
 		});
+
+		// it('should show an icon when iconShape prop is specified', () => {
+		// 	const iconEl = component.find('input').getDOMNode();
+		// 	console.log(iconEl.style);
+		// });
+
 	});
 });

--- a/src/forms/textInput.test.jsx
+++ b/src/forms/textInput.test.jsx
@@ -118,10 +118,5 @@ describe('TextInput', function() {
 			expect(errorEl.textContent).toEqual(ERROR_TEXT);
 		});
 
-		// it('should show an icon when iconShape prop is specified', () => {
-		// 	const iconEl = component.find('input').getDOMNode();
-		// 	console.log(iconEl.style);
-		// });
-
 	});
 });


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-432

#### Description
Adds the option to have text inputs with icons. Chose to use a `background-image` instead of `<Icon>` in order to have the least changes to `<TextInput>` as possible.

#### Screenshots (if applicable)
<img width="622" alt="screen shot 2017-10-10 at 4 14 16 pm" src="https://user-images.githubusercontent.com/2313998/31408342-310c9416-add6-11e7-8e7b-9f086c15451c.png">

