### PR TITLE
CalendarComponent datepickerOptions prop updates

### DIFF
--- a/src/forms/CalendarComponent.jsx
+++ b/src/forms/CalendarComponent.jsx
@@ -7,7 +7,6 @@ import cx from 'classnames';
  * inits flatpickr js date picker over a text input
 */
 class CalendarComponent extends React.Component {
-
 	constructor(props) {
 		super(props);
 
@@ -44,7 +43,7 @@ class CalendarComponent extends React.Component {
 				<use xlink:href="#icon-chevron-left" />
 				</svg>
 			</span>`,
-			...this.props.datepickerOptions
+			...this.props.datepickerOptions,
 		};
 
 		this.flatpickr = new Flatpickr(this.inputEl, options);
@@ -57,7 +56,27 @@ class CalendarComponent extends React.Component {
 	// replaces updateFlatpickr
 	// if we receive a new value from parent, update Flatpickr
 	componentWillReceiveProps(newProps) {
-		this.flatpickr && this.flatpickr.setDate(newProps.value);
+		if (this.flatpickr) {
+			if (newProps.datepickerOptions) {
+				this.updateFlatpickrOptions(newProps.datepickerOptions);
+			}
+			this.flatpickr.setDate(newProps.value);
+		}
+	}
+
+	/**
+	 * Updates config options on the flatpickr instance
+	 * @param {Object} newOptions new configaration options for flatpickr
+	 * @return {undefined}
+	 */
+	updateFlatpickrOptions(newOptions) {
+		Object.keys(newOptions)
+			.filter(
+				option => this.props.datepickerOptions[option] !== newOptions[option]
+			)
+			.forEach(option => {
+				this.flatpickr.set(option, newOptions[option]);
+			});
 	}
 
 	/**
@@ -99,34 +118,33 @@ class CalendarComponent extends React.Component {
 			required,
 			value,
 			error,
-			datepickerOptions,	// eslint-disable-line no-unused-vars
-			onChange,			// eslint-disable-line no-unused-vars
+			datepickerOptions, // eslint-disable-line no-unused-vars
+			onChange, // eslint-disable-line no-unused-vars
 			...other
 		} = this.props;
 
-		const classNames = cx(
-			'input--dateTimePicker',
-			className
-		);
+		const classNames = cx('input--dateTimePicker', className);
 
-		const labelClassNames = cx(
-			{required},
-			className
-		);
+		const labelClassNames = cx({ required }, className);
 
 		return (
 			<span>
-				{ label && <label htmlFor={id} className={labelClassNames}>{label}</label> }
+				{label && (
+					<label htmlFor={id} className={labelClassNames}>
+						{label}
+					</label>
+				)}
 				<input
-					type='text'
+					type="text"
 					id={id}
 					name={name}
 					defaultValue={value}
 					className={classNames}
-					ref={ input => this.inputEl = input }
-					{...other} />
+					ref={input => (this.inputEl = input)}
+					{...other}
+				/>
 
-				{ error && <p className='text--error text--small'>{error}</p> }
+				{error && <p className="text--error text--small">{error}</p>}
 			</span>
 		);
 	}
@@ -134,7 +152,12 @@ class CalendarComponent extends React.Component {
 
 CalendarComponent.propTypes = {
 	name: PropTypes.string.isRequired,
-	onChange: PropTypes.func // provided by DateTimePicker or redux-form
+	onChange: PropTypes.func, // provided by DateTimePicker or redux-form
+	datepickerOptions: PropTypes.object,
+};
+
+CalendarComponent.defaultProps = {
+	datepickerOptions: {},
 };
 
 export default CalendarComponent;

--- a/src/forms/calendarComponent.story.jsx
+++ b/src/forms/calendarComponent.story.jsx
@@ -3,34 +3,38 @@ import CalendarComponent from './CalendarComponent';
 import { storiesOf } from '@kadira/storybook';
 import { InfoWrapper } from '../utils/storyComponents';
 import { decorateWithLocale } from '../utils/decorators';
+import { withKnobs, boolean } from '@kadira/storybook-addon-knobs';
 
 storiesOf('CalendarComponent', module)
 	.addDecorator(decorateWithLocale)
-	.addWithInfo(
-		'default',
-		'renders a calendar component',
-		() => (
-			<InfoWrapper>
-				<div className='span--50'>
-					<CalendarComponent
-						name='event_time'
-						label='Start at'
-						value={new Date()}
-						datepickerOptions={{ allowInput: true }}
-					/>
-				</div>
-			</InfoWrapper>
-		)
-	)
+	.addDecorator(withKnobs)
+	.addWithInfo('default', 'renders a calendar component', () => (
+		<InfoWrapper>
+			<div className="span--50">
+				<CalendarComponent
+					name="event_time"
+					label="Start at"
+					value={new Date()}
+					datepickerOptions={{
+						allowInput: true,
+						maxDate: boolean('max date today', false) && new Date(),
+						minDate: boolean('min date today', false) && new Date(),
+					}}
+				/>
+			</div>
+		</InfoWrapper>
+	))
 	.add('required', () => {
-		return (<div className='span--50'>
-			<CalendarComponent
-				name='event_time'
-				label='Start at'
-				value={new Date()}
-				required
-			/>
-		</div>);
+		return (
+			<div className="span--50">
+				<CalendarComponent
+					name="event_time"
+					label="Start at"
+					value={new Date()}
+					required
+				/>
+			</div>
+		);
 	})
 	.add('sets a valid date range', () => {
 		const min = new Date(),
@@ -42,43 +46,47 @@ storiesOf('CalendarComponent', module)
 		const opts = {
 			allowInput: true,
 			minDate: min,
-			maxDate: max
+			maxDate: max,
 		};
-		return (<div className='span--50'>
-			<CalendarComponent
-				name='event_time'
-				label='From 2 days ago to 1 week from now'
-				value={now}
-				datepickerOptions={opts}
-			/>
-		</div>);
+		return (
+			<div className="span--50">
+				<CalendarComponent
+					name="event_time"
+					label="From 2 days ago to 1 week from now"
+					value={now}
+					datepickerOptions={opts}
+				/>
+			</div>
+		);
 	})
 	.add('sets a default date and time', () => {
 		const opts = {
 				allowInput: true,
-				minDate: Date.now()
+				minDate: Date.now(),
 			},
-			date = new Date(3000,1,1,15,0,0);
-		return (<div className='span--50'>
-			<CalendarComponent
-				name='event_time'
-				label='In the year 3000'
-				value={date}
-				datepickerOptions={opts}
-			/>
-		</div>);
+			date = new Date(3000, 1, 1, 15, 0, 0);
+		return (
+			<div className="span--50">
+				<CalendarComponent
+					name="event_time"
+					label="In the year 3000"
+					value={date}
+					datepickerOptions={opts}
+				/>
+			</div>
+		);
 	})
 	.add('error state', () => {
 		const opts = {
 				allowInput: true,
-				minDate: Date.now()
+				minDate: Date.now(),
 			},
-			date = new Date(3000,1,1,15,0,0);
+			date = new Date(3000, 1, 1, 15, 0, 0);
 		return (
-			<div className='span--50'>
+			<div className="span--50">
 				<CalendarComponent
-					name='event_time'
-					label='Start at'
+					name="event_time"
+					label="Start at"
 					value={date}
 					error={'Woops, something went wrong.'}
 					datepickerOptions={opts}

--- a/src/forms/calendarComponent.test.jsx
+++ b/src/forms/calendarComponent.test.jsx
@@ -3,7 +3,6 @@ import { shallow } from 'enzyme';
 import CalendarComponent from './CalendarComponent';
 
 describe('CalendarComponent', function() {
-
 	let calendarComponent;
 
 	const id = 'beyonce',
@@ -24,7 +23,7 @@ describe('CalendarComponent', function() {
 				value={value}
 				datepickerOptions={opts}
 				onChangeCallback={onChangeCallback}
-				ref={ node => this.node = node }
+				ref={node => (this.node = node)}
 			/>
 		);
 		calendarComponent.instance().componentDidMount();
@@ -33,10 +32,7 @@ describe('CalendarComponent', function() {
 	});
 
 	describe('onChange callback tests', () => {
-
-		let calendarComponent,
-			onChangePropMock,
-			callbackMock;
+		let calendarComponent, onChangePropMock, callbackMock;
 
 		// because we are rendering shallow here, flatpickr isnt
 		// instantiated (because componentDidMount not called)
@@ -60,14 +56,10 @@ describe('CalendarComponent', function() {
 			expect(onChangePropMock).toHaveBeenCalledWith(newValue);
 			calendarComponent = null;
 		});
-
 	});
 
 	describe('onBlur onFocus callback tests', () => {
-
-		let cal,
-			onFocusMock,
-			onBlurMock;
+		let cal, onFocusMock, onBlurMock;
 
 		beforeEach(() => {
 			onFocusMock = jest.fn();
@@ -100,6 +92,63 @@ describe('CalendarComponent', function() {
 			expect(onBlurMock).not.toHaveBeenCalled();
 			cal.instance().onClose();
 			expect(onBlurMock).toHaveBeenCalled();
+		});
+	});
+
+	describe('componentWillReceiveProps', () => {
+		it('should updateFlatpickrOptions when receiving datepickerOptions prop', () => {
+			const instance = shallow(<CalendarComponent name="test" />).instance();
+			const datepickerOptions = { option1: true };
+
+			instance.flatpickr = { setDate: jest.fn() };
+
+			jest
+				.spyOn(instance, 'updateFlatpickrOptions')
+				.mockImplementation(() => {});
+
+			instance.componentWillReceiveProps({ datepickerOptions });
+
+			expect(instance.updateFlatpickrOptions).toHaveBeenCalledWith(
+				datepickerOptions
+			);
+		});
+	});
+
+	describe('updateFlatpickrOptions', () => {
+		it('should update flatpickr with updated options', () => {
+			const optionThatDoesntChange = 'will not change';
+
+			const wrapper = shallow(
+				<CalendarComponent
+					name="test"
+					datepickerOptions={{
+						optionThatDoesntChange,
+						maxDate: 1507751589972,
+					}}
+				/>
+			);
+
+			const instance = wrapper.instance();
+
+			instance.flatpickr = {
+				set: jest.fn(),
+			};
+
+			const minDate = 12345;
+			const maxDate = 67890;
+
+			instance.updateFlatpickrOptions({
+				minDate,
+				maxDate,
+				optionThatDoesntChange,
+			});
+
+			expect(instance.flatpickr.set).toHaveBeenCalledWith('maxDate', maxDate);
+			expect(instance.flatpickr.set).toHaveBeenCalledWith('minDate', minDate);
+			expect(instance.flatpickr.set).not.toHaveBeenCalledWith(
+				'optionThatDoesntChange',
+				optionThatDoesntChange
+			);
 		});
 	});
 });

--- a/src/forms/redux-form/__snapshots__/calendarComponent.test.jsx.snap
+++ b/src/forms/redux-form/__snapshots__/calendarComponent.test.jsx.snap
@@ -3,6 +3,7 @@
 exports[`redux-form Calendar Component renders a Calendar component with expected attributes from mock data 1`] = `
 <CalendarComponent
   className="beyonce-halo"
+  datepickerOptions={Object {}}
   error="pick a different album"
   id="beyonce"
   name="halo"


### PR DESCRIPTION
#### Related issues
Relates to https://meetup.atlassian.net/browse/MUP-15668

#### Description
Updating values via the `datepickerOptions` prop does not actually update the flatpickr config in `CalendarComponent`. This currently only gets set on `componentDidMount`. This causes a problem when trying to set a date range based off of the value of another date picker, for example. This PR fixes that and allows you to dynamically set the config of the flatpicker by passing an updated `datepickerOptions` prop.

`Prettier` seems to have made the diff larger than necessary - sorry about that.