### PR TITLE
Bugfix - character count layout

### DIFF
--- a/src/forms/TextInput.jsx
+++ b/src/forms/TextInput.jsx
@@ -58,32 +58,33 @@ const TextInput = (props) => {
 	};
 
 	return (
-		<div className="inputContainer">
-			{label &&
-				<label className={labelClassNames} htmlFor={id}>
-					{label}
-				</label>
-			}
+		<div>
+			<div className="inputContainer">
+				{label &&
+					<label className={labelClassNames} htmlFor={id}>
+						{label}
+					</label>
+				}
 
-			<input type={isSearch ? 'search' : 'text'}
-				name={name}
-				value={value}
-				required={required}
-				placeholder={placeholder}
-				className={classNames}
-				onChange={onChange}
-				maxLength={maxLength}
-				pattern={pattern}
-				disabled={disabled}
-				id={id}
-				style={inputStyles}
-				{...other}
-			/>
+				<input type={isSearch ? 'search' : 'text'}
+					name={name}
+					value={value}
+					required={required}
+					placeholder={placeholder}
+					className={classNames}
+					onChange={onChange}
+					maxLength={maxLength}
+					pattern={pattern}
+					disabled={disabled}
+					id={id}
+					style={inputStyles}
+					{...other}
+				/>
 
-			{ maxLength && <p className='text--tiny text--secondary align--right charCount'>{parseInt(maxLength - value.length)}</p> }
-
+				{ maxLength && <p className='text--tiny text--secondary align--right charCount'>{parseInt(maxLength - value.length)}</p> }
+				{children}
+			</div>
 			{ error && <p className='text--error text--small'>{error}</p> }
-			{children}
 		</div>
 	);
 };

--- a/src/forms/Textarea.jsx
+++ b/src/forms/Textarea.jsx
@@ -113,29 +113,30 @@ class Textarea extends React.Component {
 		};
 
 		return (
-			<div className="inputContainer">
-				{label &&
-					<label className={classNames.label} htmlFor={id}>
-						{label}
-					</label>
-				}
+			<div>
+				<div className="inputContainer">
+					{label &&
+						<label className={classNames.label} htmlFor={id}>
+							{label}
+						</label>
+					}
 
-				<textarea
-					type='text'
-					name={name}
-					required={required}
-					className={classNames.textarea}
-					onChange={this.onChange}
-					rows={rows}
-					ref={(textarea) => {this.textarea = textarea;}}
-					style={{ ...style, ...heightConstraints }}
-					id={id}
-					value={this.state.value}
-					{...other}
-				/>
+					<textarea
+						type='text'
+						name={name}
+						required={required}
+						className={classNames.textarea}
+						onChange={this.onChange}
+						rows={rows}
+						ref={(textarea) => {this.textarea = textarea;}}
+						style={{ ...style, ...heightConstraints }}
+						id={id}
+						value={this.state.value}
+						{...other}
+					/>
 
-				{ maxLength && <p className='text--tiny text--secondary align--right charCount'>{parseInt(maxLength - this.state.value.length)}</p> }
-
+					{ maxLength && <p className='text--tiny text--secondary align--right charCount'>{parseInt(maxLength - this.state.value.length)}</p> }
+				</div>
 				{ error && <p className='text--error text--small'>{error}</p> }
 			</div>
 		);

--- a/src/forms/__snapshots__/textInput.test.jsx.snap
+++ b/src/forms/__snapshots__/textInput.test.jsx.snap
@@ -1,22 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TextInput renders a required HTML <input> with expected attributes for mock data 1`] = `
-<div
-  className="inputContainer"
->
-  <label
-    className="label--field required"
-    htmlFor="superhero"
+<div>
+  <div
+    className="inputContainer"
   >
-    Super Hero
-  </label>
-  <input
-    className="span--100"
-    id="superhero"
-    name="superhero"
-    required={true}
-    type="text"
-    value="Batman"
-  />
+    <label
+      className="label--field required"
+      htmlFor="superhero"
+    >
+      Super Hero
+    </label>
+    <input
+      className="span--100"
+      id="superhero"
+      name="superhero"
+      required={true}
+      type="text"
+      value="Batman"
+    />
+  </div>
 </div>
 `;

--- a/src/forms/textInput.story.jsx
+++ b/src/forms/textInput.story.jsx
@@ -122,6 +122,7 @@ storiesOf('TextInput', module)
 							id='fullname'
 							name='name'
 							value='how long is this'
+							error='this is an error'
 							{...rules} />
 					</div>
 				</InfoWrapper>


### PR DESCRIPTION
#### Description
Moved error element outside of `.inputContainer` so when it get's absolutely positioned, it's always inside the input box

#### Screenshots (if applicable)
BAD (before):
<img width="655" alt="screen shot 2017-10-12 at 11 30 44 am" src="https://user-images.githubusercontent.com/2313998/31504786-4c61fd5c-af41-11e7-8618-4ded2bcf04cf.png">

GOOD (after):
<img width="627" alt="screen shot 2017-10-12 at 11 30 27 am" src="https://user-images.githubusercontent.com/2313998/31504802-5499de90-af41-11e7-8b47-2f58f5bad584.png">

