### PR TITLE
Wc 110 checkbox onchange event

### DIFF
--- a/src/forms/Checkbox.jsx
+++ b/src/forms/Checkbox.jsx
@@ -24,7 +24,7 @@ class Checkbox extends React.Component {
 	}
 
 	onChange(e) {
-		this.props.onChange && this.props.onChange(e.target.checked);
+		this.props.onChange && this.props.onChange(e);
 		this.setState({ checked: e.target.checked });
 	}
 

--- a/src/forms/checkbox.test.jsx
+++ b/src/forms/checkbox.test.jsx
@@ -81,7 +81,7 @@ describe('Checkbox', function() {
 			expect(fakeOnChange).not.toHaveBeenCalled();
 			checkbox.simulate('change', { target: { checked: true } });
 			expect(checkbox.props().checked).toBe(true);
-			expect(fakeOnChange).toHaveBeenCalledWith(true);
+			expect(fakeOnChange).toHaveBeenCalled();
 		});
 	});
 


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-110

#### Description
the `onChange` call should be passed the `e` `event` arg,  rather than the value.
Not sure if something was dependent on the checked value in particular, but passing `e` will allow it to work with `onChange` coming from `redux-form`.

*Some background:*
the call to `props.onChange` was added so that delete events would be supported here:

https://github.com/meetup/mup-web/blob/5b7940b87e0142276df3eb031c3f1629d233d1c3/src/app/group/event/home/ConfirmCancelModal.jsx#L160

but the handler doesn't do anything with the args, so it shouldn't be a problem to change the signature.
https://github.com/meetup/mup-web/blob/5b7940b87e0142276df3eb031c3f1629d233d1c3/src/app/group/event/home/ConfirmCancelModal.jsx#L98

the `onChange` is also supplied here
https://github.com/meetup/mup-web/blob/075fed0ffb9a8ce4c5ce3a6c29d7c053766afee4/src/app/group/event/schedule/venue/AddVenue.jsx#L278

and it looks like the handler expects the `e` arg, so actually this may not be working currently
https://github.com/meetup/mup-web/blob/075fed0ffb9a8ce4c5ce3a6c29d7c053766afee4/src/app/group/event/schedule/venue/AddVenue.jsx#L132

I went through places `Checkbox` is used, I don't think this is breaking, and it might fix the above ^^
https://github.com/meetup/mup-web/search?utf8=%E2%9C%93&q=%3CCheckbox&type=

