### PR TITLE
Accordion panel changes

### DIFF
--- a/src/interactive/AccordionPanel.jsx
+++ b/src/interactive/AccordionPanel.jsx
@@ -17,11 +17,7 @@ export const ACTIVEPANEL_CLASS = 'accordionPanel--active';
 class AccordionPanel extends React.Component {
 	constructor(props){
 		super(props);
-
-		this.state = {
-			isOpen: this.props.isOpen
-		};
-
+		this.state = {};
 		this._handleToggle = this._handleToggle.bind(this);
 	}
 
@@ -36,18 +32,17 @@ class AccordionPanel extends React.Component {
 	/**
 	 * @returns {undefined}
 	 *
-	 * Updates state to toggle `AccordionPanel` open and closed
+	 * Updates state to toggle `AccordionPanel` open and closeds
 	 */
 	_handleToggle(e){
 		e.preventDefault();
 		e.stopPropagation();
 
-		const willOpen = !this.state.isOpen;
+		const isToggledOpen = !this.props.isOpen;
+		this.props.setClickedPanel && this.props.setClickedPanel(this.props.clickId, isToggledOpen);
 		this.setState({
-			isOpen: willOpen,
-			height: this.getHeight(willOpen)
-		}, () => this.props.setClickedPanel && this.props.setClickedPanel(this, willOpen));
-
+			height: this.getHeight(isToggledOpen)
+		});
 	}
 
 	/**
@@ -57,7 +52,7 @@ class AccordionPanel extends React.Component {
 	 */
 	componentDidMount() {
 		this.setState({
-			height: this.getHeight(this.state.isOpen)
+			height: this.getHeight(this.props.isOpen)
 		});
 	}
 
@@ -67,32 +62,12 @@ class AccordionPanel extends React.Component {
 	 * Updates state to toggle `AccordionPanel` open and closed
 	 */
 	componentWillReceiveProps(nextProps) {
-		console.log('using componentWillReceiveProps which should be better');
-		if (nextProps.isOpen !== this.state.isOpen) {
-			const isOpen = nextProps.isOpen;
+		if (nextProps.isOpen !== this.props.isOpen) {
 			this.setState({
-				isOpen: isOpen,
-				height: this.getHeight(isOpen)
+				height: this.getHeight(nextProps.isOpen)
 			});
 		}
 	}
-
-
-	/**
-	 * @returns {undefined}
-	 *
-	 * Updates state to toggle `AccordionPanel` open and closed
-	 */
-
-	// componentWillUpdate(nextProps, nextState) {
-	// 	console.log('using componentWill UPDATE');
-	// 	if (nextProps.isOpen !== this.state.isOpen) {
-	// 		this.setState({
-	// 			isOpen: nextProps.isOpen,
-	// 			height: this.getHeight(nextProps.isOpen)
-	// 		});
-	// 	}
-	// }
 
 	/**
 	 * @returns {String} icon shape
@@ -103,7 +78,7 @@ class AccordionPanel extends React.Component {
 			indicatorIconActive
 		} = this.props;
 
-		return this.state.isOpen && indicatorIconActive ?
+		return this.props.isOpen && indicatorIconActive ?
 			indicatorIconActive :
 			indicatorIcon;
 	}
@@ -113,7 +88,7 @@ class AccordionPanel extends React.Component {
 			panelContent,
 			clickId, 				// eslint-disable-line no-unused-vars
 			label,
-			isOpen, 				// eslint-disable-line no-unused-vars
+			isOpen,
 			setClickedPanel, 		// eslint-disable-line no-unused-vars
 			indicatorAlign, 		// eslint-disable-line no-unused-vars
 			indicatorIcon, 			// eslint-disable-line no-unused-vars
@@ -130,8 +105,8 @@ class AccordionPanel extends React.Component {
 			accordionPanel: cx(
 				PANEL_CLASS,
 				{
-					[ACTIVEPANEL_CLASS]: this.state.isOpen,
-					[classNamesActive]: this.state.isOpen && classNamesActive
+					[ACTIVEPANEL_CLASS]: isOpen,
+					[classNamesActive]: isOpen && classNamesActive
 				},
 				className
 			),
@@ -142,7 +117,7 @@ class AccordionPanel extends React.Component {
 			content: cx(
 				'accordionPanel-animator',
 				{
-					'accordionPanel-animator--collapse': !this.state.isOpen
+					'accordionPanel-animator--collapse': !isOpen
 				}
 			)
 		};
@@ -164,8 +139,8 @@ class AccordionPanel extends React.Component {
 						role='tab'
 						id={`label-${ariaId}`}
 						aria-controls={`panel-${ariaId}`}
-						aria-expanded={this.state.isOpen}
-						aria-selected={this.state.isOpen}
+						aria-expanded={isOpen}
+						aria-selected={isOpen}
 						className={classNames.trigger}
 						onClick={this._handleToggle}
 					>
@@ -175,7 +150,7 @@ class AccordionPanel extends React.Component {
 					<Chunk
 						role='tabpanel'
 						aria-labelledby={`label-${ariaId}`}
-						aria-hidden={!this.state.isOpen}
+						aria-hidden={!isOpen}
 						className={classNames.content}
 						style={{height: this.state.height}}
 					>
@@ -198,7 +173,7 @@ class AccordionPanel extends React.Component {
 							? <Icon shape={this.getIconShape()} size={indicatorIconSize} />
 							:
 							<ToggleSwitch
-								isActive={this.state.isOpen}
+								isActive={isOpen}
 								id={`${ariaId}-switch`}
 								name={ariaId}
 								onClick={this._handleToggle}

--- a/src/interactive/AccordionPanel.jsx
+++ b/src/interactive/AccordionPanel.jsx
@@ -38,15 +38,15 @@ class AccordionPanel extends React.Component {
 	 *
 	 * Updates state to toggle `AccordionPanel` open and closed
 	 */
-	_handleToggle(){
-		if (this.props.setClickedPanel) {
-			this.props.setClickedPanel(this);
-		}
+	_handleToggle(e){
+		e.preventDefault();
+		e.stopPropagation();
 
+		const willOpen = !this.state.isOpen;
 		this.setState({
-			height: this.getHeight(!this.state.isOpen),
-			isOpen: !this.state.isOpen
-		});
+			isOpen: willOpen,
+			height: this.getHeight(willOpen)
+		}, () => this.props.setClickedPanel && this.props.setClickedPanel(this, willOpen));
 
 	}
 
@@ -66,14 +66,33 @@ class AccordionPanel extends React.Component {
 	 *
 	 * Updates state to toggle `AccordionPanel` open and closed
 	 */
-	componentWillUpdate(nextProps, nextState) {
+	componentWillReceiveProps(nextProps) {
+		console.log('using componentWillReceiveProps which should be better');
 		if (nextProps.isOpen !== this.state.isOpen) {
+			const isOpen = nextProps.isOpen;
 			this.setState({
-				isOpen: nextProps.isOpen,
-				height: this.getHeight(nextProps.isOpen)
+				isOpen: isOpen,
+				height: this.getHeight(isOpen)
 			});
 		}
 	}
+
+
+	/**
+	 * @returns {undefined}
+	 *
+	 * Updates state to toggle `AccordionPanel` open and closed
+	 */
+
+	// componentWillUpdate(nextProps, nextState) {
+	// 	console.log('using componentWill UPDATE');
+	// 	if (nextProps.isOpen !== this.state.isOpen) {
+	// 		this.setState({
+	// 			isOpen: nextProps.isOpen,
+	// 			height: this.getHeight(nextProps.isOpen)
+	// 		});
+	// 	}
+	// }
 
 	/**
 	 * @returns {String} icon shape
@@ -92,12 +111,13 @@ class AccordionPanel extends React.Component {
 	render() {
 		const {
 			panelContent,
+			clickId, 				// eslint-disable-line no-unused-vars
 			label,
-			isOpen, // eslint-disable-line no-unused-vars
-			setClickedPanel, // eslint-disable-line no-unused-vars
-			indicatorAlign, // eslint-disable-line no-unused-vars
-			indicatorIcon, // eslint-disable-line no-unused-vars
-			indicatorIconActive, // eslint-disable-line no-unused-vars
+			isOpen, 				// eslint-disable-line no-unused-vars
+			setClickedPanel, 		// eslint-disable-line no-unused-vars
+			indicatorAlign, 		// eslint-disable-line no-unused-vars
+			indicatorIcon, 			// eslint-disable-line no-unused-vars
+			indicatorIconActive,	// eslint-disable-line no-unused-vars
 			indicatorIconSize,
 			indicatorSwitch,
 			classNamesActive,
@@ -199,6 +219,7 @@ AccordionPanel.defaultProps = {
 };
 
 AccordionPanel.propTypes = {
+	clickId: PropTypes.number,
 	classNamesActive: PropTypes.string,
 	isOpen: PropTypes.bool,
 	panelContent: PropTypes.element,

--- a/src/interactive/AccordionPanel.jsx
+++ b/src/interactive/AccordionPanel.jsx
@@ -17,7 +17,9 @@ export const ACTIVEPANEL_CLASS = 'accordionPanel--active';
 class AccordionPanel extends React.Component {
 	constructor(props){
 		super(props);
-		this.state = {};
+		this.state = {
+			height: ''
+		};
 		this._handleToggle = this._handleToggle.bind(this);
 	}
 
@@ -30,9 +32,11 @@ class AccordionPanel extends React.Component {
 	}
 
 	/**
+	 * 
+	 * @description calls the AccordionPanelGroups's callback to toggle open state
+	 * and render the `AccordionPanel` open or closed, sets height in state
+	 * @param {Event} e - the event object
 	 * @returns {undefined}
-	 *
-	 * Updates state to toggle `AccordionPanel` open and closeds
 	 */
 	_handleToggle(e){
 		e.preventDefault();
@@ -46,8 +50,7 @@ class AccordionPanel extends React.Component {
 	}
 
 	/**
-	 * Sets height of `AccordionPanel` to be appear open or closed when mounting
-	 *
+	 * @description Sets height of `AccordionPanel` to be appear open or closed when mounting
 	 * @returns {undefined}
 	 */
 	componentDidMount() {
@@ -57,9 +60,8 @@ class AccordionPanel extends React.Component {
 	}
 
 	/**
+	 * @description updates height in state based on `AccordionPanel` open and closed prop
 	 * @returns {undefined}
-	 *
-	 * Updates state to toggle `AccordionPanel` open and closed
 	 */
 	componentWillReceiveProps(nextProps) {
 		if (nextProps.isOpen !== this.props.isOpen) {

--- a/src/interactive/AccordionPanelGroup.jsx
+++ b/src/interactive/AccordionPanelGroup.jsx
@@ -36,11 +36,10 @@ class AccordionPanelGroup extends React.Component {
 
 	/**
 	 * @param {Object} accordionPanel - `AccordionPanel` components to clone
-	 * @param {number} i - index of the `AccordionPanel`
-	 * @param {boolean} isOpen - whether the `AccordionPanel` is open or not
+	 * @param {number} key - index of the `AccordionPanel` used as the key
 	 * @returns {Array} `AccordionPanel` components with props from `AccordionPanelGroup`
 	 */
-	clonePanel(accordionPanel, key, isOpen) {
+	clonePanel(accordionPanel, key) {
 		const panelProps = {
 			key,
 			indicatorAlign: this.props.indicatorAlign,

--- a/src/interactive/AccordionPanelGroup.jsx
+++ b/src/interactive/AccordionPanelGroup.jsx
@@ -12,13 +12,15 @@ class AccordionPanelGroup extends React.Component {
 		super(props);
 
 		this.state = {
-			clickedPanel: null
+			openPanels: []
 		};
 
 		this.clonePanel = this.clonePanel.bind(this);
-		this.setClickedPanel = this.setClickedPanel.bind(this);
+		this.setOpenPanels = this.setOpenPanels.bind(this);
+		this.isPanelInState = this.isPanelInState.bind(this);
 
-		this.accordionPanels = this.props.accordionPanels.map(this.clonePanel);
+		this.accordionPanels = this.props.accordionPanels.map((panel, i, arr) => this.clonePanel(panel, i, arr, true));
+
 	}
 
 	/**
@@ -28,29 +30,62 @@ class AccordionPanelGroup extends React.Component {
 	 * Keeps track of the clicked panel in order to support AccordionPanelGroups that only
 	 * have one panel open at a time.
 	 */
-	setClickedPanel(clickedPanel) {
-		if (!this.props.multiSelectable) {
-			this.setState({ clickedPanel });
+	setOpenPanels(clickedPanel, isOpen) {
+
+		const isSaved = this.isPanelInState(clickedPanel);
+
+		// tell parent to store it
+		let panelsToSave;
+
+		if (isOpen && !isSaved) {
+			if (this.props.multiSelectable) {
+				const openPanels = [...this.state.openPanels];
+				openPanels.push(clickedPanel);
+				panelsToSave = openPanels;
+			} else {
+				panelsToSave = [clickedPanel];
+			}
+		} else if (!isOpen && isSaved) {
+			const openPanels = [...this.state.openPanels];
+			const filteredPanels = openPanels.filter((panel) => panel.props.clickId !== clickedPanel.props.clickId);
+			panelsToSave = filteredPanels;
 		}
+		this.setState({ openPanels: panelsToSave });
+	}
+
+	isPanelInState(panel) {
+		return this.state.openPanels.filter((openPanel) => openPanel.props.clickId === panel.props.clickId).length > 0;
 	}
 
 	/**
 	 * @param {Object} accordionPanel - `AccordionPanel` components to clone
-	 * @param {number} key - index of the `AccordionPanel` used as the key
+	 * @param {number} i - index of the `AccordionPanel` used as the key
 	 * @returns {Array} `AccordionPanel` components with props from `AccordionPanelGroup`
 	 */
-	clonePanel(accordionPanel, key) {
-		const panelProps = {
-			key,
+	clonePanel(accordionPanel, i, arr, initialize) {
+		const isOpen = (initialize) ? accordionPanel.props.isOpen : this.isPanelInState(accordionPanel);
+
+		let panelProps = {
+			key: i,
 			indicatorAlign: this.props.indicatorAlign,
 			indicatorIcon: this.props.indicatorIcon,
 			indicatorIconActive: this.props.indicatorIconActive,
 			indicatorSwitch: this.props.indicatorSwitch,
 			className: accordionPanel.props.className,
-			setClickedPanel: this.setClickedPanel,
-			isOpen: accordionPanel.props.isOpen
+			setClickedPanel: this.setOpenPanels,
+			isOpen
 		};
-		return React.cloneElement(accordionPanel, panelProps);
+		if (initialize) {
+			panelProps = {
+				...panelProps,
+				clickId: i
+			};
+		}
+		const panel = React.cloneElement(accordionPanel, panelProps);
+		if (initialize && panel.props.isOpen) {
+			this.setOpenPanels(panel, panel.props.isOpen);
+		}
+		return panel;
 	}
 
 	/**

--- a/src/interactive/AccordionPanelGroup.jsx
+++ b/src/interactive/AccordionPanelGroup.jsx
@@ -10,30 +10,33 @@ export const ACCORDIONPANELGROUP_CLASS = 'accordionPanelGroup';
 class AccordionPanelGroup extends React.Component {
 	constructor(props) {
 		super(props);
-		this.state = { panelStates: {} };
+
+		this.state = { panelStates: {} }; // this will be an object in the form [clickId]: isOpen
 
 		this.clonePanel = this.clonePanel.bind(this);
 		this.setPanelStates = this.setPanelStates.bind(this);
 		this.accordionPanels = this.props.accordionPanels.map(this.clonePanel);
 	}
 
+	/**
+	 * @description sets the initial panelStates object based on panel props
+	 */
 	componentWillMount() {
 		const panelStates = this.accordionPanels.reduce(function(stateObj, panel) {
 			stateObj[panel.props.clickId] = panel.props.isOpen;
 			return stateObj;
 		}, {});
 
-		this.setState({ panelStates }, () => {
-			console.log(this.state.panelStates);
-		});
+		this.setState({ panelStates });
 	}
 
 	/**
-	 * @param clickedPanel is the `AccordionPanel` component passed in from `_handleToggle`
-	 * @returns {undefined}
-	 *
-	 * Keeps track of the clicked panel in order to support AccordionPanelGroups that only
+	 * @description callback called when individual panel is clicked
+	 * and keeps track of open states in order to support AccordionPanelGroups that only
 	 * have one panel open at a time.
+	 * @param {Integer} clickedPanelId the clickId prop of the `AccordionPanel` component
+	 * @param {Boolean} isOpen whether to open the panel or not (!props.isOpen of the panel)
+	 * @returns {undefined}
 	 */
 	setPanelStates(clickedPanelId, isOpen) {
 		const panelStates = (!this.props.multiSelectable && isOpen) ?
@@ -51,12 +54,15 @@ class AccordionPanelGroup extends React.Component {
 	}
 
 	/**
+	 * @description inits/clones a panel with props from the group and individual panel,
+	 * whhich is then stored as part of accordionPanels array
 	 * @param {Object} accordionPanel - `AccordionPanel` components to clone
 	 * @param {number} i - index of the `AccordionPanel` used as the key
-	 * @returns {Array} `AccordionPanel` components with props from `AccordionPanelGroup`
+	 * @returns {Component} `AccordionPanel` component with props from `AccordionPanelGroup`
 	 */
-	clonePanel(panel, index, arr) {
-		// if we've already initialized state for the accordion, use the open state
+	clonePanel(panel, index) {
+		// if we've already initialized state for the accordion panels,
+		// use the state we've stored, else use original prop
 		const panelState = this.state.panelStates && this.state.panelStates[panel.props.clickId];
 		const isOpen = (typeof(panelState) === 'undefined') ?
 			panel.props.isOpen : panelState;


### PR DESCRIPTION
The PR has moved to: https://github.com/meetup/meetup-web-components/pull/330

#### Related issues
Fixes https://meetup.atlassian.net/browse/<XXX-###>

There is no bug for this yet.

#### Description
When using the `AccordionPanelGroup` in `mup-web` problems with re-rendering and props came up where the accordion panel would open and immediately rerender and close.

The problem seemed to be in AccordionPanelGroup's `render/clonePanels` method, which relied on `props` from each panel to dictate whether or not the panel should be rendered open.
This prop was often still `false` even after being clicked open, it never gets set as `true` by any parent.

I'm thinking that the reason it looks like it works in storybook and not `mup-web`, is that storybook doesnt have as may parents/containers that can trigger re-renders like our app.

The solution I implemented was to have the `AccrodionPanelGroup` keep track of `openPanels` in its state. `clickId` prop is given to each panel by the panelGroup in order to identify whether or not the panel is in its `openPanels`.

The code needs some cleanup, but I would like feedback on whether or not this is correct.
It works in storybook and in `mup-web` event schedule.

#### Screenshots (if applicable)

- [ ] update tests
