### PR TITLE
Non-dismissing toast hover bugfix

### DIFF
--- a/src/interactive/Toaster.jsx
+++ b/src/interactive/Toaster.jsx
@@ -48,11 +48,12 @@ class Toaster extends React.PureComponent {
 	 * sets timers to delay a toast's dismissal
 	 */
 	setTimer(toast) {
-		this.timeouts.push(
-			setTimeout(() => {
-				this.dismissToast(toast);
-			}, DELAY_TIME + MARGINAL_DELAY * toast.key)
-		);
+		toast.props.autodismiss &&
+			this.timeouts.push(
+				setTimeout(() => {
+					this.dismissToast(toast);
+				}, DELAY_TIME + MARGINAL_DELAY * toast.key)
+			);
 	}
 
 	/**
@@ -62,7 +63,7 @@ class Toaster extends React.PureComponent {
 	 */
 	restartTimeouts() {
 		this.state.toasts &&
-			this.state.toasts.filter(t => t.props.autodismiss).map(this.setTimer);
+			this.state.toasts.map(this.setTimer);
 	}
 
 	/**

--- a/src/interactive/Toaster.jsx
+++ b/src/interactive/Toaster.jsx
@@ -61,9 +61,8 @@ class Toaster extends React.PureComponent {
 	 * removes timers in order to prevent toasts from being automatically dismissed
 	 */
 	restartTimeouts() {
-		const toasts = this.state.toasts;
-
-		toasts.forEach(this.setTimer);
+		this.state.toasts &&
+			this.state.toasts.filter(t => t.props.autodismiss).map(this.setTimer);
 	}
 
 	/**
@@ -80,8 +79,7 @@ class Toaster extends React.PureComponent {
 	}
 
 	componentDidMount() {
-		this.state.toasts &&
-			this.state.toasts.filter(t => t.props.autodismiss).map(this.setTimer);
+		this.restartTimeouts();
 	}
 
 	componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
#### Description
Toasts with `autodismiss` prop set to `false` would still dismiss toasts if the toast was hovered
