### PR TITLE
Update button styles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 3.1.$(CI_BUILD_NUMBER)
+VERSION ?= 3.2.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/assets/scss/components/_button.scss
+++ b/assets/scss/components/_button.scss
@@ -44,7 +44,7 @@ _(The `extend` directive can cause ugly cascade problems)_
 	font-size: $font-size-small;
 	line-height: $line-height-smallText;
 	outline: 0;
-	padding: $space $space-double;
+	padding: $space-half $space-double;
 	vertical-align: middle;
 
 	@include browser-ie11() {
@@ -129,9 +129,9 @@ _(The `extend` directive can cause ugly cascade problems)_
 
 	.inverted & {
 		@include buttonColor(
-			$bgColor: $C_fieldBGInverted,
-			$hoverColor: opacify($C_fieldBGInverted, .05),
-			$activeColor: opacify($C_fieldBGInverted, .1),
+			$bgColor: $C_buttonBGNeutralInverted,
+			$hoverColor: opacify($C_buttonBGNeutralInverted, .05),
+			$activeColor: opacify($C_buttonBGNeutralInverted, .1),
 			$textColor: $C_textSecondaryInverted
 		);
 	}
@@ -142,18 +142,14 @@ _(The `extend` directive can cause ugly cascade problems)_
 //
 .button {
 	@include buttonBase();
-	@include buttonColor(
-		$textColor: $C_textPrimaryInverted
-	);
+	@include buttonColor();
 
 	.inverted & {
 		@include buttonColor(
-			$bgColor: $C_blue,
-			$hoverColor: opacify($C_blue, .05),
-			$activeColor: opacify($C_blue, .1)
-			// $textColor: $C_textPrimaryInverted
+			$bgColor: $C_textSecondaryInverted,
+			$hoverColor: opacify($C_textSecondaryInverted, .1),
+			$activeColor: opacify($C_textSecondaryInverted, .25)
 		);
-		// @include color-all($C_textPrimaryInverted);
 	}
 }
 
@@ -179,7 +175,6 @@ _(The `extend` directive can cause ugly cascade problems)_
 //
 // Subtle/neutral buttons
 //
-$C_buttonBGNeutralInverted: rgba(255,255,255,.2);
 %button--neutral,
 .button--neutral {
 	@include buttonColor(
@@ -246,9 +241,9 @@ $C_buttonBGNeutralInverted: rgba(255,255,255,.2);
 .button[disabled],
 .button--disabled {
 	@include buttonColor(
-		$bgColor: $C_fieldBG--disabled,
-		$hoverColor: $C_fieldBG--disabled,
-		$activeColor: $C_fieldBG--disabled,
+		$bgColor: $C_buttonBGNeutral--disabled,
+		$hoverColor: $C_buttonBGNeutral--disabled,
+		$activeColor: $C_buttonBGNeutral--disabled,
 		$textColor: $C_textHint
 	);
 	outline: none;
@@ -256,9 +251,10 @@ $C_buttonBGNeutralInverted: rgba(255,255,255,.2);
 
 	.inverted & {
 		@include buttonColor(
-			$bgColor: $C_fieldBGinverted--disabled,
-			$hoverColor: $C_fieldBGinverted--disabled,
-			$activeColor: $C_fieldBGinverted--disabled
+			$bgColor: $C_buttonBGNeutralInverted--disabled,
+			$hoverColor: $C_buttonBGNeutralInverted--disabled,
+			$activeColor: $C_buttonBGNeutralInverted--disabled,
+			$textColor: $C_textHintInverted
 		);
 		@include color-all($C_textHintInverted);
 	}

--- a/assets/scss/components/_button.scss
+++ b/assets/scss/components/_button.scss
@@ -67,9 +67,9 @@ Applies button color-related styles using a mixin.
 ```
 */
 @mixin buttonColor(
-	$bgColor: $C_buttonBG,
-	$hoverColor: opacify($bgColor, .05),
-	$activeColor: opacify($hoverColor, .1),
+	$bgColor: $C_blue,
+	$hoverColor: darken($bgColor, 5%),
+	$activeColor: darken($bgColor, 12%),
 	$textColor: getPrimaryTextColor($bgColor)
 ) {
 	@include color-all($textColor);
@@ -137,118 +137,29 @@ _(The `extend` directive can cause ugly cascade problems)_
 	}
 }
 
-/*doc
----
-title: Buttons
-name: buttons
-category: UI Components
----
-
-#### Example
-
-```html_example
-<ul class="list">
-	<li class="list-item chunk">
-		<h3>Standard Buttons</h3>
-		<button class="button" href="#">Button</button>
-		<button class="button button--primary" href="#">Primary Button</button>
-	</li>
-	<li class="list-item chunk stripe--inverted inverted padding--all">
-		<h3>Contrast Buttons</h3>
-		<button class="button button--contrast" href="#">Contrast Button</button>
-		<button class="button button--contrast button--primary" href="#">Primary Contrast Button</button>
-	</li>
-	<li class="list-item chunk">
-		<h3>Small buttons</h3>
-		<div class="chunk">
-			<button class="button button--small" href="#">Small Button</button>
-			<button class="button button--primary button--small" href="#">Small Button</button>
-		</div>
-		<div class="chunk">
-			<span class="text--small">Inline text with button</span><button class="button button--primary button--small margin--left" href="#">Inline button with text</button>
-		</div>
-	</li>
-	<li class="list-item chunk">
-		<h3>Full width button</h3>
-		<div class="chunk">
-			<button class="button button--fullWidth" href="#">Wide load</button>
-		</div>
-		<div class="chunk">
-			<button class="button button--primary button--fullWidth" href="#">Wide load</button>
-		</div>
-	</li>
-	<li class="list-item chunk">
-		<h3>Icon buttons</h3>
-		<div class="chunk">
-			<button class="button button--icon" href="#">
-				<span class="button-label">Button with right Icon</span>
-				<span class="button-icon">X</span>
-			</button>
-		</div>
-		<div class="chunk">
-			<button class="button button--icon button--primary" href="#">
-				<span class="button-icon">X</span>
-				<span class="button-label">Primary button with left Icon</span>
-			</button>
-		</div>
-		<div class="chunk">
-			<button class="button button--primary button--icon button--fullWidth" href="#">
-				<span class="button-icon">ヘ(◕。◕ヘ)</span>
-				<span class="button-label">Full width primary button with left Icon</span>
-			</button>
-		</div>
-	</li>
-	<li class="list-item chunk">
-		<h3>Disabled buttons</h3>
-		<button class="button button--disabled" href="#">Stop</button>
-		<button class="button button--primary" disabled>Can't touch this</button>
-		<input type="submit" class="button" value="Disabled" disabled />
-	</li>
-	<li class="list-item chunk">
-		<h3>Buttons with form fields</h3>
-		<div class="row">
-			<div class="row-item">
-				<input type="text" placeholder="Field by a button" />
-			</div>
-			<div class="row-item row-item--shrink">
-				<button class="button button--primary">Button by a field</button>
-			</div>
-		</div>
-	</li>
-</ul>
-```
-
-#### Button variants
-A class of `.button` is __required__ for buttons. The following
-classes are optional variants:
-
-Class                   | Description
------------------------ | ----------------------------------------
-`.button--primary`      | rounded button with dark background; for primary actions
-`.button--contrast`     | bold, dark text; use on dark or colorful backgrounds or on photos
-`.button--reset`        | resets default button styles; bold text on transparent background
-`.button--small`        | decreases size of button
-`.button--fullWidth`    | makes button fill width
-`.button--icon`         | button with icon (see example for markup pattern)
-*/
-
+//
+// Default buttons
+//
 .button {
 	@include buttonBase();
 	@include buttonColor(
-		$textColor: $C_textSecondary
+		$textColor: $C_textPrimaryInverted
 	);
 
 	.inverted & {
 		@include buttonColor(
-			$bgColor: $C_fieldBGInverted,
-			$hoverColor: opacify($C_fieldBGInverted, .05),
-			$activeColor: opacify($C_fieldBGInverted, .1),
-			$textColor: $C_textSecondary
+			$bgColor: $C_blue,
+			$hoverColor: opacify($C_blue, .05),
+			$activeColor: opacify($C_blue, .1)
+			// $textColor: $C_textPrimaryInverted
 		);
-		@include color-all($C_textSecondaryInverted);
+		// @include color-all($C_textPrimaryInverted);
 	}
 }
 
+//
+// Primary buttons
+//
 %button--primary,
 .button--primary {
 	@include buttonColor(
@@ -265,6 +176,32 @@ Class                   | Description
 	}
 }
 
+//
+// Subtle/neutral buttons
+//
+$C_buttonBGNeutralInverted: rgba(255,255,255,.2);
+%button--neutral,
+.button--neutral {
+	@include buttonColor(
+		$bgColor: $C_buttonBGNeutral,
+		$hoverColor: opacify($C_buttonBGNeutral, .05),
+		$activeColor: opacify($C_buttonBGNeutral, .1),
+		$textColor: $C_textSecondary
+	);
+	.inverted & {
+		@include buttonColor(
+			$bgColor: $C_buttonBGNeutralInverted,
+			$hoverColor: opacify($C_buttonBGNeutralInverted, .05),
+			$activeColor: opacify($C_buttonBGNeutralInverted, .1),
+			$textColor: $C_textSecondary
+		);
+		@include color-all($C_textSecondaryInverted);
+	}
+}
+
+//
+// Bordered buttons
+//
 .button--bordered {
 	@include buttonColor(
 		$bgColor: $C_contentBG,

--- a/assets/scss/components/_button.scss
+++ b/assets/scss/components/_button.scss
@@ -301,7 +301,7 @@ _(The `extend` directive can cause ugly cascade problems)_
 %button--small,
 .button--small {
 	border-radius: $defaultRadius;
-	padding: $space-half $space;
+	padding: $space-quarter $space;
 }
 
 //

--- a/assets/scss/components/_button.scss
+++ b/assets/scss/components/_button.scss
@@ -40,7 +40,7 @@ _(The `extend` directive can cause ugly cascade problems)_
 	@include transition(background .15s);
 	box-sizing: border-box;
 	-webkit-appearance: none;
-	border-radius: $largeRadius;
+	border-radius: 6px;
 	font-size: $font-size-small;
 	line-height: $line-height-smallText;
 	outline: 0;

--- a/assets/scss/util/_color-mappings.scss
+++ b/assets/scss/util/_color-mappings.scss
@@ -1,6 +1,7 @@
 $C_accent: $C_red;
-$C_buttonBG: rgba(0,0,0,.09);
-$C_fieldBG: rgba(0,0,0,.05);
-$C_fieldBGInverted: $C_borderInverted;
-$C_fieldBG--disabled: rgba(0,0,0,.02);
-$C_fieldBGinverted--disabled: rgba(255,255,255,.02);
+
+$C_buttonBGNeutral: $C_coolGrayLightTransp;
+$C_buttonBGNeutral--disabled: transparentize($C_coolGrayLightTransp, .04);
+
+$C_buttonBGNeutralInverted: $C_borderInverted;
+$C_buttonBGNeutralInverted--disabled: transparentize($C_borderInverted, 0.17);

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "prop-types": "15.5.10",
     "recompose": "0.24.0",
     "swarm-animation": "https://github.com/meetup/swarm-animation.git",
-    "swarm-sasstools": "2.0.135"
+    "swarm-sasstools": "2.0.282"
   },
   "devDependencies": {
     "@alrra/travis-scripts": "3.0.1",

--- a/src/forms/Button.jsx
+++ b/src/forms/Button.jsx
@@ -21,8 +21,9 @@ class Button extends React.PureComponent {
 			onClick,
 			reset,
 			fullWidth,
-			icon,
 			primary,
+			neutral,
+			icon,
 			right,
 			small,
 			bordered,
@@ -39,8 +40,8 @@ class Button extends React.PureComponent {
 					'button--small': small,
 					'button--reset': reset,
 					'button--bordered': bordered,
-					'button--hasHoverShadow': hasHoverShadow
-
+					'button--hasHoverShadow': hasHoverShadow,
+					'button--neutral': neutral
 				},
 				className
 			),

--- a/src/forms/button.story.jsx
+++ b/src/forms/button.story.jsx
@@ -29,6 +29,28 @@ storiesOf('Button', module)
 	.add('Default - with hover shadow', () => (
 		<Button onClick={action('clicked')} hasHoverShadow>Button Label</Button>
 	))
+	.add('Neutral', () => (
+		<Button onClick={action('clicked')} neutral>Button Label</Button>
+	))
+	.add('Neutral - with hover shadow', () => (
+		<Button onClick={action('clicked')} neutral hasHoverShadow>Button Label</Button>
+	))
+	.add('Neutral - inverted', () => (
+		<Inverted>
+			<Button onClick={action('clicked')}neutral>Button Label</Button>
+		</Inverted>
+	))
+	.add('Primary', () => (
+		<Button onClick={action('clicked')} primary>Button Label</Button>
+	))
+	.add('Primary - with hover shadow', () => (
+		<Button onClick={action('clicked')} primary hasHoverShadow>Button Label</Button>
+	))
+	.add('Primary - inverted', () => (
+		<Inverted>
+			<Button onClick={action('clicked')}primary>Button Label</Button>
+		</Inverted>
+	))
 	.add('Disabled', () => (
 		<Button onClick={action('clicked')} disabled>Button Label</Button>
 	))
@@ -68,17 +90,6 @@ storiesOf('Button', module)
 	))
 	.add('Full Width', () => (
 		<Button onClick={action('clicked')} fullWidth>Button Label</Button>
-	))
-	.add('Primary', () => (
-		<Button onClick={action('clicked')} primary>Button Label</Button>
-	))
-	.add('Primary - with hover shadow', () => (
-		<Button onClick={action('clicked')} primary hasHoverShadow>Button Label</Button>
-	))
-	.add('Primary - inverted', () => (
-		<Inverted>
-			<Button onClick={action('clicked')}primary>Button Label</Button>
-		</Inverted>
 	))
 	.add('Small', () => (
 		<Button onClick={action('clicked')} small>Button Label</Button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6509,9 +6509,9 @@ svgo@^0.7.0:
     jasmine-jquery "^2.1.1"
     jquery "^3.2.1"
 
-swarm-constants@0.2.31:
-  version "0.2.31"
-  resolved "https://registry.yarnpkg.com/swarm-constants/-/swarm-constants-0.2.31.tgz#be86eb4076784ec2709ebbb404213639a84aef23"
+swarm-constants@1.2.44:
+  version "1.2.44"
+  resolved "https://registry.yarnpkg.com/swarm-constants/-/swarm-constants-1.2.44.tgz#4c2e0801705163a6678d8cbded75c9e3c793e03f"
   dependencies:
     "@alrra/travis-scripts" "^3.0.1"
     gh-pages "^1.0.0"
@@ -6521,13 +6521,13 @@ swarm-icons@1.3.183:
   version "1.3.183"
   resolved "https://registry.yarnpkg.com/swarm-icons/-/swarm-icons-1.3.183.tgz#89b2033334f53003c1401499452eee1addecce4b"
 
-swarm-sasstools@2.0.135:
-  version "2.0.135"
-  resolved "https://registry.yarnpkg.com/swarm-sasstools/-/swarm-sasstools-2.0.135.tgz#f4b4db0db8f1b5a01347d4e749b6271614606c37"
+swarm-sasstools@2.0.282:
+  version "2.0.282"
+  resolved "https://registry.yarnpkg.com/swarm-sasstools/-/swarm-sasstools-2.0.282.tgz#f17247cdad026f51342d9788bb17972c16db2345"
   dependencies:
     bourbon "4.2.3"
     sass-rem "^1.2.4"
-    swarm-constants "0.2.31"
+    swarm-constants "1.2.44"
 
 symbol-observable@^1.0.1, symbol-observable@^1.0.3, symbol-observable@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
These changes aren't "breaking", but there are a few buttons we want to change to the "neutral" style. **How should this be versioned?**

#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-426

#### Description
Updated default button background color to be `$C_blue`, added a new quieter button style called "neutral"

#### Screenshots (if applicable)
New default button style:
<img width="186" alt="screen shot 2017-10-11 at 12 13 18 pm" src="https://user-images.githubusercontent.com/2313998/31452698-b507d62a-ae7d-11e7-8926-fb02b8b89d35.png">

New variant of button called "neutral" (formerly default button style):
<img width="164" alt="screen shot 2017-10-11 at 12 13 32 pm" src="https://user-images.githubusercontent.com/2313998/31452707-bc8ef7fc-ae7d-11e7-90e8-ee4774f4fba4.png">
