### PR TITLE
preventDefault in Popover onClick handler

### DIFF
--- a/src/interactive/Popover.jsx
+++ b/src/interactive/Popover.jsx
@@ -47,7 +47,12 @@ class Popover extends React.Component {
 	}
 
 	onClick(e) {
+		e.preventDefault();
 		this.openMenu();
+
+		if (this.props.onClick) {
+			this.props.onClick(e);
+		}
 	}
 
 	onKeyDown(e) {


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-117

#### Description
Need to add `e.preventDefault` so that when a `<Popover />` resides within a `<form>`, it doesn't cause the form to be submitted.

