### PR TITLE
Ensure popover menu item always has dark text color

### DIFF
--- a/assets/scss/components/_popover.scss
+++ b/assets/scss/components/_popover.scss
@@ -47,10 +47,7 @@ $view-minWidth: 320px;
 		border-top: none;
 	}
 
-	& > a,
-	& > span,
-	& > div,
-	& > button {
+	.popover-menu-option-target {
 		color: $C_textPrimary;
 		display: block;
 		padding: $space-half $space;


### PR DESCRIPTION
#### Description
Using a more specific selector to color menu item text