### PR TITLE
send whole event in props.onChange

### DIFF
--- a/src/forms/TimeInput.jsx
+++ b/src/forms/TimeInput.jsx
@@ -20,7 +20,7 @@ class TimeInput extends React.Component {
 	* 	handler prop, if there is one provided (eg supplied by redux-form or DateTimePicker)
 	*/
 	onChange(e) {
-		this.props.onChange && this.props.onChange(e.target.value);
+		this.props.onChange && this.props.onChange(e);
 	}
 
 	render() {

--- a/src/forms/timeInput.test.jsx
+++ b/src/forms/timeInput.test.jsx
@@ -41,8 +41,9 @@ describe('TimeInput', function() {
 	});
 
 	it('calls onChange prop when value is changed', function() {
-		component.instance().onChange({ target: { value: newTime } });
-		expect(onChangePropMock).toHaveBeenCalled();
+		const e = { target: { value: newTime } };
+		component.instance().onChange(e);
+		expect(onChangePropMock).toHaveBeenCalledWith(e);
 	});
 
 });


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-119

#### Description
props.onChange (which is usually set by reduc form) currently sends over e.target.value. redux form expects the event.

#### Screenshots (if applicable)

