### PR TITLE
Change red accent colors to blue

### DIFF
--- a/assets/scss/components/_avatar.scss
+++ b/assets/scss/components/_avatar.scss
@@ -158,7 +158,7 @@ $avatarBg: $C_coolGrayLight;
 	@extend %avatarCharm;
 	&:after {
 		@extend %backgroundImg--orgBadge;
-		background-color: $C_accent;
+		background-color: $C_red;
 		color: $C_textPrimaryInverted;
 	}
 }

--- a/assets/scss/components/_button.scss
+++ b/assets/scss/components/_button.scss
@@ -169,9 +169,9 @@ _(The `extend` directive can cause ugly cascade problems)_
 %button--primary,
 .button--primary {
 	@include buttonColor(
-		$bgColor: $C_actuallyRed,
-		$hoverColor: darken($C_actuallyRed, 10%),
-		$activeColor: darken($C_actuallyRed, 15%)
+		$bgColor: $C_red,
+		$hoverColor: darken($C_red, 10%),
+		$activeColor: darken($C_red, 15%)
 	);
 	.inverted & {
 		@include buttonColor(

--- a/assets/scss/components/_button.scss
+++ b/assets/scss/components/_button.scss
@@ -169,9 +169,9 @@ _(The `extend` directive can cause ugly cascade problems)_
 %button--primary,
 .button--primary {
 	@include buttonColor(
-		$bgColor: $C_accent,
-		$hoverColor: darken($C_accent, 10%),
-		$activeColor: darken($C_accent, 15%)
+		$bgColor: $C_actuallyRed,
+		$hoverColor: darken($C_actuallyRed, 10%),
+		$activeColor: darken($C_actuallyRed, 15%)
 	);
 	.inverted & {
 		@include buttonColor(

--- a/assets/scss/components/_tabs.scss
+++ b/assets/scss/components/_tabs.scss
@@ -84,6 +84,6 @@ Class                 | Description
 .tabs-tab--selected {
 	box-shadow: none;
 	border-bottom: 3px solid $C_accent;
-	color: $C_textPrimary;
+	color: $C_accent;
 	font-weight: $W_medium;
 }

--- a/assets/scss/components/_tabs.scss
+++ b/assets/scss/components/_tabs.scss
@@ -83,7 +83,7 @@ Class                 | Description
 }
 .tabs-tab--selected {
 	box-shadow: none;
-	border-bottom: 3px solid $C_red;
+	border-bottom: 3px solid $C_accent;
 	color: $C_textPrimary;
 	font-weight: $W_medium;
 }

--- a/assets/scss/util/_color-mappings.scss
+++ b/assets/scss/util/_color-mappings.scss
@@ -1,4 +1,6 @@
-$C_accent: $C_red;
+$C_accent: $C_blue;
+$C_red: $C_blue;
+$C_actuallyRed: #F13959;
 
 $C_buttonBGNeutral: $C_coolGrayLightTransp;
 $C_buttonBGNeutral--disabled: transparentize($C_coolGrayLightTransp, .04);

--- a/assets/scss/util/_color-mappings.scss
+++ b/assets/scss/util/_color-mappings.scss
@@ -1,6 +1,4 @@
 $C_accent: $C_blue;
-$C_red: $C_blue;
-$C_actuallyRed: #F13959;
 
 $C_buttonBGNeutral: $C_coolGrayLightTransp;
 $C_buttonBGNeutral--disabled: transparentize($C_coolGrayLightTransp, .04);


### PR DESCRIPTION
#### Description
We're now using `$C_blue` as an accent color instead of `$C_red` everywhere all of the time.

#### Screenshots (if applicable)
The only thing that visually changes in this PR is the tab highlight color:
<img width="325" alt="screen shot 2017-10-30 at 2 22 01 pm" src="https://user-images.githubusercontent.com/2313998/32188599-a3135efc-bd7e-11e7-8a85-898acbe0ea4f.png">
