### PR TITLE
Toggle Pills in radioButtonGroups should be responsive and felx to full width

### DIFF
--- a/assets/scss/components/_togglePill.scss
+++ b/assets/scss/components/_togglePill.scss
@@ -7,6 +7,10 @@
 	@include shadowOnHover();
 	margin: $space-quarter 0;
 	-webkit-tap-highlight-color: rgba(0,0,0,0);
+
+	.radioButtonGroup & {
+		@include display(flex);
+	}
 }
 
 .toggleButton-label--large {
@@ -14,7 +18,7 @@
 	padding: $space*1.5 $space;
 }
 
-.toggleButton-input{
+.toggleButton-input {
 	&:checked + .toggleButton-label {
 		@include buttonColor(
 			$bgColor: $C_blue,

--- a/assets/scss/components/_togglePill.scss
+++ b/assets/scss/components/_togglePill.scss
@@ -7,10 +7,6 @@
 	@include shadowOnHover();
 	margin: $space-quarter 0;
 	-webkit-tap-highlight-color: rgba(0,0,0,0);
-
-	.radioButtonGroup & {
-		@include display(flex);
-	}
 }
 
 .toggleButton-label--large {

--- a/src/forms/RadioButtonGroup.jsx
+++ b/src/forms/RadioButtonGroup.jsx
@@ -1,6 +1,5 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import cx from 'classnames';
 
 import Flex from '../layout/Flex';
 import FlexItem from '../layout/FlexItem';
@@ -46,15 +45,10 @@ export default class RadioButtonGroup extends PureComponent {
 			className
 		} = this.props;
 
-		const classNames = cx(
-			'radioButtonGroup',
-			className
-		);
-
 		const switchDirectionAttr = (switchDirection) ? { switchDirection } : '';
 
 		return (
-			<Flex direction={direction} {...switchDirectionAttr} className={classNames}>
+			<Flex direction={direction} {...switchDirectionAttr} className={className}>
 				{React.Children.map(children, option =>
 					(<FlexItem shrink>
 						{React.cloneElement(option, {

--- a/src/forms/RadioButtonGroup.jsx
+++ b/src/forms/RadioButtonGroup.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 
 import Flex from '../layout/Flex';
 import FlexItem from '../layout/FlexItem';
@@ -37,9 +38,23 @@ export default class RadioButtonGroup extends PureComponent {
 	}
 
 	render() {
-		const { direction, children, name, className } = this.props;
+		const {
+			direction,
+			switchDirection,
+			children,
+			name,
+			className
+		} = this.props;
+
+		const classNames = cx(
+			'radioButtonGroup',
+			className
+		);
+
+		const switchDirectionAttr = (switchDirection) ? { switchDirection } : '';
+
 		return (
-			<Flex direction={direction} className={className}>
+			<Flex direction={direction} {...switchDirectionAttr} className={classNames}>
 				{React.Children.map(children, option =>
 					(<FlexItem shrink>
 						{React.cloneElement(option, {

--- a/src/forms/TogglePill.jsx
+++ b/src/forms/TogglePill.jsx
@@ -32,6 +32,7 @@ class TogglePill extends React.Component {
 			isActive,
 			children,
 			className,
+			labelClassName,
 			topic,
 			id,
 			large,
@@ -59,7 +60,8 @@ class TogglePill extends React.Component {
 			'toggleButton-label',
 			{
 				'toggleButton-label--large': large
-			}
+			},
+			labelClassName
 		);
 
 		// ---
@@ -111,8 +113,11 @@ TogglePill.protoTypes = {
 	value: PropTypes.string.isRequired,
 	children: PropTypes.node.isRequired,
 	isActive: PropTypes.bool,
-	topic: PropTypes.bool
+	useRadio: PropTypes.bool,
+	topic: PropTypes.bool,
+	labelClassName: PropTypes.string,
 };
+
 TogglePill.defaultProps = {
 	isActive: false
 };

--- a/src/forms/__snapshots__/radioButtonGroup.test.jsx.snap
+++ b/src/forms/__snapshots__/radioButtonGroup.test.jsx.snap
@@ -1,8 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`RadioButtonGroup should apply switchDirection and direction props 1`] = `
+<Flex
+  className="some-class"
+  direction="column"
+  switchDirection="medium"
+>
+  <FlexItem
+    key=".0"
+    shrink={true}
+  >
+    <RadioButton
+      checked={true}
+      label="label 1"
+      name="name"
+      onChange={[Function]}
+      value="one"
+    />
+  </FlexItem>
+  <FlexItem
+    key=".1"
+    shrink={true}
+  >
+    <RadioButton
+      checked={false}
+      label="label 2"
+      name="name"
+      onChange={[Function]}
+      value="two"
+    />
+  </FlexItem>
+</Flex>
+`;
+
 exports[`RadioButtonGroup should match the snapshot 1`] = `
 <Flex
-  className="radioButtonGroup some-class"
+  className="some-class"
   direction="row"
 >
   <FlexItem

--- a/src/forms/__snapshots__/radioButtonGroup.test.jsx.snap
+++ b/src/forms/__snapshots__/radioButtonGroup.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`RadioButtonGroup should match the snapshot 1`] = `
 <Flex
-  className="some-class"
+  className="radioButtonGroup some-class"
   direction="row"
 >
   <FlexItem

--- a/src/forms/__snapshots__/togglePill.test.jsx.snap
+++ b/src/forms/__snapshots__/togglePill.test.jsx.snap
@@ -4,6 +4,8 @@ exports[`TogglePill renders a component with expected attributes 1`] = `
 <WithToggle
   id="hikingCategory"
   isActive={false}
+  labelClassName="someClass"
+  large={true}
   name="meetupCategories"
   onChange={[Function]}
   value="hiking"
@@ -15,6 +17,8 @@ exports[`TogglePill renders a component with expected attributes 1`] = `
     <TogglePill
       id="hikingCategory"
       isActive={false}
+      labelClassName="someClass"
+      large={true}
       name="meetupCategories"
       onChange={[Function]}
       toggleActive={[Function]}
@@ -33,7 +37,7 @@ exports[`TogglePill renders a component with expected attributes 1`] = `
           value="hiking"
         />
         <label
-          className="toggleButton-label"
+          className="toggleButton-label toggleButton-label--large someClass"
           htmlFor="hikingCategory"
         >
           Hiking!

--- a/src/forms/radioButtonGroup.story.jsx
+++ b/src/forms/radioButtonGroup.story.jsx
@@ -76,4 +76,46 @@ storiesOf('RadioButtonGroup', module)
 				3rd.
 			</TogglePill>
 		</RadioButtonGroup>
+	))
+	.add('with column at breakpoint', () => (
+		<RadioButtonGroup
+			name='option'
+			direction='column'
+			switchDirection='medium'
+			onChange={action('radio button change')}
+			onBlur={action('radio button blur')}
+			onFocus={action('radio button focus')}
+			selectedValue="third"
+		>
+			<TogglePill
+				id='toggle1'
+				name='ranking'
+				value='first'
+				labelClassName='span--100'
+				isActive
+				useRadio
+			>
+				Responsive btn
+			</TogglePill>
+			<TogglePill
+				id='toggle2'
+				name='ranking'
+				value='second'
+				labelClassName='span--100'
+				isActive
+				useRadio
+			>
+				Me too
+			</TogglePill>
+			<TogglePill
+				id='toggle3'
+				name='ranking'
+				value='third'
+				labelClassName='span--100'
+				isActive
+				useRadio
+			>
+				Responsive too
+			</TogglePill>
+		</RadioButtonGroup>
 	));

--- a/src/forms/radioButtonGroup.test.jsx
+++ b/src/forms/radioButtonGroup.test.jsx
@@ -23,6 +23,10 @@ describe('RadioButtonGroup', () => {
 		expect(getWrapper()).toMatchSnapshot();
 	});
 
+	it('should apply switchDirection and direction props', () => {
+		expect(getWrapper({ switchDirection: 'medium', direction: 'column' })).toMatchSnapshot();
+	});
+
 	describe('componentWillReceiveProps', () => {
 		it('should update state.selectedValue if the next props contain selectedValue', () => {
 			const wrapper = getWrapper();

--- a/src/forms/togglePill.test.jsx
+++ b/src/forms/togglePill.test.jsx
@@ -7,7 +7,8 @@ describe('TogglePill', () => {
 	const id = 'hikingCategory',
 		name = 'meetupCategories',
 		label = 'Hiking!',
-		value = 'hiking';
+		value = 'hiking',
+		labelClass = 'someClass';
 
 	let togglePillComponent;
 	const onChangeMock = jest.fn();
@@ -18,6 +19,8 @@ describe('TogglePill', () => {
 				onChange={onChangeMock}
 				id={id}
 				name={name}
+				large
+				labelClassName={labelClass}
 				value={value}>
 				{label}
 			</TogglePill>

--- a/src/forms/togglepill.story.jsx
+++ b/src/forms/togglepill.story.jsx
@@ -48,6 +48,17 @@ storiesOf('TogglePill', module)
 			Toggle Pill Label
 		</TogglePill>
 	))
+	.add('with labelClassName', () => (
+		<TogglePill
+			onChange={onChange}
+			id='togglePillId'
+			name='togglePillName'
+			value='toggle-pill'
+			labelClassName='span--100'
+		>
+			I will span--100
+		</TogglePill>
+	))
 	.add('Topic pill', () => (
 		<TogglePill
 			topic


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-124

#### Description

Toggle pills in radio button group do not fill width when you tell the group to switch to coulmn at smaller widths. 

#### Screenshots (if applicable)
Right now:

<img width="437" alt="screen shot 2017-10-30 at 9 09 21 pm" src="https://user-images.githubusercontent.com/92090/32204356-a20fe600-bdb6-11e7-9c90-c51a9b3d3429.png">

we want it to be like this:
<img width="477" alt="screen shot 2017-10-30 at 8 54 05 pm" src="https://user-images.githubusercontent.com/92090/32204185-dbca23fc-bdb5-11e7-8747-ed00021f2f6d.png">


- [x] need story
- [x] add test?
