### PR TITLE
SelectInput arrow overlapping text bugfix

### DIFF
--- a/assets/scss/components/_forms.scss
+++ b/assets/scss/components/_forms.scss
@@ -50,7 +50,7 @@ input.field--reset:active {
 	.inverted & {
 		@include resetFieldStyles;
 	}
-  
+
 }
 
 //
@@ -233,6 +233,13 @@ $C_toggleHighlight: $C_blue;
 	position: absolute;
 	pointer-events: none;
 	right: $space;
+}
+
+.padding--selectArrow {
+	padding-right: $media-xs + $space + $space-half;
+	// $media-xs:   enough padding for the arrow
+	// $space:      preserve right padding in forms
+	// $space-half: give a little space between the arrow and the text
 }
 
 //

--- a/src/forms/SelectInput.jsx
+++ b/src/forms/SelectInput.jsx
@@ -46,7 +46,7 @@ class SelectInput extends React.Component {
 		} = this.props;
 
 		const classNames = cx(
-			'select--reset span--100',
+			'select--reset span--100 padding--selectArrow',
 			{ 'field--error': errors && errors.length > 0 || error },
 			className
 		);

--- a/src/forms/__snapshots__/selectInput.test.jsx.snap
+++ b/src/forms/__snapshots__/selectInput.test.jsx.snap
@@ -11,7 +11,7 @@ exports[`SelectInput basic renders into the DOM 1`] = `
       Test select
     </label>
     <select
-      className="select--reset span--100"
+      className="select--reset span--100 padding--selectArrow"
       name="testSelect"
       onChange={[Function]}
       value="1"


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-127

#### Description
Added some right padding to <SelectInput> to accommodate the custom arrow

#### Screenshots (if applicable)

