### PR TITLE
Enable scroll bars so IE users can horizontally scroll

### DIFF
--- a/assets/scss/components/_hscroll.scss
+++ b/assets/scss/components/_hscroll.scss
@@ -59,19 +59,10 @@ Class                       | Description
 	}
 }
 
-.hscrollContainer, .hscroll {
-	margin-bottom: -#{$space-and-half};
-}
-
-.hscrollContainer {
-	overflow: hidden;
-}
-
 .hscroll {
 	-webkit-overflow-scrolling: touch;
 	-ms-overflow-style: -ms-autohiding-scrollbar;
 	overflow-x: scroll;
-	-ms-overflow-style: auto
 }
 
 .hscroll::-webkit-scrollbar {
@@ -81,7 +72,6 @@ Class                       | Description
 .hscroll-content {
 	@extend %inlineblockList;
 	box-sizing: content-box;
-	margin-bottom: $space-and-half !important; // !important to kill styles coming from `sassquatch.css`, being imported by `swarm-sasstools`
 	white-space: nowrap;
 	> li {
 		vertical-align: top;

--- a/assets/scss/storybook.scss
+++ b/assets/scss/storybook.scss
@@ -7,6 +7,10 @@ html, body, #root {
 	display: flex;
 	align-items: center;
 	justify-content: center;
+
+	> div {
+		width: 100%;
+	}
 }
 div[data-reactroot] {
 	width: 100%;


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-449

#### Description
IE doesn't allow horizontal scrolling without using the scroll bars. Instead of brute-force hiding scroll bars all of the time, I'm styling them invisible for browsers that allow that, and doing my best to only show them when necessary for browsers that don't

#### Screenshots (if applicable)

