### PR TITLE
Better autosize height updating for Textarea

### DIFF
--- a/src/forms/Textarea.jsx
+++ b/src/forms/Textarea.jsx
@@ -50,7 +50,16 @@ class Textarea extends React.Component {
 	 */
 	componentWillReceiveProps(nextProps) {
 		this.overrideValue(nextProps);
-		autosize.update(this.textarea);
+	}
+
+	/**
+	 * @param {Object} prevProps the previous props
+	 * @return {undefined} side effect only
+	 */
+	componentDidUpdate(prevProps) {
+		if (this.props.value !== prevProps.value) {
+			autosize.update(this.textarea);
+		}
 	}
 
 	/**

--- a/src/forms/textarea.test.jsx
+++ b/src/forms/textarea.test.jsx
@@ -73,6 +73,13 @@ describe('Textarea', function() {
 		expect(textareaComponent.state.value).toEqual(newValue);
 	});
 
+	it('should call autosize plugin `update` method on `componentDidUpdate`', function() {
+		const newValue = 'hello world';
+		autosizeTextareaComponent.componentDidUpdate({ value: newValue });
+
+		expect(mockAutosize.update).toHaveBeenCalled();
+	});
+
 	it('should have a name attribute', () => {
 		expect(textareaEl.name).toEqual(NAME_ATTR);
 	});


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/MW-2692

#### Description
`autosize.update()` was being called in `componentWillRecieveProps`, so it was calculating height with the previous value, not the current/replaced value