### PR TITLE
Allow Dropdown to be toggled via props

### DIFF
--- a/src/interactive/Dropdown.jsx
+++ b/src/interactive/Dropdown.jsx
@@ -61,6 +61,12 @@ class Dropdown extends React.PureComponent {
 		}
 	}
 
+	componentWillReceiveProps(nextProps) {
+		if (this.props.isActive !== nextProps.isActive) {
+			this.setState(() => ({ isActive: nextProps.isActive }));
+		}
+	}
+
 	componentDidMount() {
 		document.body.addEventListener('click', this.onBodyClick);
 		document.body.addEventListener('keydown', this.onBodyKeyDown);


### PR DESCRIPTION
#### Description
Check for new props so we can open/close a Dropdown by changing the value of the `isActive` prop