### PR TITLE
update addon packages to fix 'channel not found' addon errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
     "react-transition-group": "^2.2.1",
     "swarm-animation": "^0.0.95",
     "swarm-icons": "^1.0",
-    "swarm-sasstools": "^2.0.296",
-    "swarm-animation": "^0.0.95"
+    "swarm-sasstools": "^2.0.296"
   },
   "dependencies": {
     "autosize": "3.0.21",
@@ -56,10 +55,10 @@
   "devDependencies": {
     "@alrra/travis-scripts": "3.0.1",
     "@kadira/react-storybook-addon-info": "3.4.0",
-    "@storybook/addon-info": "3.2.13",
-    "@storybook/addon-knobs": "3.2.13",
-    "@storybook/addon-notes": "3.2.13",
-    "@storybook/addons": "3.2.13",
+    "@storybook/addon-info": "3.2.16",
+    "@storybook/addon-knobs": "3.2.16",
+    "@storybook/addon-notes": "3.2.16",
+    "@storybook/addons": "3.2.16",
     "@storybook/react": "3.2.13",
     "babel-cli": "6.24.1",
     "babel-core": "6.25.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,12 +29,12 @@
     react-inspector "^2.2.1"
     uuid "^3.1.0"
 
-"@storybook/addon-info@3.2.13":
-  version "3.2.13"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-info/-/addon-info-3.2.13.tgz#9b2ec64f497cd19f85447aeeedb12b7c2fa307c6"
+"@storybook/addon-info@3.2.16":
+  version "3.2.16"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-info/-/addon-info-3.2.16.tgz#22fea6a6675fc98e333b7d748443c36bf7b322f5"
   dependencies:
-    "@storybook/addons" "^3.2.13"
-    "@storybook/components" "^3.2.13"
+    "@storybook/addons" "^3.2.16"
+    "@storybook/components" "^3.2.16"
     babel-runtime "^6.26.0"
     global "^4.3.2"
     marksy "^2.0.0"
@@ -42,21 +42,21 @@
     react-addons-create-fragment "^15.5.3"
     util-deprecate "^1.0.2"
 
-"@storybook/addon-knobs@3.2.13":
-  version "3.2.13"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-knobs/-/addon-knobs-3.2.13.tgz#8fcf89f0e6e8363e91f621465fda4f478ea0253c"
+"@storybook/addon-knobs@3.2.16":
+  version "3.2.16"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-knobs/-/addon-knobs-3.2.16.tgz#c19747656a969e5b960e4edeb54e5d5f4198609b"
   dependencies:
-    "@storybook/addons" "^3.2.13"
+    "@storybook/addons" "^3.2.16"
     babel-runtime "^6.26.0"
     deep-equal "^1.0.1"
     global "^4.3.2"
-    insert-css "^1.0.0"
+    insert-css "^2.0.0"
     lodash.debounce "^4.0.8"
-    moment "^2.19.1"
+    moment "^2.19.2"
     prop-types "^15.6.0"
     react-color "^2.11.4"
-    react-datetime "^2.10.3"
-    react-textarea-autosize "^4.3.0"
+    react-datetime "^2.11.0"
+    react-textarea-autosize "^5.2.1"
     util-deprecate "^1.0.2"
 
 "@storybook/addon-links@^3.2.13":
@@ -65,22 +65,18 @@
   dependencies:
     "@storybook/addons" "^3.2.16"
 
-"@storybook/addon-notes@3.2.13":
-  version "3.2.13"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-notes/-/addon-notes-3.2.13.tgz#dbcf95489dd3ac301b2536128cda5f88fdfacd70"
+"@storybook/addon-notes@3.2.16":
+  version "3.2.16"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-notes/-/addon-notes-3.2.16.tgz#833332a58db5160866aa94143945ae588f6dd243"
   dependencies:
-    "@storybook/addons" "^3.2.13"
+    "@storybook/addons" "^3.2.16"
     babel-runtime "^6.26.0"
     prop-types "^15.6.0"
     util-deprecate "^1.0.2"
   optionalDependencies:
-    "@types/react" "^15.0.24"
+    "@types/react" "^16.0.20"
 
-"@storybook/addons@3.2.13":
-  version "3.2.13"
-  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-3.2.13.tgz#a133103770a7f2330bc931571df1b2ae660f8f71"
-
-"@storybook/addons@^3.2.13", "@storybook/addons@^3.2.16":
+"@storybook/addons@3.2.16", "@storybook/addons@^3.2.13", "@storybook/addons@^3.2.16":
   version "3.2.16"
   resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-3.2.16.tgz#cbad5d9e8222aba3d5a5d06af98a095322f62cb5"
 
@@ -96,7 +92,7 @@
   version "3.2.16"
   resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-3.2.16.tgz#07d8686328c0bb885aa8b69254fcf0745d22a620"
 
-"@storybook/components@^3.2.13", "@storybook/components@^3.2.16":
+"@storybook/components@^3.2.16":
   version "3.2.16"
   resolved "https://registry.yarnpkg.com/@storybook/components/-/components-3.2.16.tgz#381c4ce414f139fb03b059f1f0265c6246457e7b"
   dependencies:
@@ -237,13 +233,13 @@
   version "8.0.53"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.53.tgz#396b35af826fa66aad472c8cb7b8d5e277f4e6d8"
 
-"@types/react@^15.0.24":
-  version "15.6.7"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-15.6.7.tgz#e910b6aace59d8d0b48dd679c2c03cffedafeec6"
-
 "@types/react@^16.0.18":
   version "16.0.24"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.24.tgz#a6fd8015892fe8ae3c17453615f7ebdd2301d818"
+
+"@types/react@^16.0.20":
+  version "16.0.25"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.25.tgz#bf696b83fe480c5e0eff4335ee39ebc95884a1ed"
 
 abab@^1.0.3:
   version "1.0.4"
@@ -3987,9 +3983,9 @@ inquirer@^3.0.6:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-insert-css@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/insert-css/-/insert-css-1.1.0.tgz#4a3f7a3e783877381bb8471a6452d1d27315db9e"
+insert-css@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/insert-css/-/insert-css-2.0.0.tgz#eb5d1097b7542f4c79ea3060d3aee07d053880f4"
 
 interpret@^1.0.0:
   version "1.0.4"
@@ -5128,7 +5124,7 @@ mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkd
   dependencies:
     minimist "0.0.8"
 
-moment@^2.19.1:
+moment@^2.19.2:
   version "2.19.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.2.tgz#8a7f774c95a64550b4c7ebd496683908f9419dbe"
 
@@ -6230,7 +6226,7 @@ react-color@^2.11.4:
     reactcss "^1.2.0"
     tinycolor2 "^1.4.1"
 
-react-datetime@^2.10.3:
+react-datetime@^2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/react-datetime/-/react-datetime-2.11.0.tgz#6560a8e5b81f7e52986083dc2e8cb94bb74528ea"
   dependencies:
@@ -6365,11 +6361,11 @@ react-test-renderer@^16.0.0-0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-textarea-autosize@^4.3.0:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-4.3.2.tgz#962a52c68caceae408c18acecec29049b81e42fa"
+react-textarea-autosize@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-5.2.1.tgz#2b78f9067180f41b08ac59f78f1581abadd61e54"
   dependencies:
-    prop-types "^15.5.8"
+    prop-types "^15.6.0"
 
 react-toggle-button@^2.1.0:
   version "2.2.0"


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-144

#### Description
It looks like our storybook addon packages got out of date with some of the other dependencies in this project. These package upgrades resolve the `Accessing nonexistent addons channel` errors thrown on certain stories.

