### PR TITLE
Manually toggled dropdown

### DIFF
--- a/src/interactive/Dropdown.jsx
+++ b/src/interactive/Dropdown.jsx
@@ -21,17 +21,25 @@ class Dropdown extends React.PureComponent {
 		this.state = { isActive: props.isActive || false };
 	}
 
-	closeContent() {
-		this.setState(() => ({ isActive: false }));
+	closeContent(e) {
+		if (this.props.manualToggle && this.props.isActive) {
+			this.props.manualToggle(e);
+		} else {
+			this.setState(() => ({ isActive: false }));
+		}
 	}
 
-	toggleContent() {
-		this.setState(() => ({ isActive: !this.state.isActive }));
+	toggleContent(e) {
+		if (this.props.manualToggle) {
+			this.props.manualToggle(e);
+		} else {
+			this.setState(() => ({ isActive: !this.state.isActive }));
+		}
 	}
 
 	onClick(e) {
 		e.preventDefault();
-		this.toggleContent();
+		this.toggleContent(e);
 
 		if (this.props.onClick) {
 			this.props.onClick(e);
@@ -51,19 +59,13 @@ class Dropdown extends React.PureComponent {
 		].every(ref => !ref.contains(e.target));
 
 		if (isNotDropdownClick) {
-			this.closeContent();
+			this.closeContent(e);
 		}
 	}
 
 	onBodyKeyDown(e) {
 		if (e.key === 'Escape') {
 			this.closeContent();
-		}
-	}
-
-	componentWillReceiveProps(nextProps) {
-		if (this.props.isActive !== nextProps.isActive) {
-			this.setState(() => ({ isActive: nextProps.isActive }));
 		}
 	}
 
@@ -78,7 +80,7 @@ class Dropdown extends React.PureComponent {
 	}
 
 	render() {
-		const isActive = this.state.isActive;
+		const isActive = this.props.manualToggle ? this.props.isActive : this.state.isActive;
 		const {
 			className,
 			trigger,
@@ -148,6 +150,7 @@ Dropdown.propTypes = {
 	align: PropTypes.oneOf(['left', 'right']).isRequired,
 	className: PropTypes.string,
 	isActive: PropTypes.bool,
+	manualToggle: PropTypes.func
 };
 
 export default Dropdown;

--- a/src/interactive/dropdown.story.jsx
+++ b/src/interactive/dropdown.story.jsx
@@ -28,6 +28,60 @@ const dropdownContent = (
 	</Section>
 );
 
+/**
+ * @module DropdownWithToggle
+ */
+class DropdownWithToggle extends React.PureComponent {
+	constructor(props) {
+		super(props);
+
+		this.state = {
+			dropdownToggled: false
+		};
+
+		this.toggleDropdown = this.toggleDropdown.bind(this);
+	}
+
+	toggleDropdown() {
+		this.setState(() => ({ dropdownToggled: !this.state.dropdownToggled }));
+	}
+
+	render() {
+
+		return (
+			<Dropdown
+				align='right'
+				isActive={this.state.dropdownToggled}
+				manualToggle={this.toggleDropdown}
+				trigger={
+					<Button small>Open</Button>
+				}
+				content={
+					<div>
+						<Section>
+							<Chunk>
+								<h2 className='text--big text--bold'>Dropdown content</h2>
+							</Chunk>
+							<Chunk className="runningText">
+								<p>
+									This dropdown handles its own toggling
+									in a function called toggleDropdown.
+								</p>
+							</Chunk>
+							<Chunk>
+								<Button onClick={this.toggleDropdown}>
+									Toggle dropdown
+								</Button>
+							</Chunk>
+						</Section>
+					</div>
+				}
+			/>
+		);
+
+	}
+}
+
 storiesOf('Dropdown', module)
 	.addDecorator(decorateWithLocale)
 	.addWithInfo(
@@ -61,6 +115,17 @@ storiesOf('Dropdown', module)
 					}
 					content={dropdownContent}
 				/>
+			</InfoWrapper>
+		)
+	).addWithInfo(
+		'with custom toggle functionality',
+		() => (
+			<InfoWrapper>
+				<Flex justify='flexEnd'>
+					<FlexItem shrink>
+						<DropdownWithToggle />
+					</FlexItem>
+				</Flex>
 			</InfoWrapper>
 		)
 	);

--- a/src/interactive/dropdown.test.jsx
+++ b/src/interactive/dropdown.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import TestUtils from 'react-dom/test-utils';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import Section from '../layout/Section';
 import Chunk from '../layout/Chunk';
 import Button from '../forms/Button';
@@ -51,18 +51,10 @@ class DropdownWithToggle extends React.PureComponent {
 
 		return (
 			<Dropdown
-				align='right'
 				isActive={this.state.dropdownToggled}
 				manualToggle={this.toggleDropdown}
-				trigger={
-					<Button small>Open</Button>
-				}
-				content={
-					<div>
-						{dropdownContent}
-						<Button className="dropdownWithToggle-button" onClick={this.toggleDropdown}>Toggle dropdown</Button>
-					</div>
-				}
+				trigger={dropdownTrigger}
+				content={dropdownContent}
 			/>
 		);
 
@@ -147,30 +139,31 @@ describe('Dropdown', () => {
 			expect(getIsOpen(content)).toBeFalsy();
 		});
 	});
+
 	describe('manually toggle dropdown', () => {
-		let closedComponent, content, trigger;
+		let closedComponent, closeContentSpy, toggleContentSpy, trigger;
 
 		beforeEach(() => {
-			closedComponent = shallow(<DropdownWithToggle />);
-			content = getContent(closedComponent);
-			trigger = getTrigger(closedComponent);
+			closedComponent = mount(<DropdownWithToggle />);
+			closeContentSpy = jest.spyOn(Dropdown.prototype, 'closeContent');
+			toggleContentSpy = jest.spyOn(Dropdown.prototype, 'toggleContent');
+			trigger = closedComponent.find('.dropdown-trigger');
 		});
+
 		afterEach(() => {
 			closedComponent = null;
-			content = null;
 			trigger = null;
+			closeContentSpy.mockClear();
+			toggleContentSpy.mockClear();
 		});
 
 		it('should still open and close when clicking the trigger', () => {
+			expect(closeContentSpy).not.toHaveBeenCalled();
 			trigger.simulate('click');
-			expect(getIsOpen(content)).toBeTruthy();
 
-			closedComponent.onBodyClick({ target: '<div />' });
-			expect(getIsOpen(content)).toBeFalsy();
-		});
-
-		it('should toggle when calling the function passed into manualToggle', () => {
-			// simulate click on internal button (.dropdownWithToggle-button)
+			closedComponent.find(Dropdown).instance().onBodyClick({ target: '<div />' });
+			expect(closeContentSpy).toHaveBeenCalled();
+			expect(toggleContentSpy).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/interactive/dropdown.test.jsx
+++ b/src/interactive/dropdown.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import TestUtils from 'react-dom/test-utils';
+import { shallow } from 'enzyme';
 import Section from '../layout/Section';
 import Chunk from '../layout/Chunk';
 import Button from '../forms/Button';
@@ -27,6 +28,46 @@ const getContent = component =>
 const getIsOpen = content =>
 	content.classList.contains('display--block') &&
 	!content.classList.contains('display--none');
+
+/**
+ * @module DropdownWithToggle
+ */
+class DropdownWithToggle extends React.PureComponent {
+	constructor(props) {
+		super(props);
+
+		this.state = {
+			dropdownToggled: false
+		};
+
+		this.toggleDropdown = this.toggleDropdown.bind(this);
+	}
+
+	toggleDropdown() {
+		this.setState(() => ({ dropdownToggled: !this.state.dropdownToggled }));
+	}
+
+	render() {
+
+		return (
+			<Dropdown
+				align='right'
+				isActive={this.state.dropdownToggled}
+				manualToggle={this.toggleDropdown}
+				trigger={
+					<Button small>Open</Button>
+				}
+				content={
+					<div>
+						{dropdownContent}
+						<Button className="dropdownWithToggle-button" onClick={this.toggleDropdown}>Toggle dropdown</Button>
+					</div>
+				}
+			/>
+		);
+
+	}
+}
 
 describe('Dropdown', () => {
 	const dropdownJSX = (
@@ -104,6 +145,32 @@ describe('Dropdown', () => {
 
 			closedComponent.onBodyClick({ target: '<div />' });
 			expect(getIsOpen(content)).toBeFalsy();
+		});
+	});
+	describe('manually toggle dropdown', () => {
+		let closedComponent, content, trigger;
+
+		beforeEach(() => {
+			closedComponent = shallow(<DropdownWithToggle />);
+			content = getContent(closedComponent);
+			trigger = getTrigger(closedComponent);
+		});
+		afterEach(() => {
+			closedComponent = null;
+			content = null;
+			trigger = null;
+		});
+
+		it('should still open and close when clicking the trigger', () => {
+			trigger.simulate('click');
+			expect(getIsOpen(content)).toBeTruthy();
+
+			closedComponent.onBodyClick({ target: '<div />' });
+			expect(getIsOpen(content)).toBeFalsy();
+		});
+
+		it('should toggle when calling the function passed into manualToggle', () => {
+			// simulate click on internal button (.dropdownWithToggle-button)
 		});
 	});
 });


### PR DESCRIPTION
#### Description
Sometimes we want to manually toggle a `<Dropdown>` open and closed. For example: Will needs to close a `<Dropdown>` after a form in the dropdown content is submitted.