### PR TITLE
Wc 145/rm inline base64 loader

### DIFF
--- a/assets/scss/components/_avatar.scss
+++ b/assets/scss/components/_avatar.scss
@@ -43,7 +43,6 @@ Class                     | Description
 `avatar--icon`            | For icons in avatars (might move this in a later version)
 `avatar--noPhoto`         | Resets `text-indent` for avatars without photos, allowing display of fallback content
 */
-$noPhotoIconOpacity: alpha($C_textHint);
 $avatarBg: $C_coolGrayLight;
 
 %backgroundImg--orgBadge {
@@ -150,7 +149,7 @@ $avatarBg: $C_coolGrayLight;
 	@include valignChildren();
 	position: relative;
 	text-indent: initial;
-	background-color: darken($avatarBg, 8%);
+	background-color: darken($avatarBg, 6%);
 
 	.svg {
 		// matches size of icon wrapper div
@@ -166,6 +165,7 @@ $avatarBg: $C_coolGrayLight;
 		// sets SVG size relative to wrapper
 		width: 40%;
 		height: 40%;
+
 		transform: translateX(4%);
 		opacity: alpha($C_textSecondary);
 	}

--- a/assets/scss/components/_avatar.scss
+++ b/assets/scss/components/_avatar.scss
@@ -147,16 +147,27 @@ $avatarBg: $C_coolGrayLight;
 }
 
 .avatar--noPhoto {
+	@include valignChildren();
 	position: relative;
 	text-indent: initial;
-	background-color: darken($avatarBg, ($noPhotoIconOpacity*100%));
-	background-size: 40% !important;
-	&:before {
-		background-color: transparentize($C_white, $noPhotoIconOpacity);
-		content: '';
-		display: block;
-		height: 100%;
+	background-color: darken($avatarBg, 8%);
+
+	.svg {
+		// matches size of icon wrapper div
+		// to the size of the avatar
 		width: 100%;
+		height: 100%;
+
+		// center the SVG element within the wrapper
+		@include valignChildren();
+		justify-content: center;
+	}
+	svg {
+		// sets SVG size relative to wrapper
+		width: 40%;
+		height: 40%;
+		transform: translateX(4%);
+		opacity: alpha($C_textSecondary);
 	}
 }
 

--- a/assets/scss/components/_forms.scss
+++ b/assets/scss/components/_forms.scss
@@ -3,6 +3,22 @@
 }
 
 //
+// Input icons
+//
+.icon--field {
+	display: flex !important;
+	align-content: center;
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	left: 0;
+	padding: $space;
+}
+input:focus + .icon--field {
+	@include color-svg($C_textPrimary);
+}
+
+//
 // Labels
 //
 .label--field {

--- a/jest.config.json
+++ b/jest.config.json
@@ -12,9 +12,6 @@
     "js",
     "jsx"
   ],
-  "moduleNameMapper": {
-    "^(base64-image-loader[!?].+)": "<rootDir>/__mocks__/base64-image-loader.js"
-  },
   "testRegex": "src/.*\\.test\\.jsx?$",
   "transformIgnorePatterns": [
     "node_modules(?!\/meetup-web-components)"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   },
   "dependencies": {
     "autosize": "3.0.21",
-    "base64-image-loader": "1.2.0",
     "flatpickr": "3.0.6",
     "recompose": "0.26.0"
   },

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "husky": "0.14.3",
     "inquirer": "3.2.0",
     "jest": "20.0.4",
-    "meetup-web-mocks": "1.0.194",
+    "meetup-web-mocks": "1.0.242",
     "node-sass": "4.5.3",
     "npm-run-all": "4.0.2",
     "prop-types": "^15.6.0",

--- a/src/forms/TextInput.jsx
+++ b/src/forms/TextInput.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
+import Icon from '../media/Icon';
 import { MEDIA_SIZES } from '../utils/designConstants';
 
 export const FIELD_WITH_ICON_CLASS = 'field--withIcon';
@@ -52,18 +53,18 @@ const TextInput = (props) => {
 		helperText: cx(
 			'helperTextContainer',
 			{ required, disabled }
-		)
+		),
+		icon: 'icon--field',
 	};
 
-	const iconSize = props.iconSize || 'xs';
-	const iconSuffix = (iconSize == 'xs' || iconSize == 's') ? '--small' : '';
-	const inputIcon = iconShape && require(`base64-image-loader!swarm-icons/dist/optimized/${iconShape}${iconSuffix}.svg`);
+	const iconProps = {
+		shape: iconShape,
+		size: props.iconSize || 'xs',
+		className: classNames.icon,
+	};
 
-	const paddingSize = parseInt(MEDIA_SIZES[iconSize], 10)+24; // #TODO :SDS: replace '32' with something like "$space * 1.5" from `swarm-constants`
-	const inputStyles = iconShape &&
-	{
-		backgroundImage: `url(${inputIcon})`,
-		backgroundSize: `${MEDIA_SIZES[iconSize]}px`,
+	const paddingSize = parseInt(MEDIA_SIZES[iconProps.size], 10) + 24; // #TODO :SDS: replace '32' with something like "$space * 1.5" from `swarm-constants`
+	const inputStyles = iconShape && {
 		paddingLeft: `${paddingSize}px`
 	};
 
@@ -80,19 +81,24 @@ const TextInput = (props) => {
 						{helperText}
 					</div>
 				}
-				<input type={isSearch ? 'search' : 'text'}
-					name={name}
-					value={value}
-					required={required}
-					placeholder={placeholder}
-					className={classNames.field}
-					onChange={onChange}
-					pattern={pattern}
-					disabled={disabled}
-					id={id}
-					style={inputStyles}
-					{...other}
-				/>
+				<div style={{position: 'relative'}}>
+					<input type={isSearch ? 'search' : 'text'}
+						name={name}
+						value={value}
+						required={required}
+						placeholder={placeholder}
+						className={classNames.field}
+						onChange={onChange}
+						pattern={pattern}
+						disabled={disabled}
+						id={id}
+						style={inputStyles}
+						{...other}
+					/>
+					{iconShape &&
+						<Icon {...iconProps} />
+					}
+				</div>
 
 				{ maxLength && <p className='text--tiny text--secondary align--right charCount'>{parseInt(maxLength - value.length)}</p> }
 				{children}

--- a/src/forms/__snapshots__/textInput.test.jsx.snap
+++ b/src/forms/__snapshots__/textInput.test.jsx.snap
@@ -11,14 +11,22 @@ exports[`TextInput renders a required HTML <input> with expected attributes for 
     >
       Super Hero
     </label>
-    <input
-      className="span--100"
-      id="superhero"
-      name="superhero"
-      required={true}
-      type="text"
-      value="Batman"
-    />
+    <div
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+    >
+      <input
+        className="span--100"
+        id="superhero"
+        name="superhero"
+        required={true}
+        type="text"
+        value="Batman"
+      />
+    </div>
   </div>
 </div>
 `;

--- a/src/forms/textInput.story.jsx
+++ b/src/forms/textInput.story.jsx
@@ -3,8 +3,10 @@ import { InfoWrapper } from '../utils/storyComponents';
 import TextInput from './TextInput';
 import Button from './Button';
 import { storiesOf } from '@storybook/react';
+import { decorateWithLocale } from '../utils/decorators';
 
 storiesOf('TextInput', module)
+	.addDecorator(decorateWithLocale)
 	.add('default', () => (
 		<div className='span--50'>
 			<TextInput

--- a/src/media/AvatarMember.jsx
+++ b/src/media/AvatarMember.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
 import Avatar from './Avatar';
+import Icon from './Icon';
 
 export const AVATAR_PERSON_CLASS = 'avatar--person';
 export const AVATAR_PERSON_ORG_CLASS = 'avatar--org';
@@ -30,16 +31,22 @@ class AvatarMember extends React.PureComponent {
 			className
 		);
 
-		const noPhotoImage = require('base64-image-loader!swarm-icons/dist/optimized/profile.svg');
+		const noPhotoIcon = (<Icon
+			shape="profile"
+			size="m"
+		/>);
 
-		return (
-			<Avatar
-				alt={member.name}
-				src={showNoPhoto ? noPhotoImage : member.photo[photoLink]}
-				className={classNames}
-				{...other}
-			/>
-		);
+		const allProps = {
+			alt: member.name,
+			src: !showNoPhoto && member.photo[photoLink],
+			className: classNames,
+		};
+
+		if (showNoPhoto) {
+			return <Avatar {...allProps} {...other}>{noPhotoIcon}</Avatar>;
+		}
+
+		return <Avatar {...allProps} {...other} />;
 	}
 }
 

--- a/src/media/AvatarMember.jsx
+++ b/src/media/AvatarMember.jsx
@@ -38,7 +38,6 @@ class AvatarMember extends React.PureComponent {
 
 		const allProps = {
 			alt: member.name,
-			src: !showNoPhoto && member.photo[photoLink],
 			className: classNames,
 			children: showNoPhoto && noPhotoIcon,
 		};

--- a/src/media/AvatarMember.jsx
+++ b/src/media/AvatarMember.jsx
@@ -40,10 +40,11 @@ class AvatarMember extends React.PureComponent {
 			alt: member.name,
 			src: !showNoPhoto && member.photo[photoLink],
 			className: classNames,
+			children: showNoPhoto && noPhotoIcon,
 		};
 
-		if (showNoPhoto) {
-			return <Avatar {...allProps} {...other}>{noPhotoIcon}</Avatar>;
+		if (!showNoPhoto) {
+			allProps.src = member.photo[photoLink];
 		}
 
 		return <Avatar {...allProps} {...other} />;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4986,11 +4986,9 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
 
-meetup-web-mocks@1.0.194:
-  version "1.0.194"
-  resolved "https://registry.yarnpkg.com/meetup-web-mocks/-/meetup-web-mocks-1.0.194.tgz#0f0a4526a739a0dcebacbc12c9adf4ab16fe38e0"
-  dependencies:
-    rxjs "5.4.2"
+meetup-web-mocks@1.0.242:
+  version "1.0.242"
+  resolved "https://registry.yarnpkg.com/meetup-web-mocks/-/meetup-web-mocks-1.0.242.tgz#071cf481fe976df5262cde54e38cd3a394b74660"
 
 mem@^1.1.0:
   version "1.1.0"
@@ -6766,12 +6764,6 @@ rx-lite@*, rx-lite@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
-rxjs@5.4.2:
-  version "5.4.2"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.4.2.tgz#2a3236fcbf03df57bae06fd6972fd99e5c08fcf7"
-  dependencies:
-    symbol-observable "^1.0.1"
-
 safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
@@ -7253,7 +7245,7 @@ swarm-sasstools@2.0.296:
     sass-rem "^1.2.4"
     swarm-constants "1.2.44"
 
-symbol-observable@^1.0.1, symbol-observable@^1.0.3, symbol-observable@^1.0.4:
+symbol-observable@^1.0.3, symbol-observable@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1668,10 +1668,6 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
-base64-image-loader@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/base64-image-loader/-/base64-image-loader-1.2.0.tgz#a957cb1cbc367a150f1c312caa9cb59d0b92550b"
-
 base64-js@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.1.tgz#a91947da1f4a516ea38e5b4ec0ec3773675e0886"


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-145

#### Description
Fixes no photo avatar and icon text inputs in `mup-web`.

Removes base64 inline loader; refactors `Icon` and `TextInput` components to use actual `Icon` component instead of inline loading a base64 background image.

Shared components should not rely on inline webpack loaders, as it makes them less portable across applications.

#### Screenshots (if applicable)
![screen shot 2017-11-28 at 1 02 57 pm](https://user-images.githubusercontent.com/231252/33335940-86164c7c-d43c-11e7-94c6-5ed101956467.png)
![screen shot 2017-11-28 at 1 03 00 pm](https://user-images.githubusercontent.com/231252/33335941-8624e8f4-d43c-11e7-94f3-0a6e00e80046.png)
![screen shot 2017-11-28 at 1 03 10 pm](https://user-images.githubusercontent.com/231252/33335942-8637d982-d43c-11e7-825d-1c80190170a2.png)

