### PR TITLE
support `circled` boolean prop to surround scaled icon in a circle

### DIFF
--- a/assets/scss/components/_icon.scss
+++ b/assets/scss/components/_icon.scss
@@ -42,9 +42,32 @@
 	use { pointer-events: none; }
 }
 
+//
+// Icons with enclosing circle
+//
+.svg--circled {
+	position: relative;
+
+	&:before {
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		content: "";
+		background-color: $C_lightGray;
+		border: 1px solid $C_border;
+		border-radius: 100%;
+	}
+
+	svg {
+		transform: scale(0.4);
+	}
+
+}
 
 //
-// Specific icon styles
+// Specific icon shape styles
 //
 .svg--updates {
 	@include transform-origin(center center);

--- a/src/media/Icon.jsx
+++ b/src/media/Icon.jsx
@@ -6,6 +6,7 @@ import { VALID_SHAPES } from 'swarm-icons/dist/js/shapeConstants';
 
 export const ICON_CLASS = 'svg';
 export const SVG_THIN_STYLE = '--small';
+export const ICON_CIRCLED_CLASS = 'svg--circled';
 
 const SMALL_ICON_VARIANT_WHITELIST = VALID_SHAPES
 	.filter(s =>
@@ -38,9 +39,14 @@ export const getIconShape = (shape, size) => {
  */
 class Icon extends React.PureComponent {
 	render() {
-		const { className, shape, size, color, style, ...other } = this.props;
+		const { className, shape, size, color, style, circled, ...other } = this.props;
 
-		const classNames = cx(ICON_CLASS, `svg--${shape}`, className);
+		const classNames = cx(
+			ICON_CLASS,
+			`svg--${shape}`,
+			{ [ICON_CIRCLED_CLASS]: circled },
+			className
+		);
 
 		const sizeVal = MEDIA_SIZES[size];
 
@@ -75,6 +81,7 @@ Icon.defaultProps = {
 Icon.propTypes = {
 	shape: PropTypes.oneOf(VALID_SHAPES).isRequired,
 	size: PropTypes.oneOf(Object.keys(MEDIA_SIZES)).isRequired,
+	circled: PropTypes.bool,
 };
 
 export default Icon;

--- a/src/media/icon.story.jsx
+++ b/src/media/icon.story.jsx
@@ -50,6 +50,12 @@ storiesOf('Icon', module)
 		<Icon shape={ICON_NAME} color='#F13959' />
 	))
 	.addWithInfo(
+		'Circled',
+		'The boolean prop `circled` adds an enclosing circle around the icon.',
+		() => (
+		<Icon shape="external-twitter" size="l" circled />
+	))
+	.addWithInfo(
 		'Loading indicator',
 		'The `updates` icon is animated by default.',
 		() => (

--- a/src/media/icon.test.jsx
+++ b/src/media/icon.test.jsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-dom/test-utils';
-import Icon, { ICON_CLASS, SVG_THIN_STYLE, getIconShape } from './Icon';
+import Icon, {
+	ICON_CLASS,
+	ICON_CIRCLED_CLASS,
+	SVG_THIN_STYLE,
+	getIconShape,
+} from './Icon';
 import { MEDIA_SIZES } from '../utils/designConstants';
 
 describe('Icon', () => {
@@ -104,6 +109,23 @@ describe('Icon', () => {
 			const svgEl = ReactDOM.findDOMNode(icon).querySelector('svg');
 
 			expect(svgEl.style.fill).toContain(fillColor);
+		});
+	});
+
+	describe('circle shape surrounding icon', () => {
+		it('adds circle class to span wrapper when `circled` prop is passed', () => {
+			const icon = TestUtils.renderIntoDocument(
+				<Icon aria-label={label} shape={shape} circled />
+			);
+			const iconEl = ReactDOM.findDOMNode(icon);
+			expect(iconEl.classList.contains(ICON_CIRCLED_CLASS)).toBe(true);
+		});
+		it('does NOT add circle class to span wrapper when `circled` prop is NOT passed', () => {
+			const icon = TestUtils.renderIntoDocument(
+				<Icon aria-label={label} shape={shape} />
+			);
+			const iconEl = ReactDOM.findDOMNode(icon);
+			expect(iconEl.classList.contains(ICON_CIRCLED_CLASS)).toBe(false);
 		});
 	});
 });


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-113

#### Description
Adds `circled` prop to enable placing a scaled down icon inside a circle of a given media `size`.

#### Screenshots (if applicable)
![screen shot 2017-12-04 at 3 11 35 pm](https://user-images.githubusercontent.com/231252/33574037-c8e46390-d905-11e7-9aeb-cdbea1afe182.png)
![screen shot 2017-12-04 at 3 11 48 pm](https://user-images.githubusercontent.com/231252/33574038-c8f5e3c2-d905-11e7-8a4f-79810f573da0.png)
![screen shot 2017-12-04 at 3 12 02 pm](https://user-images.githubusercontent.com/231252/33574039-c9064532-d905-11e7-80fe-def2f4325143.png)
![screen shot 2017-12-04 at 3 12 22 pm](https://user-images.githubusercontent.com/231252/33574040-c9149cae-d905-11e7-8e52-2c61d7d78c41.png)
![screen shot 2017-12-04 at 3 12 30 pm](https://user-images.githubusercontent.com/231252/33574041-c9238912-d905-11e7-8e69-96739da4fd79.png)

