### PR TITLE
disallow tab navigation into number input buttons

### DIFF
--- a/src/forms/NumberInput.jsx
+++ b/src/forms/NumberInput.jsx
@@ -180,6 +180,7 @@ class NumberInput extends React.Component {
 
 						<FlexItem shrink>
 							<button
+								tabIndex="-1"
 								className={classNames.decrementBtn}
 								onBlur={this.onBlur}
 								onClick={this.decrementAction}
@@ -191,6 +192,7 @@ class NumberInput extends React.Component {
 
 						<FlexItem shrink>
 							<button
+								tabIndex="-1"
 								className={classNames.incrementBtn}
 								onBlur={this.onBlur}
 								onClick={this.incrementAction}


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-150

#### Description
Because translation is not supported in shared inputs, there's no easy way to add labels to the increment/decrement buttons in `NumberInput`.

Because we're unable to label the buttons to provide context to screen readers, I've disabled keyboard navigation to these buttons. Keyboard and screen reader users are still able to modify the value by typing or using arrow keys as they would any other native number input.

