### PR TITLE
Wc 146/char counter a11y

### DIFF
--- a/src/forms/TextInput.jsx
+++ b/src/forms/TextInput.jsx
@@ -91,7 +91,7 @@ const TextInput = (props) => {
 					disabled={disabled}
 					id={id}
 					style={inputStyles}
-					maxLength={maxLength ? parseInt(maxLength) : -1}
+					maxLength={parseInt(maxLength) || -1}
 					{...other}
 				/>
 

--- a/src/forms/TextInput.jsx
+++ b/src/forms/TextInput.jsx
@@ -91,10 +91,11 @@ const TextInput = (props) => {
 					disabled={disabled}
 					id={id}
 					style={inputStyles}
+					maxLength={maxLength ? parseInt(maxLength) : -1}
 					{...other}
 				/>
 
-				{ maxLength && <p className='text--tiny text--secondary align--right charCount'>{parseInt(maxLength - value.length)}</p> }
+				{ maxLength && <p tabIndex="-1" className='text--tiny text--secondary align--right charCount'>{parseInt(maxLength - value.length)}</p> }
 				{children}
 			</div>
 			{ error && <p className='text--error text--small'>{error}</p> }

--- a/src/forms/Textarea.jsx
+++ b/src/forms/Textarea.jsx
@@ -153,10 +153,11 @@ class Textarea extends React.Component {
 						style={{ ...style, ...heightConstraints }}
 						id={id}
 						value={this.state.value}
+						maxLength={parseInt(maxLength) || -1}
 						{...other}
 					/>
 
-					{ maxLength && <p className='text--tiny text--secondary align--right charCount'>{parseInt(maxLength - this.state.value.length)}</p> }
+					{ maxLength && <p tabIndex="-1" className='text--tiny text--secondary align--right charCount'>{parseInt(maxLength - this.state.value.length)}</p> }
 				</div>
 				{ error && <p className='text--error text--small'>{error}</p> }
 			</div>

--- a/src/forms/__snapshots__/textInput.test.jsx.snap
+++ b/src/forms/__snapshots__/textInput.test.jsx.snap
@@ -14,6 +14,7 @@ exports[`TextInput renders a required HTML <input> with expected attributes for 
     <input
       className="span--100"
       id="superhero"
+      maxLength={-1}
       name="superhero"
       required={true}
       type="text"


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-146

#### Description
Fields with character counters currently allow screen readers to tab to the characters remaining element, which reads a number out of context.

To fix this and provide better hints, tab navigation to the character counter has been disabled, and the `maxlength` attribute will be used on text areas or text inputs in which the `maxLength` prop is passed. This attribute will alert screen readers to "invalid data" when the max length is exceeded. Depending on the screen reader, the `maxlength` value may also be read to provide a hint.

