### PR TITLE
Wc 148/aria form errors

### DIFF
--- a/src/forms/CalendarComponent.jsx
+++ b/src/forms/CalendarComponent.jsx
@@ -2,6 +2,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
 import ErrorList from './ErrorList';
+import {
+	getFieldErrorProps,
+	getErrorListProps,
+} from './util/errorProps';
 
 /**
  * @module CalendarComponent
@@ -113,7 +117,6 @@ class CalendarComponent extends React.Component {
 	render() {
 		const {
 			className,
-			id,
 			name,
 			error,
 			suppressError,
@@ -149,7 +152,7 @@ class CalendarComponent extends React.Component {
 			<div>
 				<span>
 					{label && (
-						<label htmlFor={id} className={classNames.label}>
+						<label htmlFor={name} className={classNames.label}>
 							{label}
 						</label>
 					)}
@@ -160,15 +163,16 @@ class CalendarComponent extends React.Component {
 					}
 					<input
 						type="text"
-						id={id}
+						id={name}
 						name={name}
 						defaultValue={value}
 						className={classNames.field}
 						ref={input => (this.inputEl = input)}
 						{...other}
+						{...getFieldErrorProps(name, !!error)}
 					/>
 				</span>
-				{!suppressError && <ErrorList errors={error} />}
+				{!suppressError && <ErrorList {...getErrorListProps(name, error)} />}
 			</div>
 		);
 	}

--- a/src/forms/CalendarComponent.jsx
+++ b/src/forms/CalendarComponent.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
+import ErrorList from './ErrorList';
 
 /**
  * @module CalendarComponent
@@ -167,8 +168,7 @@ class CalendarComponent extends React.Component {
 						{...other}
 					/>
 				</span>
-				{!suppressError &&
-					error && <p className="text--error text--small">{error}</p>}
+				{!suppressError && <ErrorList errors={error} />}
 			</div>
 		);
 	}

--- a/src/forms/DateTimeLocalInput.jsx
+++ b/src/forms/DateTimeLocalInput.jsx
@@ -62,7 +62,7 @@ class DateTimeLocalInput extends React.Component {
 					{...other}
 					{...getFieldErrorProps(id, !!error)}
 				/>
-				{ error && <ErrorList {...getErrorListProps(id, error)} /> }
+				<ErrorList {...getErrorListProps(id, error)} />
 			</div>
 		);
 

--- a/src/forms/DateTimeLocalInput.jsx
+++ b/src/forms/DateTimeLocalInput.jsx
@@ -1,6 +1,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
+import ErrorList from './ErrorList';
+import {
+	getFieldErrorProps,
+	getErrorListProps,
+} from './util/errorProps';
 
 /**
  * @module DateTimeLocalInput
@@ -44,12 +49,6 @@ class DateTimeLocalInput extends React.Component {
 
 		const labelClassNames = cx({required});
 
-		const errorId = `${id}-error`;
-		if (error) {
-			other['aria-invalid'] = true;
-			other['aria-describedby'] = errorId;
-		}
-
 		return (
 			<div>
 				<label htmlFor={id} className={labelClassNames}>{label}</label>
@@ -61,8 +60,9 @@ class DateTimeLocalInput extends React.Component {
 					onChange={this.onChange}
 					required={required}
 					{...other}
+					{...getFieldErrorProps(id, !!error)}
 				/>
-				{ error && <p className='text--error text--small' id={errorId}>{error}</p> }
+				{ error && <ErrorList {...getErrorListProps(id, error)} /> }
 			</div>
 		);
 

--- a/src/forms/ErrorList.jsx
+++ b/src/forms/ErrorList.jsx
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import cx from 'classnames';
 
-export const ERROR_CLASSNAMES = 'text--error text--small';
+export const ERROR_CLASSNAME = 'text--error text--small';
 
 const ErrorList = (props) => {
 	const {
@@ -23,7 +24,7 @@ const ErrorList = (props) => {
 		>
 			{
 				errorList.map((err, key) => (
-					<li key={key} className={ERROR_CLASSNAMES}>{err}</li>
+					<li key={key} className={cx(ERROR_CLASSNAME, 'text--small')}>{err}</li>
 				))
 			}
 		</ul>

--- a/src/forms/ErrorList.jsx
+++ b/src/forms/ErrorList.jsx
@@ -1,0 +1,36 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export const ERROR_CLASSNAMES = 'text--error text--small';
+
+const ErrorList = (props) => {
+	const {
+		errors,
+		...other
+	} = props;
+
+	const errorList = Array.isArray(errors) ? errors : [errors];
+
+	return (
+		<ul
+			aria-role="alert"
+			aria-live="assertive"
+			{...other}
+		>
+			{
+				errorList.map((err) => (
+					<li className={ERROR_CLASSNAMES}>{err}</li>
+				))
+			}
+		</ul>
+	);
+};
+
+ErrorList.propTypes = {
+	errors: PropTypes.oneOfType([
+		PropTypes.string,
+		PropTypes.array
+	])
+};
+
+export default ErrorList;

--- a/src/forms/ErrorList.jsx
+++ b/src/forms/ErrorList.jsx
@@ -13,13 +13,12 @@ const ErrorList = (props) => {
 
 	return (
 		<ul
-			aria-role="alert"
 			aria-live="assertive"
 			{...other}
 		>
 			{
-				errorList.map((err) => (
-					<li className={ERROR_CLASSNAMES}>{err}</li>
+				errorList.map((err, key) => (
+					<li key={key} className={ERROR_CLASSNAMES}>{err}</li>
 				))
 			}
 		</ul>

--- a/src/forms/ErrorList.jsx
+++ b/src/forms/ErrorList.jsx
@@ -5,11 +5,16 @@ export const ERROR_CLASSNAMES = 'text--error text--small';
 
 const ErrorList = (props) => {
 	const {
+		errorId,
 		errors,
 		...other
 	} = props;
 
 	const errorList = Array.isArray(errors) ? errors : [errors];
+
+	if (errorId) {
+		other['id'] = errorId;
+	}
 
 	return (
 		<ul
@@ -26,6 +31,7 @@ const ErrorList = (props) => {
 };
 
 ErrorList.propTypes = {
+	errorId: PropTypes.string,
 	errors: PropTypes.oneOfType([
 		PropTypes.string,
 		PropTypes.array

--- a/src/forms/NumberInput.jsx
+++ b/src/forms/NumberInput.jsx
@@ -5,6 +5,10 @@ import Flex from '../layout/Flex';
 import FlexItem from '../layout/FlexItem';
 import Icon from '../media/Icon';
 import ErrorList from './ErrorList';
+import {
+	getFieldErrorProps,
+	getErrorListProps,
+} from './util/errorProps';
 
 export const DECREMENT_BTN_CLASS = 'decrementButton';
 export const FAUX_INPUT_CLASS = 'fauxInput';
@@ -164,6 +168,7 @@ class NumberInput extends React.Component {
 					<Flex align='center'>
 						<FlexItem>
 							<input type='number'
+								id={id}
 								name={name}
 								max={max}
 								min={min}
@@ -176,7 +181,9 @@ class NumberInput extends React.Component {
 								onChange={this.onChange}
 								onKeyDown={this.onKeyDown}
 								disabled={disabled}
-								{...other} />
+								{...other}
+								{...getFieldErrorProps(id, !!error)}
+							/>
 						</FlexItem>
 
 						<FlexItem shrink>
@@ -206,7 +213,7 @@ class NumberInput extends React.Component {
 						{children}
 					</Flex>
 				</div>
-				{ error && <ErrorList errors={error} /> }
+				<ErrorList {...getErrorListProps(id, error)} />
 			</div>
 		);
 	}

--- a/src/forms/NumberInput.jsx
+++ b/src/forms/NumberInput.jsx
@@ -4,6 +4,7 @@ import cx from 'classnames';
 import Flex from '../layout/Flex';
 import FlexItem from '../layout/FlexItem';
 import Icon from '../media/Icon';
+import ErrorList from './ErrorList';
 
 export const DECREMENT_BTN_CLASS = 'decrementButton';
 export const FAUX_INPUT_CLASS = 'fauxInput';
@@ -205,7 +206,7 @@ class NumberInput extends React.Component {
 						{children}
 					</Flex>
 				</div>
-				{ error && <p className='text--error text--small'>{error}</p> }
+				{ error && <ErrorList errors={error} /> }
 			</div>
 		);
 	}

--- a/src/forms/SelectInput.jsx
+++ b/src/forms/SelectInput.jsx
@@ -103,13 +103,7 @@ class SelectInput extends React.Component {
 						size="xs"
 					/>
 				</div>
-				{error && <p className='text--error text--small'>{error}</p>}
-				{
-					errors && errors.length > 0 &&
-						errors.map((error, key) =>
-							<p key={key} className='text--error text--small'>{error}</p>
-						)
-				}
+				{error || errors && <ErrorList errors={error || errors} /> }
 				{children}
 			</div>
 		);

--- a/src/forms/SelectInput.jsx
+++ b/src/forms/SelectInput.jsx
@@ -3,6 +3,11 @@ import React from 'react';
 import cx from 'classnames';
 
 import Icon from '../media/Icon';
+import ErrorList from './ErrorList';
+import {
+	getFieldErrorProps,
+	getErrorListProps,
+} from './util/errorProps';
 
 /**
  * @module SelectInput
@@ -70,7 +75,7 @@ class SelectInput extends React.Component {
 			<div>
 				<div className="inputContainer">
 					{label &&
-						<label className={classNames.label} htmlFor={other.id}>
+						<label className={classNames.label} htmlFor={name}>
 							{label}
 						</label>
 					}
@@ -81,11 +86,13 @@ class SelectInput extends React.Component {
 					}
 					<select
 						name={name}
+						id={name}
 						required={required}
 						className={classNames.field}
 						onChange={this.onChange}
 						value={this.state.value}
 						{...other}
+						{...getFieldErrorProps(name, (!!error || !!errors))}
 					>
 						{
 							options.map((option, key) =>
@@ -103,7 +110,7 @@ class SelectInput extends React.Component {
 						size="xs"
 					/>
 				</div>
-				{error || errors && <ErrorList errors={error || errors} /> }
+				<ErrorList {...getErrorListProps(name, (errors || error))} />
 				{children}
 			</div>
 		);

--- a/src/forms/TextInput.jsx
+++ b/src/forms/TextInput.jsx
@@ -68,6 +68,13 @@ const TextInput = (props) => {
 		paddingLeft: `${paddingSize}px`
 	};
 
+	const errorId = id && `${id}-error`;
+
+	const allErrorListProps = {
+		errors: error,
+		errorId: errorId,
+	};
+
 	return (
 		<div>
 			<div className="inputContainer">
@@ -98,7 +105,7 @@ const TextInput = (props) => {
 				{ maxLength && <p tabIndex="-1" className='text--tiny text--secondary align--right charCount'>{parseInt(maxLength - value.length)}</p> }
 				{children}
 			</div>
-			<ErrorList errors={error} />
+			<ErrorList {...allErrorListProps} />
 		</div>
 	);
 };

--- a/src/forms/TextInput.jsx
+++ b/src/forms/TextInput.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
 import { MEDIA_SIZES } from '../utils/designConstants';
+import ErrorList from './ErrorList';
 
 export const FIELD_WITH_ICON_CLASS = 'field--withIcon';
 
@@ -91,14 +92,13 @@ const TextInput = (props) => {
 					disabled={disabled}
 					id={id}
 					style={inputStyles}
-					maxLength={parseInt(maxLength) || -1}
 					{...other}
 				/>
 
 				{ maxLength && <p tabIndex="-1" className='text--tiny text--secondary align--right charCount'>{parseInt(maxLength - value.length)}</p> }
 				{children}
 			</div>
-			{ error && <p className='text--error text--small'>{error}</p> }
+			<ErrorList errors={error} />
 		</div>
 	);
 };

--- a/src/forms/TextInput.jsx
+++ b/src/forms/TextInput.jsx
@@ -3,6 +3,10 @@ import React from 'react';
 import cx from 'classnames';
 import { MEDIA_SIZES } from '../utils/designConstants';
 import ErrorList from './ErrorList';
+import {
+	getFieldErrorProps,
+	getErrorListProps,
+} from './util/errorProps';
 
 export const FIELD_WITH_ICON_CLASS = 'field--withIcon';
 
@@ -68,13 +72,6 @@ const TextInput = (props) => {
 		paddingLeft: `${paddingSize}px`
 	};
 
-	const errorId = id && `${id}-error`;
-
-	const allErrorListProps = {
-		errors: error,
-		errorId: errorId,
-	};
-
 	return (
 		<div>
 			<div className="inputContainer">
@@ -100,12 +97,13 @@ const TextInput = (props) => {
 					id={id}
 					style={inputStyles}
 					{...other}
+					{...getFieldErrorProps(id, !!error)}
 				/>
 
 				{ maxLength && <p tabIndex="-1" className='text--tiny text--secondary align--right charCount'>{parseInt(maxLength - value.length)}</p> }
 				{children}
 			</div>
-			<ErrorList {...allErrorListProps} />
+			<ErrorList {...getErrorListProps(id, error)} />
 		</div>
 	);
 };

--- a/src/forms/Textarea.jsx
+++ b/src/forms/Textarea.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
 import autosize from 'autosize';
+import ErrorList from './ErrorList';
 
 /**
  * @module Textarea
@@ -159,7 +160,7 @@ class Textarea extends React.Component {
 
 					{ maxLength && <p tabIndex="-1" className='text--tiny text--secondary align--right charCount'>{parseInt(maxLength - this.state.value.length)}</p> }
 				</div>
-				{ error && <p className='text--error text--small'>{error}</p> }
+				{ error && <ErrorList errors={error} /> }
 			</div>
 		);
 	}

--- a/src/forms/Textarea.jsx
+++ b/src/forms/Textarea.jsx
@@ -3,6 +3,10 @@ import React from 'react';
 import cx from 'classnames';
 import autosize from 'autosize';
 import ErrorList from './ErrorList';
+import {
+	getFieldErrorProps,
+	getErrorListProps,
+} from './util/errorProps';
 
 /**
  * @module Textarea
@@ -160,11 +164,12 @@ class Textarea extends React.Component {
 						value={this.state.value}
 						maxLength={parseInt(maxLength) || -1}
 						{...other}
+						{...getFieldErrorProps(id, !!error)}
 					/>
 
 					{ maxLength && <p tabIndex="-1" className='text--tiny text--secondary align--right charCount'>{parseInt(maxLength - this.state.value.length)}</p> }
 				</div>
-				{ error && <ErrorList errors={error} /> }
+				<ErrorList {...getErrorListProps(id, error)} />
 			</div>
 		);
 	}

--- a/src/forms/Textarea.jsx
+++ b/src/forms/Textarea.jsx
@@ -130,6 +130,10 @@ class Textarea extends React.Component {
 			maxHeight: maxHeight
 		};
 
+		if (error) {
+			other['aria-invalid'] = true;
+		}
+
 		return (
 			<div>
 				<div className="inputContainer">

--- a/src/forms/__snapshots__/calendarComponent.test.jsx.snap
+++ b/src/forms/__snapshots__/calendarComponent.test.jsx.snap
@@ -12,10 +12,8 @@ exports[`CalendarComponent renders the calendarComponent with appropriate attrib
       type="text"
     />
   </span>
-  <p
-    className="text--error text--small"
-  >
-    this is an error
-  </p>
+  <ErrorList
+    errors="this is an error"
+  />
 </div>
 `;

--- a/src/forms/__snapshots__/errorList.test.jsx.snap
+++ b/src/forms/__snapshots__/errorList.test.jsx.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ErrorList matches snapshot for input without id 1`] = `
+<ul
+  aria-live="assertive"
+>
+  <li
+    className="text--error text--small text--small"
+    key="0"
+  >
+    This is an error message
+  </li>
+</ul>
+`;
+
+exports[`ErrorList matches snapshot for multiple errors 1`] = `
+<ul
+  aria-live="assertive"
+  id="name"
+>
+  <li
+    className="text--error text--small text--small"
+    key="0"
+  >
+    First error message
+  </li>
+  <li
+    className="text--error text--small text--small"
+    key="1"
+  >
+    Second error message
+  </li>
+  <li
+    className="text--error text--small text--small"
+    key="2"
+  >
+    Third error message
+  </li>
+</ul>
+`;
+
+exports[`ErrorList matches snapshot for single error 1`] = `
+<ul
+  aria-live="assertive"
+  id="name"
+>
+  <li
+    className="text--error text--small text--small"
+    key="0"
+  >
+    This is an error message
+  </li>
+</ul>
+`;

--- a/src/forms/__snapshots__/textInput.test.jsx.snap
+++ b/src/forms/__snapshots__/textInput.test.jsx.snap
@@ -14,12 +14,12 @@ exports[`TextInput renders a required HTML <input> with expected attributes for 
     <input
       className="span--100"
       id="superhero"
-      maxLength={-1}
       name="superhero"
       required={true}
       type="text"
       value="Batman"
     />
   </div>
+  <ErrorList />
 </div>
 `;

--- a/src/forms/errorList.story.jsx
+++ b/src/forms/errorList.story.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import ErrorList from './ErrorList';
+import Bounds from '../layout/Bounds';
+import { decorateWithInfo } from '../utils/decorators';
+import { storiesOf } from '@storybook/react';
+import {
+	withKnobs,
+	array,
+} from '@storybook/addon-knobs';
+
+storiesOf('ErrorList', module)
+	.addDecorator(decorateWithInfo)
+	.addDecorator(withKnobs)
+	.add('Single Error', () => (
+			<Bounds>
+				<ErrorList errors="There is one error" />
+			</Bounds>
+		)
+	)
+	.add('Multiple Errors', () => {
+			const errorListKnob = array('Errors', [
+				'You must use a special character in your name',
+				'You must not use a name you have used before',
+				'You must not reveal your true identity'
+			]);
+
+			return (
+				<Bounds>
+					<ErrorList errors={errorListKnob} />
+				</Bounds>
+			);
+		}
+	);

--- a/src/forms/errorList.test.jsx
+++ b/src/forms/errorList.test.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import ErrorList from './ErrorList';
+import { shallow } from 'enzyme';
+
+const MOCK_ERROR = "This is an error message";
+const MOCK_ERROR_LIST = [
+	"First error message",
+	"Second error message",
+	"Third error message"
+];
+const MOCK_ERROR_ID = "name";
+
+describe('ErrorList', () => {
+
+	const componentWithId = shallow(
+		<ErrorList
+			errorId={MOCK_ERROR_ID}
+			errors={MOCK_ERROR}
+		/>
+	);
+	const componentWithoutId = shallow(
+		<ErrorList errors={MOCK_ERROR} />
+	);
+
+	it('matches snapshot for single error', () => {
+		expect(componentWithId).toMatchSnapshot();
+	});
+	it('matches snapshot for multiple errors', () => {
+		const component = shallow(
+			<ErrorList
+				errorId={MOCK_ERROR_ID}
+				errors={MOCK_ERROR_LIST}
+			/>
+		);
+		expect(component).toMatchSnapshot();
+	});
+	it('matches snapshot for input without id', () => {
+		expect(componentWithoutId).toMatchSnapshot();
+	});
+	it('applies id attribute when `errorId` provided', () => {
+		expect(componentWithId.props()).toHaveProperty('id');
+		expect(componentWithId.prop('id')).toEqual(MOCK_ERROR_ID);
+	});
+	it('does NOT apply id attribute when `errorId` is not provided', () => {
+		expect(componentWithoutId.props()).not.toHaveProperty('id');
+	});
+	it('list of errors has `aria-live` attribute', () => {
+		[
+			componentWithoutId,
+			componentWithId
+		].forEach(c => {
+			expect(c.find('ul').html()).toEqual(
+				expect.stringContaining('aria-live')
+			);
+		});
+	});
+});

--- a/src/forms/selectInput.test.jsx
+++ b/src/forms/selectInput.test.jsx
@@ -36,20 +36,6 @@ describe('SelectInput basic', () => {
 	});
 });
 
-describe('Errors', () => {
-	it('shows a single error when a single error is passed in', () => {
-		const importantError = 'if you like it then you better put a ring on it';
-		const props = {
-			label: 'Bday',
-			name: 'Deluxe Edition',
-			options: testOptions,
-			error: importantError,
-		};
-		const component = shallow(<SelectInput {...props} />);
-		expect(component.find('.text--error').text()).toEqual(importantError);
-	});
-});
-
 describe('SelectInput advanced', () => {
 	it('should set correct value in state on change', () => {
 		const newValue = '2';

--- a/src/forms/util/errorProps.js
+++ b/src/forms/util/errorProps.js
@@ -1,0 +1,49 @@
+/**
+ * @function getErrorId
+ * returns an id with which we can set ARIA
+ * relationships between errors and form fields
+ *
+ * @param {string} id - the id of the form field
+ * @returns {string} id for error list
+ */
+const getErrorId = (id) => id && `${id}-error`;
+
+/**
+ * @function getFieldErrorProps
+ * returns an object of ARIA attributes to assign
+ * to a form field with an error
+ *
+ * @param {string} id - the id of the form field
+ * @param {boolean} hasError - pass `true` if field has an error
+ * @returns {object} props object to apply to field
+ */
+export const getFieldErrorProps = (id, hasError) => {
+	const ariaProps = {
+		'aria-invalid': !!hasError,
+	};
+
+	if (id) {
+		ariaProps['aria-describedby'] = getErrorId(id);
+	}
+
+	return ariaProps;
+};
+
+/**
+ * @function getErrorListProps
+ * returns props to pass for an ErrorList related
+ * to a form field
+ *
+ * @param {string} id - the id of the form field
+ * @param {string|array} errors - single or multiple error messages
+ * @returns {object} props object to apply to ErrorList
+ */
+export const getErrorListProps = (id, errors) => {
+	const props = { errors };
+
+	if (id) {
+		props['errorId'] = getErrorId(id);
+	}
+
+	return props;
+};

--- a/src/forms/util/errorProps.test.js
+++ b/src/forms/util/errorProps.test.js
@@ -1,0 +1,46 @@
+import {
+	getFieldErrorProps,
+	getErrorListProps,
+} from './errorProps';
+
+const MOCK_FIELD_ID = 'name';
+const MOCK_ERROR_MSG = 'You are not Keith Hernandez';
+
+describe('getFieldErrorProps', () => {
+	it('"aria-invalid" attribute should be true if there is an error passed', () => {
+		const actual = getFieldErrorProps(MOCK_FIELD_ID, true);
+		expect(actual).toHaveProperty('aria-invalid');
+		expect(actual['aria-invalid']).toBe(true);
+	});
+	it('"aria-invalid" attribute should be false if there is no error passed', () => {
+		const actual = getFieldErrorProps(MOCK_FIELD_ID, undefined);
+		expect(actual).toHaveProperty('aria-invalid');
+		expect(actual['aria-invalid']).toBe(false);
+	});
+	it('adds "aria-describedby" attribute when `id` is defined', () => {
+		const actual = getFieldErrorProps(MOCK_FIELD_ID, true);
+		expect(actual).toHaveProperty('aria-describedby');
+	});
+	it('does NOT add "aria-describedby" attribute when `id` is undefined', () => {
+		const actual = getFieldErrorProps(undefined, true);
+		expect(actual).not.toHaveProperty('aria-describedby');
+	});
+});
+
+describe('getErrorListProps', () => {
+	it('populates `errorId` when a defined id is passed', () => {
+		const actual = getErrorListProps(MOCK_FIELD_ID, MOCK_ERROR_MSG);
+		const expected = {
+			errors: MOCK_ERROR_MSG,
+			errorId: `${MOCK_FIELD_ID}-error`,
+		};
+		expect(actual).toMatchObject(expected);
+	});
+	it('does NOT populate `errorId` when an undefined id is passed', () => {
+		const actual = getErrorListProps(undefined, MOCK_ERROR_MSG);
+		const expected = {
+			errors: MOCK_ERROR_MSG
+		};
+		expect(actual).toMatchObject(expected);
+	});
+});


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-148


#### Description
Accessibility enhancements for form errors. Because we conditionally rendered field errors without an `aria-live` region, assistive technology was not informed of visual UI changes and error states.

This branch introduces an `ErrorList` component and adds attributes to all base form components in order to assist accessibility.

* error container always renders with `aria-live` attribute, which alerts screen readers when field errors appear
* form fields in error state now receive an `aria-invalid="true"` attribute
* when an `id` prop is passed to a form component, it is now used to link the error container to the related field with `aria-describedby` when there is an error


#### Screenshots (if applicable)

**No significant visual difference from previous error rendering**
![screen shot 2017-12-06 at 4 40 01 pm](https://user-images.githubusercontent.com/231252/33687892-9d4ee536-daa7-11e7-87a4-60cc97400100.png)

