### PR TITLE
Add center-aligned dropdown option

### DIFF
--- a/assets/scss/components/_dropdown.scss
+++ b/assets/scss/components/_dropdown.scss
@@ -66,12 +66,26 @@ $spaceFromTrigger: $space-3 + $triangleSize;
 }
 
 @mixin alignDropdown($direction) {
-	#{$direction}: 0;
-	&:before {
-		#{$direction}: $space-2;
-	}
-	&:after {
-		#{$direction}: $space-2 + 1;
+	@if $direction == 'center' {
+		left: 50%;
+		transform: translateX(-50%);
+
+		&:before {
+			left: 50%;
+			transform: translateX(-50%);
+		}
+		&:after {
+			left: 50%;
+			transform: translateX(-50%);
+		}
+	} @else {
+		#{$direction}: 0;
+		&:before {
+			#{$direction}: $space-2;
+		}
+		&:after {
+			#{$direction}: $space-2 + 1;
+		}
 	}
 }
 
@@ -80,4 +94,7 @@ $spaceFromTrigger: $space-3 + $triangleSize;
 }
 .dropdown-content--left {
 	@include alignDropdown('left');
+}
+.dropdown-content--center {
+	@include alignDropdown('center');
 }

--- a/src/interactive/Dropdown.jsx
+++ b/src/interactive/Dropdown.jsx
@@ -109,6 +109,7 @@ class Dropdown extends React.PureComponent {
 				{
 					'dropdown-content--right': (align == 'right'),
 					'dropdown-content--left': (align == 'left'),
+					'dropdown-content--center': (align == 'center'),
 					'display--none': !isActive,
 					'display--block': isActive
 				}
@@ -147,7 +148,7 @@ class Dropdown extends React.PureComponent {
 Dropdown.propTypes = {
 	trigger: PropTypes.element.isRequired,
 	content: PropTypes.element.isRequired,
-	align: PropTypes.oneOf(['left', 'right']).isRequired,
+	align: PropTypes.oneOf(['left', 'right', 'center']).isRequired,
 	className: PropTypes.string,
 	isActive: PropTypes.bool,
 	manualToggle: PropTypes.func

--- a/src/interactive/dropdown.story.jsx
+++ b/src/interactive/dropdown.story.jsx
@@ -112,7 +112,21 @@ storiesOf('Dropdown', module)
 				content={dropdownContent}
 			/>
 		)
-	).addWithInfo(
+	)
+	.addWithInfo(
+		'Center aligned dropdown',
+		'Use the `align` prop to change alignment to left',
+		() => (
+			<Dropdown
+				align='center'
+				trigger={
+					<Button small>Open</Button>
+				}
+				content={dropdownContent}
+			/>
+		)
+	)
+	.addWithInfo(
 		'with custom toggle functionality',
 		() => (
 			<Flex justify='flexEnd'>


### PR DESCRIPTION
#### Related issues
Helps with https://meetup.atlassian.net/browse/MW-2973

#### Description
Yanyi got [a design](https://meetup.atlassian.net/secure/attachment/39667/Event%20%28Upcoming%29.png) that calls for a center-aligned dropdown, so I added `center` as one of the possible directions that can be passed to `align`

#### Screenshots (if applicable)
<img width="417" alt="screen shot 2017-12-07 at 2 48 44 pm" src="https://user-images.githubusercontent.com/2313998/33735808-6418892c-db5e-11e7-85cc-5e06a08b8869.png">
