### PR TITLE
Darken neutral button text color

### DIFF
--- a/assets/scss/components/_button.scss
+++ b/assets/scss/components/_button.scss
@@ -191,16 +191,16 @@ _(The `extend` directive can cause ugly cascade problems)_
 		$bgColor: $C_buttonBGNeutral,
 		$hoverColor: opacify($C_buttonBGNeutral, .05),
 		$activeColor: opacify($C_buttonBGNeutral, .1),
-		$textColor: $C_textSecondary
+		$textColor: $C_textPrimary
 	);
 	.inverted & {
 		@include buttonColor(
 			$bgColor: $C_buttonBGNeutralInverted,
 			$hoverColor: opacify($C_buttonBGNeutralInverted, .05),
 			$activeColor: opacify($C_buttonBGNeutralInverted, .1),
-			$textColor: $C_textSecondary
+			$textColor: $C_textPrimaryInverted
 		);
-		@include color-all($C_textSecondaryInverted);
+		@include color-all($C_textPrimaryInverted);
 	}
 }
 


### PR DESCRIPTION
#### Description
The design team noticed that the neutral button looks disabled with `$C_textSecondary`, so I've updated the color to be `$C_textPrimary`. There may be more updates to this button style next month