### PR TITLE
Render dropdown content in document body

### DIFF
--- a/assets/scss/components/_dropdown.scss
+++ b/assets/scss/components/_dropdown.scss
@@ -3,7 +3,6 @@
 //
 $dropdownShadow: $interactiveShadow;
 $content-minWidth: $block-6;
-// $content-maxWidth: 512px; // match chapstick
 $triangleSize: 10px;
 $spaceFromTrigger: $space-3 + $triangleSize;
 

--- a/assets/scss/components/_dropdown.scss
+++ b/assets/scss/components/_dropdown.scss
@@ -3,7 +3,7 @@
 //
 $dropdownShadow: $interactiveShadow;
 $content-minWidth: $block-6;
-$content-maxWidth: 512px; // match chapstick
+// $content-maxWidth: 512px; // match chapstick
 $triangleSize: 10px;
 $spaceFromTrigger: $space-3 + $triangleSize;
 
@@ -29,10 +29,11 @@ $spaceFromTrigger: $space-3 + $triangleSize;
 	background-color: $C_contentBG;
 	box-shadow: $dropdownShadow;
 	box-sizing: border-box;
+	margin-top: $triangleSize;
 	position: absolute;
 	top: $spaceFromTrigger;
-	min-width: $content-minWidth;
-	max-width: $content-minWidth;
+	// min-width: $content-minWidth;
+	// max-width: $content-minWidth;
 	z-index: map-get($zindex-map, 'popup');
 
 	// outer triangle for border

--- a/assets/scss/components/_dropdown.scss
+++ b/assets/scss/components/_dropdown.scss
@@ -32,9 +32,6 @@ $spaceFromTrigger: $space-3 + $triangleSize;
 	margin-top: $triangleSize;
 	position: absolute;
 	top: $spaceFromTrigger;
-	// min-width: $content-minWidth;
-	// max-width: $content-minWidth;
-	z-index: map-get($zindex-map, 'popup');
 
 	// outer triangle for border
 	&:before {

--- a/assets/scss/components/_dropdown.scss
+++ b/assets/scss/components/_dropdown.scss
@@ -30,7 +30,6 @@ $spaceFromTrigger: $space-3 + $triangleSize;
 	box-sizing: border-box;
 	margin-top: $triangleSize;
 	position: absolute;
-	top: $spaceFromTrigger;
 
 	// outer triangle for border
 	&:before {

--- a/assets/scss/components/_dropdown.scss
+++ b/assets/scss/components/_dropdown.scss
@@ -30,6 +30,8 @@ $spaceFromTrigger: $space-3 + $triangleSize;
 	box-sizing: border-box;
 	margin-top: $triangleSize;
 	position: absolute;
+	transition: left $duration--short $easing--standard, top $duration--short $easing--standard;
+	z-index: map-get($zindex-map, "floating-content");
 
 	// outer triangle for border
 	&:before {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
   "dependencies": {
     "autosize": "3.0.21",
     "flatpickr": "3.0.6",
-    "recompose": "0.26.0"
+    "recompose": "0.26.0",
+    "react-portal": "3.2.0"
   },
   "devDependencies": {
     "@alrra/travis-scripts": "3.0.1",

--- a/src/interactive/Dropdown.jsx
+++ b/src/interactive/Dropdown.jsx
@@ -30,7 +30,7 @@ class Dropdown extends React.PureComponent {
 
 	getContentPosition() {
 		const {left, top, width, height} = this.triggerRef.getBoundingClientRect();
-		const contentWidth = this.props.width;
+		const contentWidth = this.props.maxWidth;
 		const getCoordX = (alignment) => {
 			switch (alignment) {
 				case 'left':
@@ -124,7 +124,8 @@ class Dropdown extends React.PureComponent {
 			trigger,
 			content,
 			align, // eslint-disable-line no-unused-vars
-			width,
+			maxWidth,
+			minWidth,
 			...other
 		} = this.props;
 
@@ -180,8 +181,8 @@ class Dropdown extends React.PureComponent {
 						style={{
 							left: `${this.state.posX}px`,
 							top: `${this.state.posY}px`,
-							minWidth: `${width}px`,
-							maxWidth: `${width}px`
+							minWidth: `${minWidth}px`,
+							maxWidth: `${maxWidth}px`
 						}}
 					>
 						{content}
@@ -193,7 +194,8 @@ class Dropdown extends React.PureComponent {
 }
 
 Dropdown.defaultProps = {
-	width: 384,
+	maxWidth: 384,
+	minWidth: 0
 };
 
 Dropdown.propTypes = {
@@ -203,7 +205,8 @@ Dropdown.propTypes = {
 	className: PropTypes.string,
 	isActive: PropTypes.bool,
 	manualToggle: PropTypes.func,
-	width: PropTypes.number
+	maxWidth: PropTypes.number,
+	minWidth: PropTypes.number,
 };
 
 export default Dropdown;

--- a/src/interactive/Dropdown.jsx
+++ b/src/interactive/Dropdown.jsx
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
+import Portal from 'react-portal';
+
 import bindAll from '../utils/bindAll';
 
 /**
@@ -11,6 +13,7 @@ class Dropdown extends React.PureComponent {
 		super(props);
 
 		bindAll(this,
+			'getContentPosition',
 			'toggleContent',
 			'onClick',
 			'onKeyDown',
@@ -18,7 +21,36 @@ class Dropdown extends React.PureComponent {
 			'onBodyKeyDown'
 		);
 
-		this.state = { isActive: props.isActive || false };
+		this.state = {
+			isActive: props.isActive || false,
+			posX: 0,
+			posY: 0
+		};
+	}
+
+	getContentPosition() {
+		const {x, y, width, height} = this.triggerRef.getBoundingClientRect();
+		const contentWidth = this.props.width;
+		const getCoordX = (alignment) => {
+			switch (alignment) {
+				case 'left':
+					return x;
+				case 'center':
+					return x + (width/2);
+				default:
+					return x - (contentWidth - width);
+			}
+		};
+
+		const ddPosition = {
+			x: getCoordX(this.props.align),
+			y: y + height
+		};
+
+		this.setState(() => ({
+			posX: ddPosition.x,
+			posY: ddPosition.y
+		}));
 	}
 
 	closeContent(e) {
@@ -30,6 +62,8 @@ class Dropdown extends React.PureComponent {
 	}
 
 	toggleContent(e) {
+		this.getContentPosition();
+
 		if (this.props.manualToggle) {
 			this.props.manualToggle(e);
 		} else {
@@ -72,11 +106,13 @@ class Dropdown extends React.PureComponent {
 	componentDidMount() {
 		document.body.addEventListener('click', this.onBodyClick);
 		document.body.addEventListener('keydown', this.onBodyKeyDown);
+		window.addEventListener('resize', this.getContentPosition);
 	}
 
 	componentWillUnmount() {
 		document.body.removeEventListener('click', this.onBodyClick);
 		document.body.removeEventListener('keydown', this.onBodyKeyDown);
+		window.removeEventListener('resize', this.getContentPosition);
 	}
 
 	render() {
@@ -86,6 +122,7 @@ class Dropdown extends React.PureComponent {
 			trigger,
 			content,
 			align, // eslint-disable-line no-unused-vars
+			width, // eslint-disable-line no-unused-vars
 			...other
 		} = this.props;
 
@@ -133,17 +170,29 @@ class Dropdown extends React.PureComponent {
 					{trigger}
 				</div>
 
-				<div
-					ref={(el) => this.contentRef = el}
-					className={classNames.content}
-					aria-hidden={!isActive}
-				>
-					{content}
-				</div>
+				<Portal isOpened={isActive}>
+					<div
+						ref={(el) => this.contentRef = el}
+						className={classNames.content}
+						aria-hidden={!isActive}
+						style={{
+							left: `${this.state.posX}px`,
+							top: `${this.state.posY}px`,
+							minWidth: `${this.props.width}px`,
+							maxWidth: `${this.props.width}px`
+						}}
+					>
+						{content}
+					</div>
+				</Portal>
 			</div>
 		);
 	}
 }
+
+Dropdown.defaultProps = {
+	width: 384
+};
 
 Dropdown.propTypes = {
 	trigger: PropTypes.element.isRequired,
@@ -151,7 +200,8 @@ Dropdown.propTypes = {
 	align: PropTypes.oneOf(['left', 'right', 'center']).isRequired,
 	className: PropTypes.string,
 	isActive: PropTypes.bool,
-	manualToggle: PropTypes.func
+	manualToggle: PropTypes.func,
+	width: PropTypes.number
 };
 
 export default Dropdown;

--- a/src/interactive/Dropdown.jsx
+++ b/src/interactive/Dropdown.jsx
@@ -5,6 +5,15 @@ import Portal from 'react-portal';
 
 import bindAll from '../utils/bindAll';
 
+const throttle = (fn, wait) => {
+	let time = Date.now();
+	return () => {
+		if ((time + wait - Date.now()) < 0) {
+			fn();
+			time = Date.now();
+		}
+	};
+};
 /**
  * @module Dropdown
  */
@@ -30,7 +39,8 @@ class Dropdown extends React.PureComponent {
 
 	getContentPosition() {
 		const {left, top, width, height} = this.triggerRef.getBoundingClientRect();
-		const contentWidth = parseInt(this.props.maxWidth, 10);
+		const scrollTop = window.scrollY || window.pageYOffset;
+		const contentWidth = parseInt(this.props.maxWidth);
 		const getCoordX = (alignment) => {
 			switch (alignment) {
 				case 'left':
@@ -44,8 +54,10 @@ class Dropdown extends React.PureComponent {
 
 		const ddPosition = {
 			x: getCoordX(this.props.align),
-			y: window.scrollY || window.pageYOffset + top + height
+			y: scrollTop + top + height
 		};
+
+		console.log(scrollTop);
 
 		this.setState(() => ({
 			posX: ddPosition.x,
@@ -106,8 +118,8 @@ class Dropdown extends React.PureComponent {
 	componentDidMount() {
 		document.body.addEventListener('click', this.onBodyClick);
 		document.body.addEventListener('keydown', this.onBodyKeyDown);
-		window.addEventListener('resize', this.getContentPosition);
-		document.addEventListener('scroll', this.getContentPosition, true);
+		window.addEventListener('resize', throttle(this.getContentPosition, 1000/60)); // 1000/60 because 60fps
+		document.addEventListener('scroll', throttle(this.getContentPosition, 1000/60), true); // 1000/60 because 60fps
 	}
 
 	componentWillUnmount() {

--- a/src/interactive/Dropdown.jsx
+++ b/src/interactive/Dropdown.jsx
@@ -30,7 +30,7 @@ class Dropdown extends React.PureComponent {
 
 	getContentPosition() {
 		const {left, top, width, height} = this.triggerRef.getBoundingClientRect();
-		const contentWidth = this.props.maxWidth;
+		const contentWidth = parseInt(this.props.maxWidth, 10);
 		const getCoordX = (alignment) => {
 			switch (alignment) {
 				case 'left':
@@ -44,7 +44,7 @@ class Dropdown extends React.PureComponent {
 
 		const ddPosition = {
 			x: getCoordX(this.props.align),
-			y: window.scrollY + top + height
+			y: window.scrollY || window.pageYOffset + top + height
 		};
 
 		this.setState(() => ({
@@ -62,7 +62,7 @@ class Dropdown extends React.PureComponent {
 	}
 
 	toggleContent(e) {
-		this.getContentPosition(e);
+		this.getContentPosition();
 
 		if (this.props.manualToggle) {
 			this.props.manualToggle(e);
@@ -181,8 +181,8 @@ class Dropdown extends React.PureComponent {
 						style={{
 							left: `${this.state.posX}px`,
 							top: `${this.state.posY}px`,
-							minWidth: `${minWidth}px`,
-							maxWidth: `${maxWidth}px`
+							minWidth: `${minWidth}`,
+							maxWidth: `${maxWidth}`
 						}}
 					>
 						{content}
@@ -194,8 +194,8 @@ class Dropdown extends React.PureComponent {
 }
 
 Dropdown.defaultProps = {
-	maxWidth: 384,
-	minWidth: 0
+	maxWidth: '384px',
+	minWidth: '0px'
 };
 
 Dropdown.propTypes = {
@@ -205,8 +205,14 @@ Dropdown.propTypes = {
 	className: PropTypes.string,
 	isActive: PropTypes.bool,
 	manualToggle: PropTypes.func,
-	maxWidth: PropTypes.number,
-	minWidth: PropTypes.number,
+	maxWidth: PropTypes.oneOfType([
+		PropTypes.string,
+		PropTypes.number
+	]),
+	minWidth: PropTypes.oneOfType([
+		PropTypes.string,
+		PropTypes.number
+	]),
 };
 
 export default Dropdown;

--- a/src/interactive/Dropdown.jsx
+++ b/src/interactive/Dropdown.jsx
@@ -124,7 +124,7 @@ class Dropdown extends React.PureComponent {
 			trigger,
 			content,
 			align, // eslint-disable-line no-unused-vars
-			width, // eslint-disable-line no-unused-vars
+			width,
 			...other
 		} = this.props;
 
@@ -146,9 +146,9 @@ class Dropdown extends React.PureComponent {
 			content: cx(
 				'dropdown-content',
 				{
-					'dropdown-content--right': (align == 'right'),
-					'dropdown-content--left': (align == 'left'),
-					'dropdown-content--center': (align == 'center'),
+					'dropdown-content--right': (align === 'right'),
+					'dropdown-content--left': (align === 'left'),
+					'dropdown-content--center': (align === 'center'),
 					'display--none': !isActive,
 					'display--block': isActive
 				}
@@ -180,8 +180,8 @@ class Dropdown extends React.PureComponent {
 						style={{
 							left: `${this.state.posX}px`,
 							top: `${this.state.posY}px`,
-							minWidth: `${this.props.width}px`,
-							maxWidth: `${this.props.width}px`
+							minWidth: `${width}px`,
+							maxWidth: `${width}px`
 						}}
 					>
 						{content}
@@ -193,7 +193,7 @@ class Dropdown extends React.PureComponent {
 }
 
 Dropdown.defaultProps = {
-	width: 384
+	width: 384,
 };
 
 Dropdown.propTypes = {

--- a/src/interactive/Dropdown.jsx
+++ b/src/interactive/Dropdown.jsx
@@ -29,22 +29,22 @@ class Dropdown extends React.PureComponent {
 	}
 
 	getContentPosition() {
-		const {x, y, width, height} = this.triggerRef.getBoundingClientRect();
+		const {left, top, width, height} = this.triggerRef.getBoundingClientRect();
 		const contentWidth = this.props.width;
 		const getCoordX = (alignment) => {
 			switch (alignment) {
 				case 'left':
-					return x;
+					return left;
 				case 'center':
-					return x + (width/2);
+					return left + (width/2);
 				default:
-					return x - (contentWidth - width);
+					return left - (contentWidth - width);
 			}
 		};
 
 		const ddPosition = {
 			x: getCoordX(this.props.align),
-			y: y + height
+			y: window.scrollY + top + height
 		};
 
 		this.setState(() => ({
@@ -62,7 +62,7 @@ class Dropdown extends React.PureComponent {
 	}
 
 	toggleContent(e) {
-		this.getContentPosition();
+		this.getContentPosition(e);
 
 		if (this.props.manualToggle) {
 			this.props.manualToggle(e);
@@ -107,12 +107,14 @@ class Dropdown extends React.PureComponent {
 		document.body.addEventListener('click', this.onBodyClick);
 		document.body.addEventListener('keydown', this.onBodyKeyDown);
 		window.addEventListener('resize', this.getContentPosition);
+		document.addEventListener('scroll', this.getContentPosition, true);
 	}
 
 	componentWillUnmount() {
 		document.body.removeEventListener('click', this.onBodyClick);
 		document.body.removeEventListener('keydown', this.onBodyKeyDown);
 		window.removeEventListener('resize', this.getContentPosition);
+		document.removeEventListener('scroll', this.getContentPosition);
 	}
 
 	render() {

--- a/src/interactive/__snapshots__/dropdown.test.jsx.snap
+++ b/src/interactive/__snapshots__/dropdown.test.jsx.snap
@@ -1,0 +1,117 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Dropdown renders into DOM 1`] = `
+<Dropdown
+  align="right"
+  content={
+    <Section
+      noSeparator={true}
+    >
+      <Chunk>
+        <h2
+          className="text--big text--bold"
+        >
+          Dropdown content
+        </h2>
+      </Chunk>
+    </Section>
+  }
+  maxWidth={384}
+  minWidth={0}
+  trigger={
+    <Button
+      small={true}
+    >
+      Open
+    </Button>
+  }
+>
+  <div
+    aria-haspopup="true"
+    className="dropdown"
+    onKeyDown={[Function]}
+  >
+    <div
+      className="dropdown-trigger"
+      onClick={[Function]}
+      tabIndex="0"
+    >
+      <Button
+        small={true}
+      >
+        <button
+          className="button button--small"
+          onClick={undefined}
+          role="button"
+        >
+          Open
+        </button>
+      </Button>
+    </div>
+    <Portal
+      isOpened={false}
+      onClose={[Function]}
+      onOpen={[Function]}
+      onUpdate={[Function]}
+    />
+  </div>
+</Dropdown>
+`;
+
+exports[`Dropdown right aligned dropdown renders right-aligned dropdown to DOM 1`] = `
+<Dropdown
+  align="right"
+  content={
+    <Section
+      noSeparator={true}
+    >
+      <Chunk>
+        <h2
+          className="text--big text--bold"
+        >
+          Dropdown content
+        </h2>
+      </Chunk>
+    </Section>
+  }
+  maxWidth={384}
+  minWidth={0}
+  trigger={
+    <Button
+      small={true}
+    >
+      Open
+    </Button>
+  }
+>
+  <div
+    aria-haspopup="true"
+    className="dropdown"
+    onKeyDown={[Function]}
+  >
+    <div
+      className="dropdown-trigger"
+      onClick={[Function]}
+      tabIndex="0"
+    >
+      <Button
+        small={true}
+      >
+        <button
+          className="button button--small"
+          onClick={undefined}
+          role="button"
+        >
+          Open
+        </button>
+      </Button>
+    </div>
+    <Portal
+      isOpened={false}
+      onClose={[Function]}
+      onOpen={[Function]}
+      onUpdate={[Function]}
+    />
+  </div>
+</Dropdown>
+`;

--- a/src/interactive/__snapshots__/dropdown.test.jsx.snap
+++ b/src/interactive/__snapshots__/dropdown.test.jsx.snap
@@ -16,8 +16,8 @@ exports[`Dropdown renders into DOM 1`] = `
       </Chunk>
     </Section>
   }
-  maxWidth={384}
-  minWidth={0}
+  maxWidth="384px"
+  minWidth="0px"
   trigger={
     <Button
       small={true}
@@ -74,8 +74,8 @@ exports[`Dropdown right aligned dropdown renders right-aligned dropdown to DOM 1
       </Chunk>
     </Section>
   }
-  maxWidth={384}
-  minWidth={0}
+  maxWidth="384px"
+  minWidth="0px"
   trigger={
     <Button
       small={true}

--- a/src/interactive/dropdown.story.jsx
+++ b/src/interactive/dropdown.story.jsx
@@ -51,7 +51,7 @@ class DropdownWithToggle extends React.PureComponent {
 			<Dropdown
 				align='right'
 				minWidth='0'
-				maxWidth='384'
+				maxWidth='384px'
 				isActive={this.state.dropdownToggled}
 				manualToggle={this.toggleDropdown}
 				trigger={
@@ -93,7 +93,7 @@ storiesOf('Dropdown', module)
 				<FlexItem shrink>
 					<Dropdown
 						minWidth='0'
-						maxWidth='384'
+						maxWidth='384px'
 						align='right'
 						trigger={
 							<Button small>Open</Button>
@@ -111,7 +111,7 @@ storiesOf('Dropdown', module)
 			<Dropdown
 				align='left'
 				minWidth='0'
-				maxWidth='384'
+				maxWidth='384px'
 				trigger={
 					<Button small>Open</Button>
 				}
@@ -126,7 +126,7 @@ storiesOf('Dropdown', module)
 			<Dropdown
 				align='center'
 				minWidth='0'
-				maxWidth='384'
+				maxWidth='384px'
 				trigger={
 					<Button small>Open</Button>
 				}

--- a/src/interactive/dropdown.story.jsx
+++ b/src/interactive/dropdown.story.jsx
@@ -50,6 +50,8 @@ class DropdownWithToggle extends React.PureComponent {
 		return (
 			<Dropdown
 				align='right'
+				minWidth='0'
+				maxWidth='384'
 				isActive={this.state.dropdownToggled}
 				manualToggle={this.toggleDropdown}
 				trigger={
@@ -90,6 +92,8 @@ storiesOf('Dropdown', module)
 			<Flex justify='flexEnd'>
 				<FlexItem shrink>
 					<Dropdown
+						minWidth='0'
+						maxWidth='384'
 						align='right'
 						trigger={
 							<Button small>Open</Button>
@@ -106,6 +110,8 @@ storiesOf('Dropdown', module)
 		() => (
 			<Dropdown
 				align='left'
+				minWidth='0'
+				maxWidth='384'
 				trigger={
 					<Button small>Open</Button>
 				}
@@ -119,6 +125,8 @@ storiesOf('Dropdown', module)
 		() => (
 			<Dropdown
 				align='center'
+				minWidth='0'
+				maxWidth='384'
 				trigger={
 					<Button small>Open</Button>
 				}

--- a/src/interactive/dropdown.test.jsx
+++ b/src/interactive/dropdown.test.jsx
@@ -19,15 +19,15 @@ const dropdownTrigger = <Button small>Open</Button>;
 const getDropdownFn = component => () =>
 	TestUtils.findRenderedComponentWithType(component, Dropdown);
 
-const getTrigger = component =>
-	TestUtils.findRenderedDOMComponentWithClass(component, 'dropdown-trigger');
+// const getTrigger = component =>
+// 	TestUtils.findRenderedDOMComponentWithClass(component, 'dropdown-trigger');
 
-const getContent = component =>
-	TestUtils.findRenderedDOMComponentWithClass(component, 'dropdown-content');
+// const getContent = component =>
+// 	TestUtils.findRenderedDOMComponentWithClass(component, 'dropdown-content');
 
-const getIsOpen = content =>
-	content.classList.contains('display--block') &&
-	!content.classList.contains('display--none');
+// const getIsOpen = content =>
+// 	content.classList.contains('display--block') &&
+// 	!content.classList.contains('display--none');
 
 /**
  * @module DropdownWithToggle
@@ -75,10 +75,10 @@ describe('Dropdown', () => {
 		expect(getDropdownFn(component)).not.toThrow();
 	});
 
-	it('should hide dropdown content by default', () => {
-		const content = getContent(component);
-		expect(content.classList).toContain('display--none');
-	});
+	// it('should hide dropdown content by default', () => {
+	// 	const content = getContent(component);
+	// 	expect(content.classList).toContain('display--none');
+	// });
 
 	describe('right aligned dropdown', () => {
 		const rightDropdown = TestUtils.renderIntoDocument(
@@ -93,52 +93,52 @@ describe('Dropdown', () => {
 			expect(getDropdownFn(rightDropdown)).not.toThrow();
 		});
 
-		it('applies correct alignment className to dropdown content', () => {
-			const content = getContent(rightDropdown);
-			expect(content.classList).toContain('dropdown-content--right');
-		});
+		// it('applies correct alignment className to dropdown content', () => {
+		// 	const content = getContent(rightDropdown);
+		// 	expect(content.classList).toContain('dropdown-content--right');
+		// });
 	});
 
-	describe('open and close', () => {
-		let closedComponent, content, trigger;
+	// describe('open and close', () => {
+	// 	let closedComponent, content, trigger;
 
-		beforeEach(() => {
-			closedComponent = TestUtils.renderIntoDocument(dropdownJSX);
-			content = getContent(closedComponent);
-			trigger = getTrigger(closedComponent);
-		});
-		afterEach(() => {
-			closedComponent = null;
-			content = null;
-			trigger = null;
-		});
+	// 	beforeEach(() => {
+	// 		closedComponent = TestUtils.renderIntoDocument(dropdownJSX);
+	// 		content = getContent(closedComponent);
+	// 		trigger = getTrigger(closedComponent);
+	// 	});
+	// 	afterEach(() => {
+	// 		closedComponent = null;
+	// 		content = null;
+	// 		trigger = null;
+	// 	});
 
-		it('shold show dropdown when trigger is clicked', () => {
-			expect(getIsOpen(content)).toBeFalsy();
-			TestUtils.Simulate.click(trigger);
-			expect(getIsOpen(content)).toBeTruthy();
-		});
+	// 	it('shold show dropdown when trigger is clicked', () => {
+	// 		expect(getIsOpen(content)).toBeFalsy();
+	// 		TestUtils.Simulate.click(trigger);
+	// 		expect(getIsOpen(content)).toBeTruthy();
+	// 	});
 
-		it('should close the dropdown on ESC key', () => {
-			// open it first
-			// dropdowns do not support default open by design
-			TestUtils.Simulate.click(trigger);
-			expect(getIsOpen(content)).toBeTruthy();
+	// 	it('should close the dropdown on ESC key', () => {
+	// 		// open it first
+	// 		// dropdowns do not support default open by design
+	// 		TestUtils.Simulate.click(trigger);
+	// 		expect(getIsOpen(content)).toBeTruthy();
 
-			closedComponent.onBodyKeyDown({ key: 'Escape' });
-			expect(getIsOpen(content)).toBeFalsy();
-		});
+	// 		closedComponent.onBodyKeyDown({ key: 'Escape' });
+	// 		expect(getIsOpen(content)).toBeFalsy();
+	// 	});
 
-		it('should close when clicking outside of the dropdown content', () => {
-			// open it first
-			// dropdowns do not support default open by design
-			TestUtils.Simulate.click(trigger);
-			expect(getIsOpen(content)).toBeTruthy();
+	// 	it('should close when clicking outside of the dropdown content', () => {
+	// 		// open it first
+	// 		// dropdowns do not support default open by design
+	// 		TestUtils.Simulate.click(trigger);
+	// 		expect(getIsOpen(content)).toBeTruthy();
 
-			closedComponent.onBodyClick({ target: '<div />' });
-			expect(getIsOpen(content)).toBeFalsy();
-		});
-	});
+	// 		closedComponent.onBodyClick({ target: '<div />' });
+	// 		expect(getIsOpen(content)).toBeFalsy();
+	// 	});
+	// });
 
 	describe('manually toggle dropdown', () => {
 		let closedComponent, closeContentSpy, toggleContentSpy, trigger;

--- a/src/interactive/dropdown.test.jsx
+++ b/src/interactive/dropdown.test.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-// import TestUtils from 'react-dom/test-utils';
 import { mount, ReactWrapper } from 'enzyme';
 import Portal from 'react-portal';
 
@@ -18,25 +17,8 @@ const dropdownContent = (
 );
 const dropdownTrigger = <Button small>Open</Button>;
 
-// const getDropdownFn = component => () =>
-// 	TestUtils.findRenderedComponentWithType(component, Dropdown);
-
-// const getTrigger = component =>
-// 	TestUtils.findRenderedDOMComponentWithClass(component, 'dropdown-trigger');
-
-// const getContent = component =>
-// 	TestUtils.findRenderedDOMComponentWithClass(component, 'dropdown-content');
-
 const getPortalContent = portal =>
 	new ReactWrapper(portal.prop('children'));
-
-// const getIsOpen = content =>
-// 	content.classList.contains('display--block') &&
-// 	!content.classList.contains('display--none');
-
-// const getIsPortalOpen = portal =>
-// 	portal.prop('className').includes('display--block') &&
-// 	!portal.prop('className').includes('display--none');
 
 /**
  * @module DropdownWithToggle
@@ -79,7 +61,6 @@ describe('Dropdown', () => {
 		/>
 	);
 	const wrapper = mount(dropdownJSX);
-	// const wrapperWithRef = new ReactWrapper( mount(dropdownJSX).instance().triggerRef, true );
 	const portalWrapper = wrapper.find(Portal);
 
 	it('renders into DOM', () => {

--- a/src/interactive/dropdown.test.jsx
+++ b/src/interactive/dropdown.test.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import TestUtils from 'react-dom/test-utils';
-import { mount } from 'enzyme';
+// import TestUtils from 'react-dom/test-utils';
+import { mount, ReactWrapper } from 'enzyme';
+import Portal from 'react-portal';
+
 import Section from '../layout/Section';
 import Chunk from '../layout/Chunk';
 import Button from '../forms/Button';
@@ -16,18 +18,25 @@ const dropdownContent = (
 );
 const dropdownTrigger = <Button small>Open</Button>;
 
-const getDropdownFn = component => () =>
-	TestUtils.findRenderedComponentWithType(component, Dropdown);
+// const getDropdownFn = component => () =>
+// 	TestUtils.findRenderedComponentWithType(component, Dropdown);
 
-const getTrigger = component =>
-	TestUtils.findRenderedDOMComponentWithClass(component, 'dropdown-trigger');
+// const getTrigger = component =>
+// 	TestUtils.findRenderedDOMComponentWithClass(component, 'dropdown-trigger');
 
-const getContent = component =>
-	TestUtils.findRenderedDOMComponentWithClass(component, 'dropdown-content');
+// const getContent = component =>
+// 	TestUtils.findRenderedDOMComponentWithClass(component, 'dropdown-content');
 
-const getIsOpen = content =>
-	content.classList.contains('display--block') &&
-	!content.classList.contains('display--none');
+const getPortalContent = portal =>
+	new ReactWrapper(portal.prop('children'));
+
+// const getIsOpen = content =>
+// 	content.classList.contains('display--block') &&
+// 	!content.classList.contains('display--none');
+
+// const getIsPortalOpen = portal =>
+// 	portal.prop('className').includes('display--block') &&
+// 	!portal.prop('className').includes('display--none');
 
 /**
  * @module DropdownWithToggle
@@ -69,74 +78,77 @@ describe('Dropdown', () => {
 			content={dropdownContent}
 		/>
 	);
-	const component = TestUtils.renderIntoDocument(dropdownJSX);
+	const wrapper = mount(dropdownJSX);
+	// const wrapperWithRef = new ReactWrapper( mount(dropdownJSX).instance().triggerRef, true );
+	const portalWrapper = wrapper.find(Portal);
 
 	it('renders into DOM', () => {
-		expect(getDropdownFn(component)).not.toThrow();
+		expect(wrapper).toMatchSnapshot();
 	});
 
 	it('should hide dropdown content by default', () => {
-		const content = getContent(component);
-		expect(content.classList).toContain('display--none');
+		const content = getPortalContent(portalWrapper);
+
+		expect(content.prop('className')).toContain('display--none');
 	});
 
 	describe('right aligned dropdown', () => {
-		const rightDropdown = TestUtils.renderIntoDocument(
+		const rightDropdown = (
 			<Dropdown
 				align="right"
 				trigger={dropdownTrigger}
 				content={dropdownContent}
 			/>
 		);
+		const rightDropdownWrapper = mount(rightDropdown);
+		const rightDropdownPortal = rightDropdownWrapper.find(Portal);
 
-		it('renders left-aligned dropdown to DOM', () => {
-			expect(getDropdownFn(rightDropdown)).not.toThrow();
+		it('renders right-aligned dropdown to DOM', () => {
+			expect(rightDropdownWrapper).toMatchSnapshot();
 		});
 
 		it('applies correct alignment className to dropdown content', () => {
-			const content = getContent(rightDropdown);
-			expect(content.classList).toContain('dropdown-content--right');
+			const content = getPortalContent(rightDropdownPortal);
+			expect(content.prop('className')).toContain('dropdown-content--right');
 		});
 	});
 
 	describe('open and close', () => {
-		let closedComponent, content, trigger;
+		let closedComponent, trigger;
 
 		beforeEach(() => {
-			closedComponent = TestUtils.renderIntoDocument(dropdownJSX);
-			content = getContent(closedComponent);
-			trigger = getTrigger(closedComponent);
+			closedComponent = mount(dropdownJSX);
+			trigger = closedComponent.find('.dropdown-trigger').first();
 		});
 		afterEach(() => {
 			closedComponent = null;
-			content = null;
 			trigger = null;
 		});
 
 		it('shold show dropdown when trigger is clicked', () => {
-			expect(getIsOpen(content)).toBeFalsy();
-			TestUtils.Simulate.click(trigger);
-			expect(getIsOpen(content)).toBeTruthy();
+			expect(closedComponent.state('isActive')).toBeFalsy();
+			trigger.simulate('click');
+			expect(closedComponent.state('isActive')).toBeTruthy();
 		});
 
 		it('should close the dropdown on ESC key', () => {
 			// open it first
 			// dropdowns do not support default open by design
-			TestUtils.Simulate.click(trigger);
-			expect(getIsOpen(content)).toBeTruthy();
+			trigger.simulate('click');
+			expect(closedComponent.state('isActive')).toBeTruthy();
 
-			closedComponent.onBodyKeyDown({ key: 'Escape' });
-			expect(getIsOpen(content)).toBeFalsy();
+			closedComponent.instance().onBodyKeyDown({ key: 'Escape' });
+			expect(closedComponent.state('isActive')).toBeFalsy();
 		});
 
 		it('should close when clicking outside of the dropdown content', () => {
 			// open it first
 			// dropdowns do not support default open by design
-			TestUtils.Simulate.click(trigger);
-			expect(getIsOpen(content)).toBeTruthy();
+			trigger.simulate('click');
+			expect(closedComponent.state('isActive')).toBeTruthy();
 
-			closedComponent.onBodyClick({ target: '<div />' });
-			expect(getIsOpen(content)).toBeFalsy();
+			closedComponent.instance().onBodyClick({ target: '<div />' });
+			expect(closedComponent.state('isActive')).toBeFalsy();
 		});
 	});
 

--- a/src/interactive/dropdown.test.jsx
+++ b/src/interactive/dropdown.test.jsx
@@ -19,15 +19,15 @@ const dropdownTrigger = <Button small>Open</Button>;
 const getDropdownFn = component => () =>
 	TestUtils.findRenderedComponentWithType(component, Dropdown);
 
-// const getTrigger = component =>
-// 	TestUtils.findRenderedDOMComponentWithClass(component, 'dropdown-trigger');
+const getTrigger = component =>
+	TestUtils.findRenderedDOMComponentWithClass(component, 'dropdown-trigger');
 
-// const getContent = component =>
-// 	TestUtils.findRenderedDOMComponentWithClass(component, 'dropdown-content');
+const getContent = component =>
+	TestUtils.findRenderedDOMComponentWithClass(component, 'dropdown-content');
 
-// const getIsOpen = content =>
-// 	content.classList.contains('display--block') &&
-// 	!content.classList.contains('display--none');
+const getIsOpen = content =>
+	content.classList.contains('display--block') &&
+	!content.classList.contains('display--none');
 
 /**
  * @module DropdownWithToggle
@@ -75,10 +75,10 @@ describe('Dropdown', () => {
 		expect(getDropdownFn(component)).not.toThrow();
 	});
 
-	// it('should hide dropdown content by default', () => {
-	// 	const content = getContent(component);
-	// 	expect(content.classList).toContain('display--none');
-	// });
+	it('should hide dropdown content by default', () => {
+		const content = getContent(component);
+		expect(content.classList).toContain('display--none');
+	});
 
 	describe('right aligned dropdown', () => {
 		const rightDropdown = TestUtils.renderIntoDocument(
@@ -93,52 +93,52 @@ describe('Dropdown', () => {
 			expect(getDropdownFn(rightDropdown)).not.toThrow();
 		});
 
-		// it('applies correct alignment className to dropdown content', () => {
-		// 	const content = getContent(rightDropdown);
-		// 	expect(content.classList).toContain('dropdown-content--right');
-		// });
+		it('applies correct alignment className to dropdown content', () => {
+			const content = getContent(rightDropdown);
+			expect(content.classList).toContain('dropdown-content--right');
+		});
 	});
 
-	// describe('open and close', () => {
-	// 	let closedComponent, content, trigger;
+	describe('open and close', () => {
+		let closedComponent, content, trigger;
 
-	// 	beforeEach(() => {
-	// 		closedComponent = TestUtils.renderIntoDocument(dropdownJSX);
-	// 		content = getContent(closedComponent);
-	// 		trigger = getTrigger(closedComponent);
-	// 	});
-	// 	afterEach(() => {
-	// 		closedComponent = null;
-	// 		content = null;
-	// 		trigger = null;
-	// 	});
+		beforeEach(() => {
+			closedComponent = TestUtils.renderIntoDocument(dropdownJSX);
+			content = getContent(closedComponent);
+			trigger = getTrigger(closedComponent);
+		});
+		afterEach(() => {
+			closedComponent = null;
+			content = null;
+			trigger = null;
+		});
 
-	// 	it('shold show dropdown when trigger is clicked', () => {
-	// 		expect(getIsOpen(content)).toBeFalsy();
-	// 		TestUtils.Simulate.click(trigger);
-	// 		expect(getIsOpen(content)).toBeTruthy();
-	// 	});
+		it('shold show dropdown when trigger is clicked', () => {
+			expect(getIsOpen(content)).toBeFalsy();
+			TestUtils.Simulate.click(trigger);
+			expect(getIsOpen(content)).toBeTruthy();
+		});
 
-	// 	it('should close the dropdown on ESC key', () => {
-	// 		// open it first
-	// 		// dropdowns do not support default open by design
-	// 		TestUtils.Simulate.click(trigger);
-	// 		expect(getIsOpen(content)).toBeTruthy();
+		it('should close the dropdown on ESC key', () => {
+			// open it first
+			// dropdowns do not support default open by design
+			TestUtils.Simulate.click(trigger);
+			expect(getIsOpen(content)).toBeTruthy();
 
-	// 		closedComponent.onBodyKeyDown({ key: 'Escape' });
-	// 		expect(getIsOpen(content)).toBeFalsy();
-	// 	});
+			closedComponent.onBodyKeyDown({ key: 'Escape' });
+			expect(getIsOpen(content)).toBeFalsy();
+		});
 
-	// 	it('should close when clicking outside of the dropdown content', () => {
-	// 		// open it first
-	// 		// dropdowns do not support default open by design
-	// 		TestUtils.Simulate.click(trigger);
-	// 		expect(getIsOpen(content)).toBeTruthy();
+		it('should close when clicking outside of the dropdown content', () => {
+			// open it first
+			// dropdowns do not support default open by design
+			TestUtils.Simulate.click(trigger);
+			expect(getIsOpen(content)).toBeTruthy();
 
-	// 		closedComponent.onBodyClick({ target: '<div />' });
-	// 		expect(getIsOpen(content)).toBeFalsy();
-	// 	});
-	// });
+			closedComponent.onBodyClick({ target: '<div />' });
+			expect(getIsOpen(content)).toBeFalsy();
+		});
+	});
 
 	describe('manually toggle dropdown', () => {
 		let closedComponent, closeContentSpy, toggleContentSpy, trigger;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6293,6 +6293,12 @@ react-onclickoutside@^6.5.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.7.0.tgz#997a4d533114c9a0a104913638aa26afc084f75c"
 
+react-portal@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-portal/-/react-portal-3.2.0.tgz#4224e19b2b05d5cbe730a7ba0e34ec7585de0043"
+  dependencies:
+    prop-types "^15.5.8"
+
 react-router-dom@4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-4.2.2.tgz#c8a81df3adc58bba8a76782e946cbd4eae649b8d"


### PR DESCRIPTION
Re Prelim:
- ~Still needs tests to be updated~
- ~Need to test in mup-web~

#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-152

#### Description
Dropdown content needs to be rendered in the document body to avoid issues with `z-index` and `overflow`

#### Screenshots (if applicable)

