### PR TITLE
WC-156: AccordionPanelGroup should re-render if any AccordionPanel props have…

### DIFF
--- a/src/interactive/AccordionPanelGroup.jsx
+++ b/src/interactive/AccordionPanelGroup.jsx
@@ -5,6 +5,14 @@ import cx from 'classnames';
 export const ACCORDIONPANELGROUP_CLASS = 'accordionPanelGroup';
 
 /**
+ * Determines if the passed in value is a primitive type
+ * @param {any} value
+ * @return {boolean} True if value is a primitive type
+ */
+const isPrimitive = value =>
+	['object', 'function'].indexOf(typeof value) === -1;
+
+/**
  * @module AccordionPanelGroup
  */
 class AccordionPanelGroup extends React.Component {
@@ -20,12 +28,54 @@ class AccordionPanelGroup extends React.Component {
 	 */
 	componentWillMount() {
 		// this will be an object in the form [clickId]: isOpen
-		const panelStates = this.accordionPanels.reduce(function(stateObj, panel) {
+		const panelStates = this.getPanelStates();
+		this.setState({ panelStates });
+	}
+
+	/**
+	 * React lifecyle method which provides an opportunity to compare current props
+	 * with incoming props.
+	 * @param {Object} nextProps the next form values the ui will receive
+	 * @return {undefined}
+	 */
+	componentWillReceiveProps(nextProps) {
+		const { accordionPanels: currentPanels } = this.props;
+		const { accordionPanels: nextPanels } = nextProps;
+		let panelPropsHaveChanged = false;
+
+		nextPanels.forEach((panel, index) => {
+			const nextPanelProps = panel.props;
+			const currentPanelProps = currentPanels[index].props;
+
+			Object.keys(nextPanelProps).forEach(key => {
+				// Don't waste time if we already know at least one prop
+				// on any panel has changed
+				if (panelPropsHaveChanged) {
+					return;
+				}
+
+				if (isPrimitive(nextPanelProps[key]) && nextPanelProps[key] !== currentPanelProps[key]) {
+					panelPropsHaveChanged = true;
+				}
+			});
+		});
+
+		if (panelPropsHaveChanged) {
+			this.accordionPanels = nextProps.accordionPanels.map(this.initPanel, this);
+			const panelStates = this.getPanelStates();
+			this.setState({ panelStates });
+		}
+	}
+
+	/**
+	 * Get a mapping of panels and their open/closed state
+	 * @return {object} Panel open state keyed by panel id
+	 */
+	getPanelStates() {
+		return this.accordionPanels.reduce(function(stateObj, panel) {
 			stateObj[panel.props.clickId] = panel.props.isOpen;
 			return stateObj;
 		}, {});
-
-		this.setState({ panelStates });
 	}
 
 	/**

--- a/src/interactive/AccordionPanelGroup.jsx
+++ b/src/interactive/AccordionPanelGroup.jsx
@@ -9,7 +9,7 @@ export const ACCORDIONPANELGROUP_CLASS = 'accordionPanelGroup';
  * @param {any} value
  * @return {boolean} True if value is a primitive type
  */
-const isPrimitive = value =>
+export const isPrimitive = value =>
 	['object', 'function'].indexOf(typeof value) === -1;
 
 /**

--- a/src/interactive/accordionPanelGroup.test.jsx
+++ b/src/interactive/accordionPanelGroup.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 
-import AccordionPanelGroup from './AccordionPanelGroup';
+import AccordionPanelGroup, { isPrimitive } from './AccordionPanelGroup';
 import AccordionPanel from './AccordionPanel';
 
 describe('AccordionPanelGroup', () => {
@@ -57,6 +57,14 @@ describe('AccordionPanelGroup', () => {
 			}
 		/>,
 	];
+
+	describe('isPrimitve', () => {
+		it('returns true when passed a primitive value', () => {
+			const values = [1, 'string', true, () => {}, [], {}];
+			const valueTypes = values.map(x => isPrimitive(x));
+			expect(valueTypes).toEqual([true, true, true, false, false, false]);
+		});
+	});
 
 	describe('AccordionPanelGroup, multiselectable', () => {
 		let accordionPanelGroup;
@@ -115,6 +123,45 @@ describe('AccordionPanelGroup', () => {
 			expect(accordionPanelGroup.state('panelStates')[clickId]).toEqual(
 				!isOpen
 			);
+		});
+
+		it('calls componentWillReceiveProps on AccordionPanel primitive prop changes', () => {
+			const spy = jest.spyOn(
+				AccordionPanelGroup.prototype,
+				'componentWillReceiveProps'
+			);
+
+			const component = shallow(
+				<AccordionPanelGroup accordionPanels={accordionPanelsArr} />
+			);
+
+			expect(component.state('panelStates')['0']).toBe(true);
+			expect(spy).not.toHaveBeenCalled();
+
+			const modifiedAccordionPanelsArr = [ ...accordionPanelsArr ];
+			// Change first panel isOpen prop to false
+			modifiedAccordionPanelsArr[0] = (
+				<AccordionPanel
+					label="First Section"
+					isOpen={false}
+					panelContent={
+						<div className="runningText">
+							<p>
+								Contrary to popular belief, Lorem Ipsum is not simply random text.
+								It has roots in a piece of classical Latin literature from 45 BC,
+								making it over 2000 years old. Richard McClintock, a Latin professor
+								at Hampden-Sydney College in Virginia, looked up one of the more
+								obscure Latin words, consectetur, from a Lorem Ipsum passage, and
+								going through the cites of the word in classical literature,
+								discovered the undoubtable source.
+							</p>
+						</div>
+					}
+				/>
+			);
+
+			component.setProps({ accordionPanels: modifiedAccordionPanelsArr});
+			expect(spy).toHaveBeenCalled();
 		});
 	});
 


### PR DESCRIPTION
… changed

#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-156

#### Description
On the new event edit form, frequently `event` data is available after the page loads and components mount. `AccordionPanelGroup` had no way of updating itself when it received new props. This task fixes that.
