### PR TITLE
use inline-flex instead of flex in no photo avatar

### DIFF
--- a/assets/scss/components/_avatar.scss
+++ b/assets/scss/components/_avatar.scss
@@ -146,7 +146,9 @@ $avatarBg: $C_coolGrayLight;
 }
 
 .avatar--noPhoto {
-	@include valignChildren();
+	@include display(inline-flex);
+	@include align-items(center);
+	@include justify-content(center);
 	position: relative;
 	text-indent: initial;
 	background-color: darken($avatarBg, 6%);
@@ -158,8 +160,9 @@ $avatarBg: $C_coolGrayLight;
 		height: 100%;
 
 		// center the SVG element within the wrapper
-		@include valignChildren();
-		justify-content: center;
+		@include display(inline-flex);
+		@include align-items(center);
+		@include justify-content(center);
 	}
 	svg {
 		// sets SVG size relative to wrapper
@@ -190,7 +193,7 @@ $avatarBg: $C_coolGrayLight;
 }
 
 .avatar--icon {
-	@include display(flex);
+	@include display(inline-flex);
 	@include align-items(center);
 	@include justify-content(center);
 	background: $C_collectionBG;


### PR DESCRIPTION
#### Description
Fixes issue where no photo avatar is displaying `flex` instead of `inline-flex`

#### Before
![screen shot 2017-12-13 at 3 14 04 pm](https://user-images.githubusercontent.com/231252/33960312-5fe481e4-e018-11e7-9995-b12c1e4b8477.png)

#### After
![screen shot 2017-12-13 at 3 14 24 pm](https://user-images.githubusercontent.com/231252/33960317-68b8ee72-e018-11e7-91d3-8d96d421ac6f.png)
