### PR TITLE
rm maxLength dom attribute from textInput

### DIFF
--- a/src/forms/TextInput.jsx
+++ b/src/forms/TextInput.jsx
@@ -93,7 +93,6 @@ const TextInput = (props) => {
 						disabled={disabled}
 						id={id}
 						style={inputStyles}
-						maxLength={parseInt(maxLength) || -1}
 						{...other}
 					/>
 					{iconShape &&

--- a/src/forms/__snapshots__/textInput.test.jsx.snap
+++ b/src/forms/__snapshots__/textInput.test.jsx.snap
@@ -21,7 +21,6 @@ exports[`TextInput renders a required HTML <input> with expected attributes for 
       <input
         className="span--100"
         id="superhero"
-        maxLength={-1}
         name="superhero"
         required={true}
         type="text"


### PR DESCRIPTION
#### Description
The `maxLength` DOM attribute was added to `TextInput` to aid accessibility. We do however, want to allow users to type beyond the max characters for a field in `mup-web`. This branch removes the property in order to revert text inputs to previous behavior.

