### PR TITLE
Wc 158/ie11 text inputs

### DIFF
--- a/src/forms/TextInput.jsx
+++ b/src/forms/TextInput.jsx
@@ -68,6 +68,13 @@ const TextInput = (props) => {
 		paddingLeft: `${paddingSize}px`
 	};
 
+	// WC-158
+	// Only add a `value` prop if it is defined.
+	// Workaround for IE11 support (see ticket)
+	if (value) {
+		other.value = value;
+	}
+
 	return (
 		<div>
 			<div className="inputContainer">
@@ -84,7 +91,6 @@ const TextInput = (props) => {
 				<div style={{position: 'relative'}}>
 					<input type={isSearch ? 'search' : 'text'}
 						name={name}
-						value={value}
 						required={required}
 						placeholder={placeholder}
 						className={classNames.field}

--- a/src/forms/Textarea.jsx
+++ b/src/forms/Textarea.jsx
@@ -129,6 +129,14 @@ class Textarea extends React.Component {
 			maxHeight: maxHeight
 		};
 
+		// WC-158
+		// IE11 does not recognize `-1` as a valid value
+		// for the `maxLength` attribute, so we only
+		// add the prop if `maxLength` is passed.
+		if (maxLength) {
+			other.maxLength = parseInt(maxLength, 10);
+		}
+
 		return (
 			<div>
 				<div className="inputContainer">
@@ -153,7 +161,6 @@ class Textarea extends React.Component {
 						style={{ ...style, ...heightConstraints }}
 						id={id}
 						value={this.state.value}
-						maxLength={parseInt(maxLength) || -1}
 						{...other}
 					/>
 


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-158

#### Description

- `TextInput` `value` prop should only be added to the `input` element if the prop is defined. This works around the wonky IE11 event model.
- `Textarea` should **not** have a `maxLength` prop that defaults to `-1`. IE11 will treat a value of `-1` as `0` for the `maxlength` attribute on a text area, which prevents users from interacting with the input. As a workaround, this branch conditionally sets the `maxLength` prop rather than falling back to `-1` as a default.
