### PR TITLE
Bugfix - vertically align check icon in checkbox

### DIFF
--- a/assets/scss/components/_forms.scss
+++ b/assets/scss/components/_forms.scss
@@ -229,6 +229,10 @@ $C_toggleHighlight: $C_blue;
 	width: 8px;
 }
 
+.checkbox-indicator {
+	height: 100%;
+}
+
 //
 // Select input
 //

--- a/src/forms/Checkbox.jsx
+++ b/src/forms/Checkbox.jsx
@@ -93,7 +93,13 @@ class Checkbox extends React.Component {
 							ref={el => (this.fauxCheckboxEl = el)}
 							className={fauxCheckboxClassNames}
 						>
-							{this.state.checked && <Icon shape="check" size="xs" />}
+							{this.state.checked &&
+								<Icon
+									className="display--flex flex--center checkbox-indicator"
+									shape="check"
+									size="xs"
+								/>
+							}
 						</span>
 					</FlexItem>
 					<FlexItem className="toggleLabel-container">

--- a/src/forms/__snapshots__/checkbox.test.jsx.snap
+++ b/src/forms/__snapshots__/checkbox.test.jsx.snap
@@ -28,6 +28,7 @@ exports[`Checkbox basic renders checked checkbox 1`] = `
         className="display--block align--center fauxToggle fauxToggle--checkbox checked"
       >
         <Icon
+          className="display--flex flex--center checkbox-indicator"
           shape="check"
           size="xs"
         />


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/<XXX-###>

#### Description
Just a small/easy bug Gavin pointed out to me. Not sure when this broke

#### Screenshots (if applicable)
Before:
![image](https://user-images.githubusercontent.com/2313998/34173486-91e9fe94-e4c3-11e7-9f4e-09348e3add31.png)

After:
<img width="171" alt="screen shot 2017-12-19 at 1 49 03 pm" src="https://user-images.githubusercontent.com/2313998/34173493-95b85a20-e4c3-11e7-9517-611c618a8c7d.png">

