### PR TITLE
update editorconfig with max line length matching `mup-web` settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,7 @@ root = true
 # Change these settings to your own preference
 indent_style = tab
 indent_size = 4
+max_line_length = 90
 
 # We recommend you to keep these unchanged
 end_of_line = lf


### PR DESCRIPTION
Brings this repo up to date with `mup-web` editor settings
