### PR TITLE
withMatchMedia: use initialMedia prop if provided in constructor

### DIFF
--- a/src/utils/components/withMatchMedia.jsx
+++ b/src/utils/components/withMatchMedia.jsx
@@ -44,7 +44,7 @@ const withMatchMedia = WrappedComponent => {
 			super(props);
 
 			this.state = {
-				media: {},
+				media: props.initialMedia || {},
 			};
 
 			this.handleMediaChange = this.handleMediaChange.bind(this);


### PR DESCRIPTION
#### Related issues
https://meetup.atlassian.net/browse/MW-2907

#### Description
Related to / supports this PR https://github.com/meetup/meetup-web-platform/pull/423/files
If initialMedia prop is present, set that in the constructor

#### Screenshots (if applicable)

