### PR TITLE
remove initialMedia prop from dom elements

### DIFF
--- a/src/utils/components/withMatchMedia.jsx
+++ b/src/utils/components/withMatchMedia.jsx
@@ -104,7 +104,9 @@ const withMatchMedia = WrappedComponent => {
 		 * @returns {React.element}
 		 */
 		render() {
-			return <WrappedComponent {...this.props} media={this.state.media} />;
+			const props = {...this.props};
+			delete props.initialMedia;
+			return <WrappedComponent {...props} media={this.state.media} />;
 		}
 	}
 

--- a/src/utils/components/withMatchMedia.jsx
+++ b/src/utils/components/withMatchMedia.jsx
@@ -104,8 +104,7 @@ const withMatchMedia = WrappedComponent => {
 		 * @returns {React.element}
 		 */
 		render() {
-			const props = {...this.props};
-			delete props.initialMedia;
+			const { initialMedia, ...props } = this.props; // eslint-disable-line no-unused-vars
 			return <WrappedComponent {...props} media={this.state.media} />;
 		}
 	}


### PR DESCRIPTION
#### Description
Do not pass initialMedia as a prop to the wrapped element. Causes errors in the browser dev console.

#### Screenshots (if applicable)

