### PR TITLE
Negative left margin on autoheight gridlist

### DIFF
--- a/assets/scss/components/_gridList.scss
+++ b/assets/scss/components/_gridList.scss
@@ -96,7 +96,7 @@ Class                                     | Description
 }
 
 .gridList--autoHeight {
-	@include customPropertyValue(margin-left, var(--responsiveSpace), $space);
+	@include customPropertyValue(margin-left, calc(var(--responsiveSpace)* -1), -#{$space});
 
 	> .gridList-item {
 		width: auto;


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/<XXX-###>

#### Description
When we updated to custom properties, left margin was accidentally set to a positive value instead of a negative

#### Screenshots (if applicable)

