### PR TITLE
Allow TextInput value prop pass even if empty string

### DIFF
--- a/src/forms/TextInput.jsx
+++ b/src/forms/TextInput.jsx
@@ -71,7 +71,7 @@ const TextInput = (props) => {
 	// WC-158
 	// Only add a `value` prop if it is defined.
 	// Workaround for IE11 support (see ticket)
-	if (value || value === '') {
+	if (value || /^ *$/.test(value)) {
 		other.value = value;
 	}
 

--- a/src/forms/TextInput.jsx
+++ b/src/forms/TextInput.jsx
@@ -71,7 +71,7 @@ const TextInput = (props) => {
 	// WC-158
 	// Only add a `value` prop if it is defined.
 	// Workaround for IE11 support (see ticket)
-	if (value || /^ *$/.test(value)) {
+	if (value || typeof value === 'string') {
 		other.value = value;
 	}
 

--- a/src/forms/TextInput.jsx
+++ b/src/forms/TextInput.jsx
@@ -71,7 +71,7 @@ const TextInput = (props) => {
 	// WC-158
 	// Only add a `value` prop if it is defined.
 	// Workaround for IE11 support (see ticket)
-	if (value) {
+	if (value || value === '') {
 		other.value = value;
 	}
 


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/<XXX-###>

#### Description
This issue came up with Mike A trying to clear a form input in `mup-web`. Passing an empty string to `value` prevents it from getting passed through because it `value` will return false

#### Screenshots (if applicable)

