### PR TITLE
IE/Edge hscroll adjustment

### DIFF
--- a/assets/scss/components/_hscroll.scss
+++ b/assets/scss/components/_hscroll.scss
@@ -61,7 +61,7 @@ Class                       | Description
 
 .hscroll {
 	-webkit-overflow-scrolling: touch;
-	-ms-overflow-style: -ms-autohiding-scrollbar;
+	-ms-overflow-style: scrollbar;
 	overflow-x: scroll;
 }
 


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-493

#### Description
`-ms-autohiding-scrollbar` overlaps content and sometimes prevents users from being able to scroll. `scrollbar` will _not_ overlap content, and gives expected behavior.
This style change will _always_ show scroll bars on parts of the UI that use the `Hscroll` in IE/Edge, regardless of whether or not the content actually overflows. This can be overridden in app-specific styles by setting `-ms-overflow-style: none;` at the desired breakpoints.

#### Screenshots (if applicable)

