### PR TITLE
Nav Items (MP-351)

### DIFF
--- a/assets/scss/components/_all.scss
+++ b/assets/scss/components/_all.scss
@@ -39,4 +39,5 @@
 @import "toast";
 @import "togglePill";
 @import "toggleSwitch";
+@import "navbar";
 

--- a/assets/scss/components/_navbar.scss
+++ b/assets/scss/components/_navbar.scss
@@ -1,0 +1,141 @@
+@mixin _labelLarge() {
+	font-size: $font-size-small;
+	max-width: 20vw; // allow more space for labels @ medium and up
+}
+
+#globalNav {
+	@include standardBorder('bottom');
+}
+
+.header {
+	justify-content: space-between;
+
+	@include atMediaUp(medium) {
+		justify-content: space-around;
+	}
+}
+
+$zindex--aboveFloatingContent: map-get($zindex-map, 'floating-content') + 1;
+.header--aboveFloatingContent {
+	position: relative;
+	z-index: $zindex--aboveFloatingContent+2;
+}
+
+.header-navItem {
+	@include color-svg($C_textSecondary);
+	color: $C_textPrimary;
+	text-align: center;
+	position: relative;
+	padding-left: 0;
+}
+
+// use negative margin to pull in some
+// of the header height and center the logos
+.header-logo {
+	margin-bottom: -6px;
+}
+.header-logo--swarm {
+	margin-top: -8px;
+}
+
+@include atMediaUp(medium) {
+	.header-navItem {
+		@include customPropertyValue(padding-left, calc(var(--responsiveSpace)), $space);
+	}
+}
+
+.header-navItem--unauthenticated {
+
+	// because login/signup links do not
+	// behave like tabs at mobile sizes,
+	// we have to set an explicit height
+	height: $space-3;
+	@include atMediaUp(medium) {
+		height: auto;
+	}
+
+	.navItem-label {
+		@include _labelLarge();
+	}
+}
+
+$maxLabelSize: 12;
+$minLabelSize: 9;
+$maxScalingBP: $breakpoint-m/1px;
+.navItem-label {
+	display: block;
+	color: $C_textSecondary;
+
+	// Using "CSS locks" technique to
+	// let wider phones get bigger type
+	// https://fvsch.com/code/css-locks/
+	font-size: $minLabelSize;
+	font-size: calc( #{$minLabelSize}px + (#{$maxLabelSize} - #{$minLabelSize}) * (100vw / #{$maxScalingBP} ));
+
+	// hack to fix vert. alignment of Login and Sign up on FF mobile
+	line-height: 2;
+	margin-top: $space-quarter;
+
+	// set max width for i18n wrapping of
+	// mobile nav
+	// (5 items, with some room for padding)
+	max-width: 19vw;
+
+	@include atMediaUp(medium) {
+		margin-top: 0;
+		display: inline-block;
+		@include _labelLarge();
+
+		&:hover,
+		&:active {
+			color: $C_accent;
+		}
+	}
+}
+
+
+.header-navItemLink {
+	align-items: center;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	margin: 0;
+	height: 100%;
+
+	@include atMediaUp(medium) {
+		display: inline;
+		height: auto;
+	}
+}
+.header-navItemLink--create {
+	@include standardBorder('right');
+	padding-right: $space;
+
+	.navItem-label {
+		color: $C_accent !important;
+	}
+}
+
+.counterBadge {
+	$_dotSize: $space-half;
+	background-color: $C_teal;
+	border-radius: 999px;
+	width: $_dotSize;
+	height: $_dotSize;
+	position: absolute;
+	top: -$_dotSize/2;
+	right: 27%;
+	border: 3px solid $C_white;
+
+	.header-navItem--messages & {
+		right: 17%;
+	}
+
+	@include atMediaUp(medium) {
+		@include transform(translate(-2px, -6px));
+		display: inline-block;
+		margin-left: $space-quarter;
+		position: static;
+		border-width: 0;
+	}
+}

--- a/assets/scss/components/_navbar.scss
+++ b/assets/scss/components/_navbar.scss
@@ -45,7 +45,6 @@ $zindex--aboveFloatingContent: map-get($zindex-map, 'floating-content') + 1;
 }
 
 .header-navItem--unauthenticated {
-
 	// because login/signup links do not
 	// behave like tabs at mobile sizes,
 	// we have to set an explicit height
@@ -70,7 +69,12 @@ $maxScalingBP: $breakpoint-m/1px;
 	// let wider phones get bigger type
 	// https://fvsch.com/code/css-locks/
 	font-size: $minLabelSize;
-	font-size: calc( #{$minLabelSize}px + (#{$maxLabelSize} - #{$minLabelSize}) * (100vw / #{$maxScalingBP} ));
+	font-size: calc(
+		#{$minLabelSize}px + (#{$maxLabelSize} - #{$minLabelSize}) *
+			(
+				100vw / #{$maxScalingBP}
+			)
+	);
 
 	// hack to fix vert. alignment of Login and Sign up on FF mobile
 	line-height: 2;
@@ -92,7 +96,6 @@ $maxScalingBP: $breakpoint-m/1px;
 		}
 	}
 }
-
 
 .header-navItemLink {
 	align-items: center;

--- a/src/navigation/NavBar.jsx
+++ b/src/navigation/NavBar.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Icon from '../media/Icon';
+import NavItem from './NavItem';
+
+export const NavBar = () => (
+	<NavItem
+		key={0}
+		shrink
+		linkTo="meetup.com"
+		label="Explore"
+		className="explore"
+		hasUpdates
+		icon={<Icon shape="search" size="s" className="atMedium_display--none" />}
+	/>
+);
+
+export default NavBar;

--- a/src/navigation/NavItem.jsx
+++ b/src/navigation/NavItem.jsx
@@ -1,0 +1,130 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import cx from 'classnames';
+
+import Button from '../forms/Button';
+import Dropdown from '../interactive/Dropdown';
+import FlexItem from '../layout/FlexItem';
+
+const NAV_ITEM_CLASS = 'navItemLink';
+
+
+export const ActionItem = ({ label, action, labelClassNames }) => (
+	<Button reset className={cx(NAV_ITEM_CLASS, 'text--secondary')} onClick={action}>
+		<span className={labelClassNames}>{label}</span>
+	</Button>
+);
+export const LinkItem = ({ linkTo, navItemContent, className }) => (
+	<a href={linkTo} className={cx(NAV_ITEM_CLASS, className)}>
+		{navItemContent}
+	</a>
+);
+export const ContentLoaderItem = ({ navItemContent, onClickAction }) => (
+	<Button aria-haspopup reset className={NAV_ITEM_CLASS} onClick={onClickAction}>
+		{navItemContent}
+	</Button>
+);
+export const DropdownItem = ({ navItemContent, dropdownContent }) => (
+	<Dropdown
+		noPortal
+		align="right"
+		maxWidth="544px"
+		minWidth="384px"
+		trigger={navItemContent}
+		content={dropdownContent}
+	/>
+);
+
+/**
+ * NavItem
+ *
+ * Renders a dropdown if `dropdownContent` prop is passed,
+ * otherwise relies on a `linkTo` prop to render a link item.
+ *
+ * @param {Object} props - React element props
+ * @returns {React.element} - navigation segment of header
+ */
+export const NavItem = props => {
+	const {
+		linkTo,
+		label,
+		shrink,
+		className,
+		labelClassName,
+		linkClassName,
+		dropdownContent,
+		icon,
+		hasUpdates,
+		onClickAction,
+		onAction,
+		...other
+	} = props;
+
+	const classNames = {
+		navItem: cx('navItem', className),
+		label: cx('navItem-label', labelClassName),
+	};
+
+	const navItemContent = (
+		<div>
+			{icon}
+			{label && <span className={classNames.label}>{label}</span>}
+			{hasUpdates && (
+				<span className="counterBadge">
+					<span className="visibility--a11yHide">
+						Updates
+					</span>
+				</span>
+			)}
+		</div>
+	);
+
+	const trigger = onClickAction ? (
+		<ContentLoaderItem
+			onClickAction={onClickAction}
+			navItemContent={navItemContent}
+		/>
+	) : (
+			navItemContent
+		);
+
+	return (
+		<FlexItem shrink={shrink} className={classNames.navItem} {...other}>
+			{linkTo && (
+				<LinkItem
+					className={linkClassName}
+					linkTo={linkTo}
+					navItemContent={navItemContent}
+				/>
+			)}
+			{dropdownContent && (
+				<DropdownItem
+					dropdownContent={dropdownContent}
+					navItemContent={trigger}
+				/>
+			)}
+			{onAction && (
+				<ActionItem
+					label={label}
+					action={onAction}
+					labelClassNames={classNames.label}
+				/>
+			)}
+		</FlexItem>
+	);
+};
+
+NavItem.propTypes = {
+	linkTo: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+	dropdownContent: PropTypes.oneOfType([PropTypes.element, PropTypes.bool]),
+	onClickAction: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
+	label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+	shrink: PropTypes.bool,
+	className: PropTypes.string,
+	labelClassName: PropTypes.string,
+	linkClassName: PropTypes.string,
+	icon: PropTypes.element,
+	hasUpdates: PropTypes.bool,
+};
+
+export default NavItem;

--- a/src/navigation/NavItems.test.jsx
+++ b/src/navigation/NavItems.test.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { NavItem, LinkItem } from './NavItem';
+
+const MOCK_PROPS = {
+	linkTo: '/zombocom/',
+	label: <p>Anything is possible</p>,
+	dropdownContent: <p>I am in a dropdown</p>,
+};
+const renderComponent = props => shallow(<NavItem {...props} />);
+
+describe('NavItem', () => {
+	const navItemBasic = renderComponent({
+		linkTo: MOCK_PROPS.linkTo,
+	});
+	const navItemWithUpdates = renderComponent({
+		linkTo: MOCK_PROPS.linkTo,
+		hasUpdates: true,
+	});
+
+	const navItemWithLabel = renderComponent({
+		linkTo: MOCK_PROPS.linkTo,
+		label: MOCK_PROPS.label,
+	});
+
+	const navItemWithDropdown = renderComponent({
+		label: MOCK_PROPS.label,
+		dropdownContent: MOCK_PROPS.dropdownContent,
+	});
+
+	const navItemWithAction = renderComponent({
+		label: MOCK_PROPS.label,
+		onAction: jest.fn(),
+	});
+
+	it('does *not* render count bubble, label, or dropdown if no count prop is provided', () => {
+		expect(navItemBasic).toMatchSnapshot();
+	});
+
+	it('renders count bubble when a count is provided', () => {
+		expect(navItemWithUpdates).toMatchSnapshot();
+	});
+
+	it('renders a label when provided', () => {
+		expect(navItemWithLabel).toMatchSnapshot();
+	});
+
+	it('link component renders correct url from prop', () => {
+		expect(navItemBasic.find(LinkItem)).toMatchSnapshot();
+	});
+
+	it('renders a dropdown when `dropdownContent` is passed as a prop', () => {
+		expect(navItemWithDropdown).toMatchSnapshot();
+	});
+
+	it('renders an ActionItem when `onAction` is passed as a prop', () => {
+		expect(navItemWithAction).toMatchSnapshot();
+	});
+});

--- a/src/navigation/__snapshots__/NavItems.test.jsx.snap
+++ b/src/navigation/__snapshots__/NavItems.test.jsx.snap
@@ -1,0 +1,112 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NavItem does *not* render count bubble, label, or dropdown if no count prop is provided 1`] = `
+<FlexItem
+  className="navItem"
+>
+  <LinkItem
+    linkTo="/zombocom/"
+    navItemContent={
+      <div>
+        
+      </div>
+    }
+  />
+</FlexItem>
+`;
+
+exports[`NavItem link component renders correct url from prop 1`] = `
+<LinkItem
+  linkTo="/zombocom/"
+  navItemContent={
+    <div>
+      
+    </div>
+  }
+/>
+`;
+
+exports[`NavItem renders a dropdown when \`dropdownContent\` is passed as a prop 1`] = `
+<FlexItem
+  className="navItem"
+>
+  <DropdownItem
+    dropdownContent={
+      <p>
+        I am in a dropdown
+      </p>
+    }
+    navItemContent={
+      <div>
+        <span
+          className="navItem-label"
+        >
+          <p>
+            Anything is possible
+          </p>
+        </span>
+      </div>
+    }
+  />
+</FlexItem>
+`;
+
+exports[`NavItem renders a label when provided 1`] = `
+<FlexItem
+  className="navItem"
+>
+  <LinkItem
+    linkTo="/zombocom/"
+    navItemContent={
+      <div>
+        <span
+          className="navItem-label"
+        >
+          <p>
+            Anything is possible
+          </p>
+        </span>
+      </div>
+    }
+  />
+</FlexItem>
+`;
+
+exports[`NavItem renders an ActionItem when \`onAction\` is passed as a prop 1`] = `
+<FlexItem
+  className="navItem"
+>
+  <ActionItem
+    action={[Function]}
+    label={
+      <p>
+        Anything is possible
+      </p>
+    }
+    labelClassNames="navItem-label"
+  />
+</FlexItem>
+`;
+
+exports[`NavItem renders count bubble when a count is provided 1`] = `
+<FlexItem
+  className="navItem"
+>
+  <LinkItem
+    linkTo="/zombocom/"
+    navItemContent={
+      <div>
+        <span
+          className="counterBadge"
+        >
+          <span
+            className="visibility--a11yHide"
+          >
+            Updates
+          </span>
+        </span>
+      </div>
+    }
+  />
+</FlexItem>
+`;

--- a/src/navigation/navbar.story.jsx
+++ b/src/navigation/navbar.story.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import {
+	decorateWithLocale,
+	decorateWithInfo,
+} from '../utils/decorators';
+
+import NavBar from './NavBar';
+
+storiesOf('NavBar', module)
+	.addDecorator(decorateWithLocale)
+	.addDecorator(decorateWithInfo)
+	.add('Default', () => (
+		<NavBar />
+	)
+	);


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/MP-351

#### Description
Since we want to unify the navigation bar across all of web, create the navigation bar in Meetup-Web Components for easy implementations in any web repo.
Part 1: Create a component to create Navigation Items

DoD:
* Create component and story displaying use
* Nav Item can fulfill pro-web and mup-web's current design

#### Comments
I just copied over mup-web's navItem's component, tests, and styling into meetup-web-components: 
* NavItems: 
https://github.com/meetup/mup-web/blob/master/src/components/chrome/header/HeaderNavItem.jsx
* NavItem Tests:
https://github.com/meetup/mup-web/blob/master/src/components/chrome/header/headerNavItem.test.jsx
* SCSS for NavItems: 
https://github.com/meetup/mup-web/blob/master/src/assets/scss/shared/chrome/_header.scss

The only thing that is left out of these files was Internationalization. This will be addressed in a later PR. The NavBar story and component file was created to test if the NavItem was working as expected and will be built out further in following tasks.
