### PR TITLE
remove 0 height for open accordion panels

### DIFF
--- a/src/interactive/AccordionPanel.jsx
+++ b/src/interactive/AccordionPanel.jsx
@@ -31,6 +31,7 @@ class AccordionPanel extends React.Component {
 
 		if (!isOpen || !contentEl) return style;
 
+		delete style.height; // allow content to expand the panel when open
 		style.minHeight = `${contentEl.getBoundingClientRect().height}px`;
 		return style;
 	}


### PR DESCRIPTION
#### Related issues
Follows up on: https://meetup.atlassian.net/browse/WC-179

#### Description
Allows `AccordionPanel` content to expand in height beyond the `min-height` originally set in `render()`.

