### PR TITLE
Fix AccordionPanel height animation jank

### DIFF
--- a/assets/scss/components/_accordion.scss
+++ b/assets/scss/components/_accordion.scss
@@ -9,12 +9,11 @@
 
 .accordionPanel-animator {
 	overflow: hidden;
-	transition: min-height $duration--medium $easing--standard;
-	will-change: height, min-height;
+	transition: height $duration--medium $easing--standard;
+	will-change: height;
 }
 
 .accordionPanel-animator--collapse {
-	height: 0;
 	padding-bottom: 0 !important;
 	visibility: hidden;
 }

--- a/src/interactive/AccordionPanel.jsx
+++ b/src/interactive/AccordionPanel.jsx
@@ -19,6 +19,11 @@ class AccordionPanel extends React.Component {
 		super(props);
 		this._handleToggle = this._handleToggle.bind(this);
 		this.onToggleClick = this.onToggleClick.bind(this);
+		this.onTransitionEnd = this.onTransitionEnd.bind(this);
+
+		this.state = {
+			height: '0px'
+		};
 	}
 
 	/**
@@ -27,12 +32,17 @@ class AccordionPanel extends React.Component {
 	 * @returns {Object} inline styles
 	 */
 	getPanelStyle(isOpen, contentEl) {
-		const style = { height: '0px', minHeight: '0px' };
+		const style = { height: '0px' };
 
-		if (!isOpen || !contentEl) return style;
+		// set height to 0
+		if (!isOpen || !contentEl) {
+			// console.log('getPanelStyle - set height to 0px');
+			return style;
+		}
 
-		delete style.height; // allow content to expand the panel when open
-		style.minHeight = `${contentEl.getBoundingClientRect().height}px`;
+		// set height to {n}px
+		// console.log(`getPanelStyle - set height to ${contentEl.getBoundingClientRect().height}px`);
+		style.height = `${contentEl.getBoundingClientRect().height}px`;
 		return style;
 	}
 
@@ -47,12 +57,26 @@ class AccordionPanel extends React.Component {
 		e.preventDefault();
 
 		const isToggledOpen = !this.props.isOpen;
+
+		this.setState(()=>
+			this.getPanelStyle(!isToggledOpen, this.contentEl),
+			() => {
+				console.log(`_handleToggle - set height to ${this.contentEl.getBoundingClientRect().height}px`);
+
+				this.setState(()=>
+					this.getPanelStyle(isToggledOpen, this.contentEl)
+					// console.log(`_handleToggle - set height to 0px`)
+				);
+
+			}
+		);
 		this.props.setClickedPanel && this.props.setClickedPanel(this.props.clickId, isToggledOpen);
 		this.props.onClickCallback && this.props.onClickCallback(e, isToggledOpen);
 	}
 
 	onToggleClick(e){
 		e.preventDefault();
+
 		this.props.onToggleClick ? this.props.onToggleClick(e) : this._handleToggle(e);
 	}
 
@@ -76,6 +100,14 @@ class AccordionPanel extends React.Component {
 		return this.props.isOpen && indicatorIconActive ?
 			indicatorIconActive :
 			indicatorIcon;
+	}
+
+	onTransitionEnd() {
+		if (this.props.isOpen) {
+			this.setState(()=>({
+				height: 'auto'
+			}));
+		}
 	}
 
 	render() {
@@ -146,7 +178,8 @@ class AccordionPanel extends React.Component {
 						aria-labelledby={`label-${ariaId}`}
 						aria-hidden={!isOpen}
 						className={classNames.content}
-						style={this.getPanelStyle(isOpen, this.contentEl)}
+						style={{height: this.state.height}}
+						onTransitionEnd={this.onTransitionEnd}
 					>
 						<div
 							className='accordionPanel-content'

--- a/src/interactive/AccordionPanel.jsx
+++ b/src/interactive/AccordionPanel.jsx
@@ -56,22 +56,28 @@ class AccordionPanel extends React.Component {
 	_handleToggle(e){
 		e.preventDefault();
 
-		const isToggledOpen = !this.props.isOpen;
+		const {
+			isOpen,
+			setClickedPanel,
+			onClickCallback
+		} = this.props;
 
 		this.setState(()=>
-			this.getPanelStyle(!isToggledOpen, this.contentEl),
+			this.getPanelStyle(isOpen, this.contentEl),
 			() => {
 				console.log(`_handleToggle - set height to ${this.contentEl.getBoundingClientRect().height}px`);
 
-				this.setState(()=>
-					this.getPanelStyle(isToggledOpen, this.contentEl)
-					// console.log(`_handleToggle - set height to 0px`)
-				);
+				setTimeout(() => {
+					this.setState(()=>
+						this.getPanelStyle(!isOpen, this.contentEl),
+						console.log(`_handleToggle - set height to 0px`)
+					);
+				}, 1);
 
 			}
 		);
-		this.props.setClickedPanel && this.props.setClickedPanel(this.props.clickId, isToggledOpen);
-		this.props.onClickCallback && this.props.onClickCallback(e, isToggledOpen);
+		setClickedPanel && setClickedPanel(this.props.clickId, !isOpen);
+		onClickCallback && onClickCallback(e, !isOpen);
 	}
 
 	onToggleClick(e){
@@ -104,6 +110,7 @@ class AccordionPanel extends React.Component {
 
 	onTransitionEnd() {
 		if (this.props.isOpen) {
+			console.log('onTransitionEnd setting height auto');
 			this.setState(()=>({
 				height: 'auto'
 			}));

--- a/src/interactive/__snapshots__/accordionPanel.test.jsx.snap
+++ b/src/interactive/__snapshots__/accordionPanel.test.jsx.snap
@@ -22,7 +22,13 @@ exports[`AccordionPanel Panel basic behavior exists and renders with mock props 
       aria-hidden={true}
       aria-labelledby="label-firstsection"
       className="accordionPanel-animator accordionPanel-animator--collapse"
+      onTransitionEnd={[Function]}
       role="tabpanel"
+      style={
+        Object {
+          "height": "0px",
+        }
+      }
     >
       <div
         className="accordionPanel-content"
@@ -72,7 +78,13 @@ exports[`AccordionPanel Panel with custom icon exists and renders a custom icon 
       aria-hidden={true}
       aria-labelledby="label-firstsection"
       className="accordionPanel-animator accordionPanel-animator--collapse"
+      onTransitionEnd={[Function]}
       role="tabpanel"
+      style={
+        Object {
+          "height": "0px",
+        }
+      }
     >
       <div
         className="accordionPanel-content"
@@ -144,15 +156,25 @@ exports[`AccordionPanel Panel with right aligned icon exists and renders icon le
             aria-hidden={true}
             aria-labelledby="label-firstsection"
             className="accordionPanel-animator accordionPanel-animator--collapse"
+            onTransitionEnd={[Function]}
             role="tabpanel"
-            style={undefined}
+            style={
+              Object {
+                "height": "0px",
+              }
+            }
           >
             <div
               aria-hidden={true}
               aria-labelledby="label-firstsection"
               className="chunk accordionPanel-animator accordionPanel-animator--collapse"
+              onTransitionEnd={[Function]}
               role="tabpanel"
-              style={undefined}
+              style={
+                Object {
+                  "height": "0px",
+                }
+              }
             >
               <div
                 className="accordionPanel-content"
@@ -252,15 +274,25 @@ exports[`AccordionPanel Panel with toggle switch exists and renders a toggle swi
             aria-hidden={true}
             aria-labelledby="label-firstsection"
             className="accordionPanel-animator accordionPanel-animator--collapse"
+            onTransitionEnd={[Function]}
             role="tabpanel"
-            style={undefined}
+            style={
+              Object {
+                "height": "0px",
+              }
+            }
           >
             <div
               aria-hidden={true}
               aria-labelledby="label-firstsection"
               className="chunk accordionPanel-animator accordionPanel-animator--collapse"
+              onTransitionEnd={[Function]}
               role="tabpanel"
-              style={undefined}
+              style={
+                Object {
+                  "height": "0px",
+                }
+              }
             >
               <div
                 className="accordionPanel-content"

--- a/src/interactive/__snapshots__/accordionPanelGroup.test.jsx.snap
+++ b/src/interactive/__snapshots__/accordionPanelGroup.test.jsx.snap
@@ -131,15 +131,25 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable gives panels a
                   aria-hidden={false}
                   aria-labelledby="label-firstsection"
                   className="accordionPanel-animator"
+                  onTransitionEnd={[Function]}
                   role="tabpanel"
-                  style={undefined}
+                  style={
+                    Object {
+                      "height": "0px",
+                    }
+                  }
                 >
                   <div
                     aria-hidden={false}
                     aria-labelledby="label-firstsection"
                     className="chunk accordionPanel-animator"
+                    onTransitionEnd={[Function]}
                     role="tabpanel"
-                    style={undefined}
+                    style={
+                      Object {
+                        "height": "0px",
+                      }
+                    }
                   >
                     <div
                       className="accordionPanel-content"
@@ -260,15 +270,25 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable gives panels a
                   aria-hidden={true}
                   aria-labelledby="label-nextsection"
                   className="accordionPanel-animator accordionPanel-animator--collapse"
+                  onTransitionEnd={[Function]}
                   role="tabpanel"
-                  style={undefined}
+                  style={
+                    Object {
+                      "height": "0px",
+                    }
+                  }
                 >
                   <div
                     aria-hidden={true}
                     aria-labelledby="label-nextsection"
                     className="chunk accordionPanel-animator accordionPanel-animator--collapse"
+                    onTransitionEnd={[Function]}
                     role="tabpanel"
-                    style={undefined}
+                    style={
+                      Object {
+                        "height": "0px",
+                      }
+                    }
                   >
                     <div
                       className="accordionPanel-content"
@@ -389,15 +409,25 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable gives panels a
                   aria-hidden={true}
                   aria-labelledby="label-thirdsection"
                   className="accordionPanel-animator accordionPanel-animator--collapse"
+                  onTransitionEnd={[Function]}
                   role="tabpanel"
-                  style={undefined}
+                  style={
+                    Object {
+                      "height": "0px",
+                    }
+                  }
                 >
                   <div
                     aria-hidden={true}
                     aria-labelledby="label-thirdsection"
                     className="chunk accordionPanel-animator accordionPanel-animator--collapse"
+                    onTransitionEnd={[Function]}
                     role="tabpanel"
-                    style={undefined}
+                    style={
+                      Object {
+                        "height": "0px",
+                      }
+                    }
                   >
                     <div
                       className="accordionPanel-content"
@@ -586,15 +616,25 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable renders panels
                   aria-hidden={false}
                   aria-labelledby="label-firstsection"
                   className="accordionPanel-animator"
+                  onTransitionEnd={[Function]}
                   role="tabpanel"
-                  style={undefined}
+                  style={
+                    Object {
+                      "height": "0px",
+                    }
+                  }
                 >
                   <div
                     aria-hidden={false}
                     aria-labelledby="label-firstsection"
                     className="chunk accordionPanel-animator"
+                    onTransitionEnd={[Function]}
                     role="tabpanel"
-                    style={undefined}
+                    style={
+                      Object {
+                        "height": "0px",
+                      }
+                    }
                   >
                     <div
                       className="accordionPanel-content"
@@ -715,15 +755,25 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable renders panels
                   aria-hidden={true}
                   aria-labelledby="label-nextsection"
                   className="accordionPanel-animator accordionPanel-animator--collapse"
+                  onTransitionEnd={[Function]}
                   role="tabpanel"
-                  style={undefined}
+                  style={
+                    Object {
+                      "height": "0px",
+                    }
+                  }
                 >
                   <div
                     aria-hidden={true}
                     aria-labelledby="label-nextsection"
                     className="chunk accordionPanel-animator accordionPanel-animator--collapse"
+                    onTransitionEnd={[Function]}
                     role="tabpanel"
-                    style={undefined}
+                    style={
+                      Object {
+                        "height": "0px",
+                      }
+                    }
                   >
                     <div
                       className="accordionPanel-content"
@@ -844,15 +894,25 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable renders panels
                   aria-hidden={true}
                   aria-labelledby="label-thirdsection"
                   className="accordionPanel-animator accordionPanel-animator--collapse"
+                  onTransitionEnd={[Function]}
                   role="tabpanel"
-                  style={undefined}
+                  style={
+                    Object {
+                      "height": "0px",
+                    }
+                  }
                 >
                   <div
                     aria-hidden={true}
                     aria-labelledby="label-thirdsection"
                     className="chunk accordionPanel-animator accordionPanel-animator--collapse"
+                    onTransitionEnd={[Function]}
                     role="tabpanel"
-                    style={undefined}
+                    style={
+                      Object {
+                        "height": "0px",
+                      }
+                    }
                   >
                     <div
                       className="accordionPanel-content"


### PR DESCRIPTION
Re Prelim tag:
* Using `setTimeout` in a `setState()` feels wrong
* Tests are failing because of the `setTimeout`

#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-182

#### Description
In master, `AccordionPanel` height abruptly opens and transitions closed. We want it to always transition between opened and closed

#### Screenshots (if applicable)

