### PR TITLE
Fix tabbing on components using withToggleControl

### DIFF
--- a/src/forms/TogglePill.jsx
+++ b/src/forms/TogglePill.jsx
@@ -95,6 +95,7 @@ class TogglePill extends React.Component {
 					value={value}
 					checked={isActive}
 					onChange={this.onChange}
+					tabIndex={-1}
 					{...other} />
 				<label
 					className={labelClassNames}

--- a/src/forms/ToggleSwitch.jsx
+++ b/src/forms/ToggleSwitch.jsx
@@ -94,6 +94,7 @@ class ToggleSwitch extends React.Component {
 					className={classNames.toggleSwitch}
 					aria-labelledby={labelId}
 					aria-checked={isActive}
+					tabIndex={-1}
 					role="switch"
 				>
 					<span className={classNames.knob}>

--- a/src/forms/__snapshots__/togglePill.test.jsx.snap
+++ b/src/forms/__snapshots__/togglePill.test.jsx.snap
@@ -35,6 +35,7 @@ exports[`TogglePill renders a component with expected attributes 1`] = `
           id="hikingCategory"
           name="meetupCategories"
           onChange={[Function]}
+          tabIndex={-1}
           type="checkbox"
           value="hiking"
         />

--- a/src/interactive/__snapshots__/accordionPanel.test.jsx.snap
+++ b/src/interactive/__snapshots__/accordionPanel.test.jsx.snap
@@ -319,6 +319,7 @@ exports[`AccordionPanel Panel with toggle switch exists and renders a toggle swi
                     onClick={[Function]}
                     reset={true}
                     role="switch"
+                    tabIndex={-1}
                   >
                     <button
                       aria-checked={false}
@@ -327,6 +328,7 @@ exports[`AccordionPanel Panel with toggle switch exists and renders a toggle swi
                       disabled={false}
                       onClick={[Function]}
                       role="switch"
+                      tabIndex={-1}
                     >
                       <span
                         className="toggleSwitch-knob flex flex--center flex--alignCenter"


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/MG-313

#### Description
Before this, tab focus was moving from the `<button>` provided by `withToggleControl` into a nested `<input>` instead of moving to the next element

#### Screenshots (if applicable)

