### PR TITLE
Add disabled classname to <Button>

### DIFF
--- a/src/forms/Button.jsx
+++ b/src/forms/Button.jsx
@@ -28,6 +28,7 @@ class Button extends React.PureComponent {
 			small,
 			bordered,
 			hasHoverShadow,
+			disabled,
 			...other
 		} = this.props;
 
@@ -41,7 +42,8 @@ class Button extends React.PureComponent {
 					'button--reset': reset,
 					'button--bordered': bordered,
 					'button--hasHoverShadow': hasHoverShadow,
-					'button--neutral': neutral
+					'button--neutral': neutral,
+					'button--disabled': disabled
 				},
 				className
 			),

--- a/src/interactive/__snapshots__/accordionPanel.test.jsx.snap
+++ b/src/interactive/__snapshots__/accordionPanel.test.jsx.snap
@@ -325,7 +325,6 @@ exports[`AccordionPanel Panel with toggle switch exists and renders a toggle swi
                       aria-checked={false}
                       aria-labelledby="firstsection-label"
                       className="button button--reset toggleSwitch"
-                      disabled={false}
                       onClick={[Function]}
                       role="switch"
                       tabIndex={-1}


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-192

#### Description
Render a disabled class when disabled prop is passed to <Button>

#### Screenshots (if applicable)

