### PR TITLE
Fix non-multiselectable AccordionPanel bug

### DIFF
--- a/src/interactive/AccordionPanel.jsx
+++ b/src/interactive/AccordionPanel.jsx
@@ -63,20 +63,6 @@ class AccordionPanel extends React.Component {
 			onClickCallback
 		} = this.props;
 
-		// this.setState(()=>
-		// 	this.getPanelStyle(isOpen, this.contentEl),
-		// 	() => {
-		// 		// console.log('first setState being hit');
-		// 		setTimeout(() => {
-		// 			this.setState(()=>
-		// 				this.getPanelStyle(!isOpen, this.contentEl),
-		// 				() => {
-		// 					// console.log('second setState being hit');
-		// 				}
-		// 			);
-		// 		}, 1);
-		// 	}
-		// );
 		setClickedPanel && setClickedPanel(this.props.clickId, !isOpen, this.getPanelStyle(!isOpen, this.contentEl)); // this.getPanelStyle(!isOpen, this.contentEl)
 		onClickCallback && onClickCallback(e, !isOpen);
 	}
@@ -95,6 +81,10 @@ class AccordionPanel extends React.Component {
 		this.forceUpdate();
 	}
 
+	/**
+	 * @description set height state when the panel receives a change
+	 * @returns {undefined}
+	 */
 	componentWillReceiveProps(nextProps) {
 		if (nextProps.isOpen !== this.props.isOpen) {
 			this.setState(()=>

--- a/src/interactive/AccordionPanel.jsx
+++ b/src/interactive/AccordionPanel.jsx
@@ -34,9 +34,6 @@ class AccordionPanel extends React.Component {
 	getPanelStyle(isOpen, contentEl) {
 		const style = { height: '0px' };
 
-		// console.log(`isOpen: ${isOpen}`);
-		// console.log(`contentEl: ${contentEl}`);
-
 		// set height to 0
 		if (!isOpen || !contentEl) {
 			return style;
@@ -63,7 +60,7 @@ class AccordionPanel extends React.Component {
 			onClickCallback
 		} = this.props;
 
-		setClickedPanel && setClickedPanel(this.props.clickId, !isOpen, this.getPanelStyle(!isOpen, this.contentEl)); // this.getPanelStyle(!isOpen, this.contentEl)
+		setClickedPanel && setClickedPanel(this.props.clickId, !isOpen, this.getPanelStyle(!isOpen, this.contentEl));
 		onClickCallback && onClickCallback(e, !isOpen);
 	}
 

--- a/src/interactive/AccordionPanel.jsx
+++ b/src/interactive/AccordionPanel.jsx
@@ -22,7 +22,7 @@ class AccordionPanel extends React.Component {
 		this.onTransitionEnd = this.onTransitionEnd.bind(this);
 
 		this.state = {
-			height: '0px'
+			height: props.isOpen ? 'auto' : '0px'
 		};
 	}
 
@@ -33,6 +33,9 @@ class AccordionPanel extends React.Component {
 	 */
 	getPanelStyle(isOpen, contentEl) {
 		const style = { height: '0px' };
+
+		// console.log(`isOpen: ${isOpen}`);
+		// console.log(`contentEl: ${contentEl}`);
 
 		// set height to 0
 		if (!isOpen || !contentEl) {
@@ -60,17 +63,21 @@ class AccordionPanel extends React.Component {
 			onClickCallback
 		} = this.props;
 
-		this.setState(()=>
-			this.getPanelStyle(isOpen, this.contentEl),
-			() => {
-				setTimeout(() => {
-					this.setState(()=>
-						this.getPanelStyle(!isOpen, this.contentEl)
-					);
-				}, 1);
-			}
-		);
-		setClickedPanel && setClickedPanel(this.props.clickId, !isOpen);
+		// this.setState(()=>
+		// 	this.getPanelStyle(isOpen, this.contentEl),
+		// 	() => {
+		// 		// console.log('first setState being hit');
+		// 		setTimeout(() => {
+		// 			this.setState(()=>
+		// 				this.getPanelStyle(!isOpen, this.contentEl),
+		// 				() => {
+		// 					// console.log('second setState being hit');
+		// 				}
+		// 			);
+		// 		}, 1);
+		// 	}
+		// );
+		setClickedPanel && setClickedPanel(this.props.clickId, !isOpen, this.getPanelStyle(!isOpen, this.contentEl)); // this.getPanelStyle(!isOpen, this.contentEl)
 		onClickCallback && onClickCallback(e, !isOpen);
 	}
 
@@ -86,6 +93,21 @@ class AccordionPanel extends React.Component {
 	 */
 	componentDidMount() {
 		this.forceUpdate();
+	}
+
+	componentWillReceiveProps(nextProps) {
+		if (nextProps.isOpen !== this.props.isOpen) {
+			this.setState(()=>
+				this.getPanelStyle(!nextProps.isOpen, this.contentEl),
+				() => {
+					setTimeout(() => {
+						this.setState(()=>
+							this.getPanelStyle(nextProps.isOpen, this.contentEl)
+						);
+					}, 1);
+				}
+			);
+		}
 	}
 
 	/**

--- a/src/interactive/__snapshots__/accordionPanelGroup.test.jsx.snap
+++ b/src/interactive/__snapshots__/accordionPanelGroup.test.jsx.snap
@@ -135,7 +135,7 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable gives panels a
                   role="tabpanel"
                   style={
                     Object {
-                      "height": "0px",
+                      "height": "auto",
                     }
                   }
                 >
@@ -147,7 +147,7 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable gives panels a
                     role="tabpanel"
                     style={
                       Object {
-                        "height": "0px",
+                        "height": "auto",
                       }
                     }
                   >
@@ -620,7 +620,7 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable renders panels
                   role="tabpanel"
                   style={
                     Object {
-                      "height": "0px",
+                      "height": "auto",
                     }
                   }
                 >
@@ -632,7 +632,7 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable renders panels
                     role="tabpanel"
                     style={
                       Object {
-                        "height": "0px",
+                        "height": "auto",
                       }
                     }
                   >


### PR DESCRIPTION
Re Prelim - thinking on whether this is the best solution

#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-193

#### Description
Open `<AccordionPanel>`s collapse their height when AccordionPanelGroup is `multiselectable`. Moved setState stuff from `this._handleToggle` to `componentWillReceiveProps`

#### Screenshots (if applicable)

