### PR TITLE
CalendarComponent year scrolling

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,9 +49,9 @@
   "dependencies": {
     "autosize": "3.0.21",
     "downshift": "1.26.1",
-    "lint-staged": "false7.0.0",
+    "lint-staged": "7.0.0",
     "raf-schd": "2.1.0",
-    "react-flatpickr": "3.6.3",
+    "react-flatpickr": "3.6.4",
     "react-portal": "4.1.2",
     "recompose": "0.26.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3853,9 +3853,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flatpickr@^4.0.5:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.2.3.tgz#084b95d353b3b64a164ebfe7151df75c8dae14b1"
+flatpickr@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.3.2.tgz#6a477043c075ef36c3ff54fadb49b936a64d635f"
 
 flatten@^1.0.2:
   version "1.0.2"
@@ -5703,7 +5703,7 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lint-staged@false7.0.0:
+lint-staged@7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-7.0.0.tgz#57926c63201e7bd38ca0576d74391efa699b4a9d"
   dependencies:
@@ -7608,11 +7608,11 @@ react-dom@16.0.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-flatpickr@3.6.3:
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/react-flatpickr/-/react-flatpickr-3.6.3.tgz#a4d5ab83b2159192f3c68981e86e721bd67d562a"
+react-flatpickr@3.6.4:
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/react-flatpickr/-/react-flatpickr-3.6.4.tgz#41a8406d00d787b629839ae1f5a01ed3bb6e84ac"
   dependencies:
-    flatpickr "^4.0.5"
+    flatpickr "^4.3.2"
     prop-types "^15.5.10"
 
 react-html-attributes@^1.3.0:


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-194

#### Description
Prevent CalendarComponent year from changing on scroll by upgrading `react-flatpickr`. Reported by Gavin and Jackie

#### Screenshots (if applicable)

