### PR TITLE
CalendarComponent layout fix

### DIFF
--- a/assets/scss/components/_calendar.scss
+++ b/assets/scss/components/_calendar.scss
@@ -262,7 +262,7 @@ $calendarWidth: 310px;
 	margin: 0;
 	display: inline-block;
 	line-height: inherit;
-	height: initial;
+	height: auto;
 	border: 0;
 }
 


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-457

#### Description
Make sure month and year are visible in the calendar dropdown in IE11

#### Screenshots (if applicable)
Before:
<img width="349" alt="screen shot 2018-02-26 at 12 47 44 pm" src="https://user-images.githubusercontent.com/2313998/36996447-e1c69862-2084-11e8-9c71-152ef4936c3a.png">

After:
![screen shot 2018-03-05 at 2 53 54 pm](https://user-images.githubusercontent.com/2313998/36996542-16c2de18-2085-11e8-9a7d-08b68319f800.png)

