### PR TITLE
Allow for setting custom validation error message on TextInput

### DIFF
--- a/src/forms/TextInput.jsx
+++ b/src/forms/TextInput.jsx
@@ -31,6 +31,8 @@ export const TextInput = (props) => {
 		helperText,
 		required,
 		requiredText,
+		isValid,
+		validityMessage,
 		...other
 	} = props;
 
@@ -69,6 +71,17 @@ export const TextInput = (props) => {
 	const inputStyles = iconShape && {
 		paddingLeft: `${paddingSize}px`
 	};
+	const customValidityMessage = isValid ? '' : validityMessage;
+
+	let textInput = null;
+
+	const handleOnChange = (e) => {
+		if (onChange) {
+			onChange(e);
+		}
+
+		textInput && textInput.setCustomValidity(customValidityMessage);
+	};
 
 	// WC-158
 	// Only add a `value` prop if it is defined.
@@ -95,11 +108,12 @@ export const TextInput = (props) => {
 					required={required}
 					placeholder={placeholder}
 					className={classNames.field}
-					onChange={onChange}
+					onChange={handleOnChange}
 					pattern={pattern}
 					disabled={disabled}
 					id={id}
 					style={inputStyles}
+					ref={(input) => { textInput = input; }}
 					{...other}
 				/>
 				{iconShape &&

--- a/src/forms/TextInput.jsx
+++ b/src/forms/TextInput.jsx
@@ -73,7 +73,7 @@ export const TextInput = (props) => {
 	};
 	const customValidityMessage = isValid ? '' : validityMessage;
 
-	let textInput = null;
+	let textInput;
 
 	const handleOnChange = (e) => {
 		if (onChange) {

--- a/src/forms/__snapshots__/textInput.test.jsx.snap
+++ b/src/forms/__snapshots__/textInput.test.jsx.snap
@@ -21,6 +21,7 @@ exports[`TextInput renders a required HTML <input> with expected attributes for 
       className="span--100"
       id="superhero"
       name="superhero"
+      onChange={[Function]}
       required={true}
       type="text"
       value="Batman"

--- a/src/forms/textInput.story.jsx
+++ b/src/forms/textInput.story.jsx
@@ -134,17 +134,47 @@ storiesOf('TextInput', module)
 		}
 	)
 	.addWithInfo('has a pattern for min length', null, () => {
-		const rules = {
-			pattern:'.{5,10}'
-		};
+		/**
+		 * @module ValidatedTextInput
+		 */
+		class ValidatedTextInput extends React.PureComponent {
+			constructor(props){
+				super(props);
+
+				this.state = {
+					valueIsValid: true
+				};
+			}
+
+			render () {
+				const rules = {
+					pattern:'.{5,10}'
+				};
+				const checkValidity = (e) => {
+					const {value} = e.target;
+
+					if (value.length > 5) {
+						this.setState(() => ({valueIsValid: false}));
+					}
+				};
+				return (
+					<TextInput
+						label='Your name'
+						id='fullname'
+						name='name'
+						defaultValue='>5'
+						onChange={(e) => checkValidity(e)}
+						isValid={this.state.valueIsValid}
+						validityMessage='Must be less than 5 characters'
+						{...rules}
+					/>
+				);
+			}
+		}
+
 		return (
 			<form>
-				<TextInput
-					label='Your name'
-					id='fullname'
-					name='name'
-					defaultValue='>5'
-					{...rules} />
+				<ValidatedTextInput />
 				<Button
 					contrast
 					fullWidth>


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-548

#### Description
Allow engineers to customize the text in the browser's native validation error message

#### Screenshots (if applicable)
Before (screenshot taken in IE11):
<img width="262" alt="screen shot 2018-02-26 at 2 10 23 pm" src="https://user-images.githubusercontent.com/2313998/37003209-4a2d438c-209a-11e8-94a4-38c66978427c.png">

After (screenshot taken in Chrome):
![screen shot 2018-03-05 at 5 26 46 pm](https://user-images.githubusercontent.com/2313998/37003256-721af646-209a-11e8-9dab-865cf21bee55.png)

