### PR TITLE
<GridList autoHeightWithWrap /> IE11 bug

### DIFF
--- a/assets/scss/components/_gridList.scss
+++ b/assets/scss/components/_gridList.scss
@@ -36,13 +36,19 @@ $glColumns: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10;
 	font-size: 1rem; // reset to normal inside each LI element
 	display: inline-block;
 	margin: 0;
-	padding: 0 $space $space 0;
 	vertical-align: top;
 	width: 50%;
 	box-sizing: border-box;
 	> a {
 		display: block;
 	}
+}
+
+// This extra layer of nesting is needed for IE11.
+// IE11 ignores `box-sizing: border-box` on items with a flex-basis,
+// causing the `gridListAutoheight` variant not to work correctly
+.gridList-itemInner {
+	padding: 0 $space $space 0;
 }
 
 /*doc

--- a/src/layout/GridList.jsx
+++ b/src/layout/GridList.jsx
@@ -54,9 +54,13 @@ class GridList extends React.Component {
 				className={autoHeight || autoHeightWithWrap ? autoHeightClassNames : classNames}
 				{...other}
 			>
-				{items.map((item, key) =>
-					<li key={key} className={listItemClassNames}>{item}</li>
-				)}
+				{items.map((item, key) => (
+					<li key={key} className={listItemClassNames}>
+						<div className="gridList-itemInner">
+							{item}
+						</div>
+					</li>
+				))}
 			</ul>
 		);
 	}


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-552

#### Description
Added a wrapper div to work around IE11 flexbox bug where `box-sizing: border-box;` is ignored for flex items with a `flex-basis`. This was breaking `<GridList autoHeightWithWrap />` - it caused a items to wrap to soon (e.g.: a 3-col grid would only have 2 cols)

#### Screenshots (if applicable)

