### PR TITLE
<AvatarMember noPhoto> icon not showing in Safari

### DIFF
--- a/src/media/Avatar.jsx
+++ b/src/media/Avatar.jsx
@@ -69,10 +69,10 @@ class Avatar extends React.PureComponent {
 				/>;
 
 		if (this.props.to || this.props.href) {
-			return <a {...allProps}>{alt}{children}{printPhoto}</a>;
+			return <a {...allProps}><span className="visibility--a11yHide">{alt}</span>{children}{printPhoto}</a>;
 		}
 
-		return <span {...allProps}>{alt}{children}{printPhoto}</span>;
+		return <span {...allProps}><span className="visibility--a11yHide">{alt}</span>{children}{printPhoto}</span>;
 	}
 }
 


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-554

#### Description
Profile icon was showing very small

#### Screenshots (if applicable)
Before:
![screen shot 2018-03-06 at 4 24 36 pm](https://user-images.githubusercontent.com/2313998/37059340-2eee432a-215b-11e8-9d81-553bcb171342.png)

After:
![screen shot 2018-03-06 at 4 24 50 pm](https://user-images.githubusercontent.com/2313998/37059355-361e5efa-215b-11e8-9746-b78940f01800.png)
