### PR TITLE
enable soft limit for char counter fields

### DIFF
--- a/src/forms/TextInput.jsx
+++ b/src/forms/TextInput.jsx
@@ -77,6 +77,10 @@ export const TextInput = (props) => {
 		other.value = value;
 	}
 
+	// Character limits should be a "soft" limit.
+	// Avoid passing maxLength as an HTML attribute
+	if (maxLength) delete other.maxLength;
+
 	return (
 		<div className="inputContainer">
 			{label &&

--- a/src/forms/Textarea.jsx
+++ b/src/forms/Textarea.jsx
@@ -126,14 +126,9 @@ export class Textarea extends React.Component {
 			)
 		};
 
-
-		// WC-158
-		// IE11 does not recognize `-1` as a valid value
-		// for the `maxLength` attribute, so we only
-		// add the prop if `maxLength` is passed.
-		if (maxLength) {
-			other.maxLength = parseInt(maxLength, 10);
-		}
+		// Character limits should be a "soft" limit.
+		// Avoid passing maxLength as an HTML attribute
+		if (maxLength) delete other.maxLength;
 
 		return (
 			<div className="inputContainer">


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-196

#### Description
Enables soft character limit for char counter fields by avoiding passing the `maxLength` prop as an HTML attribute, which triggers most browsers to give the field a hard limit.

