### PR TITLE
fall back to '*' for required field requiredText

### DIFF
--- a/src/forms/CalendarComponent.jsx
+++ b/src/forms/CalendarComponent.jsx
@@ -124,14 +124,15 @@ CalendarComponent.propTypes = {
 	]),
 	onChange: PropTypes.func, // provided by `redux-form`
 	required: PropTypes.bool,
-	requiredText: (props) => (
-		props.required && !props.requiredText &&
-			new Error('Inputs with `required` prop must provide also provide a translated string for "required" in the `requiredText` prop')
-	)
+	requiredText: PropTypes.oneOfType([
+		PropTypes.string,
+		PropTypes.element
+	])
 };
 
 CalendarComponent.defaultProps = {
-	datepickerOptions: {}
+	requiredText: '*',
+	datepickerOptions: {},
 };
 
 export default withErrorList(CalendarComponent);

--- a/src/forms/NumberInput.jsx
+++ b/src/forms/NumberInput.jsx
@@ -215,8 +215,9 @@ export class NumberInput extends React.Component {
 }
 
 NumberInput.defaultProps = {
+	requiredText: '*',
 	step: 1,
-	min: 0
+	min: 0,
 };
 
 NumberInput.propTypes = {
@@ -245,10 +246,10 @@ NumberInput.propTypes = {
 		PropTypes.element
 	]),
 	required: PropTypes.bool,
-	requiredText: (props) => (
-		props.required && !props.requiredText &&
-			new Error('Inputs with `required` prop must provide also provide a translated string for "required" in the `requiredText` prop')
-	)
+	requiredText: PropTypes.oneOfType([
+		PropTypes.string,
+		PropTypes.element
+	])
 };
 
 export default withErrorList(NumberInput);

--- a/src/forms/SelectInput.jsx
+++ b/src/forms/SelectInput.jsx
@@ -112,6 +112,10 @@ export class SelectInput extends React.Component {
 	}
 }
 
+SelectInput.defaultProps = {
+	requiredText: '*'
+};
+
 SelectInput.propTypes = {
 	name: PropTypes.string.isRequired,
 	options: PropTypes.arrayOf(PropTypes.shape({
@@ -137,10 +141,10 @@ SelectInput.propTypes = {
 		PropTypes.element
 	]),
 	required: PropTypes.bool,
-	requiredText: (props) => (
-		props.required && !props.requiredText &&
-			new Error('Inputs with `required` prop must provide also provide a translated string for "required" in the `requiredText` prop')
-	)
+	requiredText: PropTypes.oneOfType([
+		PropTypes.string,
+		PropTypes.element
+	]),
 };
 
 export default withErrorList(SelectInput);

--- a/src/forms/TextInput.jsx
+++ b/src/forms/TextInput.jsx
@@ -136,6 +136,10 @@ export const TextInput = (props) => {
 	);
 };
 
+TextInput.defaultProps = {
+	requiredText: '*',
+};
+
 TextInput.propTypes = {
 	name: PropTypes.string.isRequired,
 	error: PropTypes.oneOfType([
@@ -161,11 +165,10 @@ TextInput.propTypes = {
 		PropTypes.element
 	]),
 	required: PropTypes.bool,
-	requiredText: (props) => (
-		props.required && !props.requiredText &&
-			new Error('Inputs with `required` prop must provide also provide a translated string for "required" in the `requiredText` prop')
-	)
-
+	requiredText: PropTypes.oneOfType([
+		PropTypes.string,
+		PropTypes.element
+	])
 };
 
 export default withErrorList(TextInput);

--- a/src/forms/Textarea.jsx
+++ b/src/forms/Textarea.jsx
@@ -167,6 +167,10 @@ export class Textarea extends React.Component {
 	}
 }
 
+Textarea.defaultProps = {
+	requiredText: '*',
+};
+
 Textarea.propTypes = {
 	id: PropTypes.string.isRequired,
 	name: PropTypes.string.isRequired,
@@ -187,10 +191,10 @@ Textarea.propTypes = {
 		PropTypes.element
 	]),
 	required: PropTypes.bool,
-	requiredText: (props) => (
-		props.required && !props.requiredText &&
-			new Error('Inputs with `required` prop must provide also provide a translated string for "required" in the `requiredText` prop')
-	)
+	requiredText: PropTypes.oneOfType([
+		PropTypes.string,
+		PropTypes.element
+	])
 };
 
 export default withErrorList(Textarea);

--- a/src/forms/TimeInput.jsx
+++ b/src/forms/TimeInput.jsx
@@ -384,6 +384,7 @@ export class TimeInput extends React.Component {
 }
 
 TimeInput.defaultProps = {
+	requiredText: '*',
 	is24Hr: true
 };
 
@@ -402,10 +403,10 @@ TimeInput.propTypes = {
 		PropTypes.element
 	]),
 	required: PropTypes.bool,
-	requiredText: (props) => (
-		props.required && !props.requiredText &&
-			new Error('Inputs with `required` prop must provide also provide a translated string for "required" in the `requiredText` prop')
-	)
+	requiredText: PropTypes.oneOfType([
+		PropTypes.string,
+		PropTypes.element
+	]),
 };
 
 

--- a/src/forms/__snapshots__/textInput.test.jsx.snap
+++ b/src/forms/__snapshots__/textInput.test.jsx.snap
@@ -6,6 +6,7 @@ exports[`TextInput renders a required HTML <input> with expected attributes for 
 >
   <label
     className="label--field label--required"
+    data-requiredtext="*"
     htmlFor="superhero"
   >
     Super Hero

--- a/src/forms/__snapshots__/timeInput.test.jsx.snap
+++ b/src/forms/__snapshots__/timeInput.test.jsx.snap
@@ -6,6 +6,7 @@ exports[`TimeInput TimeInput, with input[time] support renders a time html input
   name="time"
   onChange={[Function]}
   required={true}
+  requiredText="*"
   value="22:12"
 >
   <div>


### PR DESCRIPTION
Avoids breaking change with `requiredText` by falling back on "*" as a default required message.

