### PR TITLE
Default "type" prop for `Button`

### DIFF
--- a/src/forms/Button.jsx
+++ b/src/forms/Button.jsx
@@ -30,6 +30,7 @@ class Button extends React.PureComponent {
 			hasHoverShadow,
 			component,
 			disabled,
+			type,
 			...other
 		} = this.props;
 
@@ -75,7 +76,12 @@ class Button extends React.PureComponent {
 		const Component = component;
 
 		return (
-			<Component className={classNames.button} onClick={onClick} {...other}>
+			<Component
+				className={classNames.button}
+				onClick={onClick}
+				type={type}
+				{...other}
+			>
 				{icon ? iconChildren : children}
 			</Component>
 		);
@@ -83,7 +89,8 @@ class Button extends React.PureComponent {
 }
 
 Button.defaultProps = {
-	component: 'button'
+	component: 'button',
+	type: 'button'
 };
 
 Button.propTypes = {
@@ -97,5 +104,6 @@ Button.propTypes = {
 		PropTypes.string,
 		PropTypes.func
 	]),
+	type: PropTypes.string
 };
 export default Button;

--- a/src/forms/NumberInput.jsx
+++ b/src/forms/NumberInput.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
+import Button from '../forms/Button';
 import Flex from '../layout/Flex';
 import FlexItem from '../layout/FlexItem';
 import Icon from '../media/Icon';
@@ -183,7 +184,8 @@ export class NumberInput extends React.Component {
 						</FlexItem>
 
 						<FlexItem shrink>
-							<button
+							<Button
+								reset
 								tabIndex="-1"
 								className={classNames.decrementBtn}
 								onBlur={this.onBlur}
@@ -191,11 +193,12 @@ export class NumberInput extends React.Component {
 								onFocus={this.onFocus}
 								ref={ el => this.decrementBtnEl = el }>
 								<Icon shape='minus' size='xs' />
-							</button>
+							</Button>
 						</FlexItem>
 
 						<FlexItem shrink>
-							<button
+							<Button
+								reset
 								tabIndex="-1"
 								className={classNames.incrementBtn}
 								onBlur={this.onBlur}
@@ -203,7 +206,7 @@ export class NumberInput extends React.Component {
 								onFocus={this.onFocus}
 								ref={ el => this.incrementBtnEl = el }>
 								<Icon shape='plus' size='xs' />
-							</button>
+							</Button>
 						</FlexItem>
 
 						{children}

--- a/src/interactive/__snapshots__/accordionPanel.test.jsx.snap
+++ b/src/interactive/__snapshots__/accordionPanel.test.jsx.snap
@@ -353,6 +353,7 @@ exports[`AccordionPanel Panel with toggle switch exists and renders a toggle swi
                     reset={true}
                     role="switch"
                     tabIndex={-1}
+                    type="button"
                   >
                     <button
                       aria-checked={false}
@@ -361,6 +362,7 @@ exports[`AccordionPanel Panel with toggle switch exists and renders a toggle swi
                       onClick={[Function]}
                       role="switch"
                       tabIndex={-1}
+                      type="button"
                     >
                       <span
                         className="toggleSwitch-knob flex flex--center flex--alignCenter"


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/<XXX-###>

#### Description
`<button type="button">` prevents buttons from being activated in a form when you hit "enter" within an `input` to submit the form

#### Screenshots (if applicable)

