### PR TITLE
pass error in textarea redux form wrapper only when field has been touched.

### DIFF
--- a/src/forms/redux-form/Textarea.jsx
+++ b/src/forms/redux-form/Textarea.jsx
@@ -9,8 +9,9 @@ import Textarea from '../Textarea';
  */
 const ReduxFormTextarea = props => {
 	const { meta, input, ...other } = props;
+	const error = meta.touched ? meta.error : null;
 
-	return <Textarea error={meta.error} {...input} {...other} />;
+	return <Textarea error={error} {...input} {...other} />;
 };
 
 ReduxFormTextarea.displayName = 'ReduxFormTextarea';

--- a/src/forms/redux-form/__snapshots__/textarea.test.jsx.snap
+++ b/src/forms/redux-form/__snapshots__/textarea.test.jsx.snap
@@ -3,7 +3,7 @@
 exports[`redux-form Textarea renders a Textarea component with expected attributes from mock data 1`] = `
 <WithErrorList(Textarea)
   autosize={true}
-  error="Did you mean Batman and Robin?"
+  error={null}
   id="heroField"
   label="Super Hero"
   maxLength={20}


### PR DESCRIPTION
Fixes an issue on the schedule form where some textareas were showing validation error states before touched.