### PR TITLE
Visual improvements to :focus for AccordionPanel

### DIFF
--- a/assets/scss/components/_accordion.scss
+++ b/assets/scss/components/_accordion.scss
@@ -3,10 +3,6 @@
 // Maybe we can bring this into `swarm-constants` or `swarm-animation`?
 //
 
-.accordion--hideFocus .accordionPanel-label:focus {
-	outline: 0;
-}
-
 .accordionPanel-animator {
 	overflow: hidden;
 	transition: height $duration--medium $easing--standard;
@@ -24,6 +20,30 @@
 	border: inherit;
 	text-align: inherit;
 	padding: 0;
+}
+
+.accordionPanel:focus {
+	outline: 0;
+}
+
+.accordionPanel-label:focus {
+	outline: 0;
+
+	.accordionPanel {
+		@include color-svg($C_black);
+		font-weight: $W_bold;
+		position: relative;
+
+		&:after {
+			background-color: $C_selection;
+			content: '';
+			position: absolute;
+			top: -1px;
+			bottom: -2px;
+			left: -#{$space-half};
+			right: -#{$space-half};
+		}
+	}
 }
 
 .accordionPanel-icon {

--- a/src/interactive/AccordionPanel.jsx
+++ b/src/interactive/AccordionPanel.jsx
@@ -23,6 +23,7 @@ class AccordionPanel extends React.Component {
 
 		this.state = {
 			height: props.isOpen ? 'auto' : '0px'
+			// hasFocus: false
 		};
 	}
 
@@ -111,6 +112,9 @@ class AccordionPanel extends React.Component {
 			indicatorIcon;
 	}
 
+	/**
+	 * @returns undefined
+	 */
 	onTransitionEnd() {
 		if (this.props.isOpen) {
 			this.setState(()=>({
@@ -118,6 +122,20 @@ class AccordionPanel extends React.Component {
 			}));
 		}
 	}
+
+	// /**
+	//  * @returns undefined
+	//  */
+	// handleFocus() {
+	// 	this.setState(()=>({hasFocus: true}));
+	// }
+
+	// /**
+	//  * @returns undefined
+	//  */
+	// handleBlur() {
+	// 	this.setState(()=>({hasFocus: false}));
+	// }
 
 	render() {
 		const {
@@ -140,6 +158,7 @@ class AccordionPanel extends React.Component {
 
 		const classNames = {
 			accordionPanel: cx(
+				'padding--bottom padding--top',
 				PANEL_CLASS,
 				{
 					[ACTIVEPANEL_CLASS]: isOpen,
@@ -149,7 +168,7 @@ class AccordionPanel extends React.Component {
 			),
 			trigger: cx(
 				className,
-				'accordionPanel-label display--block span--100 padding--bottom'
+				'accordionPanel-label display--block span--100'
 			),
 			content: cx(
 				'accordionPanel-animator',
@@ -163,62 +182,67 @@ class AccordionPanel extends React.Component {
 		const ariaId = label.replace(/\s+/g, '').toLowerCase();
 
 		return(
-			<Flex
-				className={classNames.accordionPanel}
-				rowReverse={indicatorAlign === 'left' && 'all'}
-				{...other}
-			>
-
-				<FlexItem>
-					<button
-						role='tab'
-						id={`label-${ariaId}`}
-						aria-controls={`panel-${ariaId}`}
-						aria-expanded={isOpen}
-						aria-selected={isOpen}
-						className={classNames.trigger}
-						onClick={this.onToggleClick}
-					>
-						{label}
-					</button>
-
-					<Chunk
-						role='tabpanel'
-						aria-labelledby={`label-${ariaId}`}
-						aria-hidden={!isOpen}
-						className={classNames.content}
-						style={{height: this.state.height}}
-						onTransitionEnd={this.onTransitionEnd}
-					>
-						<div
-							className='accordionPanel-content'
-							ref={(div) => { this.contentEl = div; }}
-						>
-							{panelContent}
-						</div>
-					</Chunk>
-				</FlexItem>
-
-				<FlexItem
-					className='accordionPanel-icon'
+			<div>
+				<button
+					role='tab'
+					id={`label-${ariaId}`}
+					aria-controls={`panel-${ariaId}`}
+					aria-expanded={isOpen}
+					aria-selected={isOpen}
+					className={classNames.trigger}
 					onClick={this.onToggleClick}
-					shrink
+					onFocus={this.handleFocus}
+					onBlur={this.handleBlur}
 				>
-					{
-						!indicatorSwitch && indicatorIcon
-							? <Icon shape={this.getIconShape()} size={indicatorIconSize} />
-							:
-							<ToggleSwitch
-								isActive={isOpen}
-								disabled={!!onToggleClick}
-								id={`${ariaId}-switch`}
-								name={ariaId}
-								onClick={this.onToggleClick}
-							/>
-					}
-				</FlexItem>
+					<Flex
+						className={classNames.accordionPanel}
+						rowReverse={indicatorAlign === 'left' && 'all'}
+						tabIndex={-1}
+						{...other}
+					>
 
-			</Flex>
+						<FlexItem>
+							{label}
+						</FlexItem>
+
+						<FlexItem
+							className='accordionPanel-icon'
+							onClick={this.onToggleClick}
+							shrink
+						>
+							{
+								!indicatorSwitch && indicatorIcon
+									? <Icon shape={this.getIconShape()} size={indicatorIconSize} />
+									:
+									<ToggleSwitch
+										isActive={isOpen}
+										disabled={!!onToggleClick}
+										id={`${ariaId}-switch`}
+										name={ariaId}
+										onClick={this.onToggleClick}
+									/>
+							}
+						</FlexItem>
+
+					</Flex>
+				</button>
+
+				<Chunk
+					role='tabpanel'
+					aria-labelledby={`label-${ariaId}`}
+					aria-hidden={!isOpen}
+					className={classNames.content}
+					style={{height: this.state.height}}
+					onTransitionEnd={this.onTransitionEnd}
+				>
+					<div
+						className='accordionPanel-content'
+						ref={(div) => { this.contentEl = div; }}
+					>
+						{panelContent}
+					</div>
+				</Chunk>
+			</div>
 		);
 	}
 }

--- a/src/interactive/AccordionPanel.jsx
+++ b/src/interactive/AccordionPanel.jsx
@@ -23,7 +23,6 @@ class AccordionPanel extends React.Component {
 
 		this.state = {
 			height: props.isOpen ? 'auto' : '0px'
-			// hasFocus: false
 		};
 	}
 
@@ -122,20 +121,6 @@ class AccordionPanel extends React.Component {
 			}));
 		}
 	}
-
-	// /**
-	//  * @returns undefined
-	//  */
-	// handleFocus() {
-	// 	this.setState(()=>({hasFocus: true}));
-	// }
-
-	// /**
-	//  * @returns undefined
-	//  */
-	// handleBlur() {
-	// 	this.setState(()=>({hasFocus: false}));
-	// }
 
 	render() {
 		const {

--- a/src/interactive/AccordionPanel.jsx
+++ b/src/interactive/AccordionPanel.jsx
@@ -215,6 +215,7 @@ class AccordionPanel extends React.Component {
 									? <Icon shape={this.getIconShape()} size={indicatorIconSize} />
 									:
 									<ToggleSwitch
+										tabIndex="-1"
 										isActive={isOpen}
 										disabled={!!onToggleClick}
 										id={`${ariaId}-switch`}

--- a/src/interactive/AccordionPanelGroup.jsx
+++ b/src/interactive/AccordionPanelGroup.jsx
@@ -175,7 +175,7 @@ class AccordionPanelGroup extends React.Component {
 			>
 				{
 					this.accordionPanels.map((panel, i) => (
-						<li key={i} className='list-item'>
+						<li key={i} className='list-item flush--top'>
 							{panel}
 						</li>
 					))

--- a/src/interactive/__snapshots__/accordionPanel.test.jsx.snap
+++ b/src/interactive/__snapshots__/accordionPanel.test.jsx.snap
@@ -1,115 +1,121 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AccordionPanel Panel basic behavior exists and renders with mock props 1`] = `
-<Flex
-  className="accordionPanel"
-  direction="row"
-  rowReverse={false}
->
-  <FlexItem>
-    <button
-      aria-controls="panel-firstsection"
-      aria-expanded={false}
-      aria-selected={false}
-      className="accordionPanel-label display--block span--100 padding--bottom"
-      id="label-firstsection"
-      onClick={[Function]}
-      role="tab"
+<div>
+  <button
+    aria-controls="panel-firstsection"
+    aria-expanded={false}
+    aria-selected={false}
+    className="accordionPanel-label display--block span--100"
+    id="label-firstsection"
+    onClick={[Function]}
+    role="tab"
+  >
+    <Flex
+      className="padding--bottom padding--top accordionPanel"
+      direction="row"
+      rowReverse={false}
+      tabIndex={-1}
     >
-      First Section
-    </button>
-    <Chunk
-      aria-hidden={true}
-      aria-labelledby="label-firstsection"
-      className="accordionPanel-animator accordionPanel-animator--collapse"
-      onTransitionEnd={[Function]}
-      role="tabpanel"
-      style={
-        Object {
-          "height": "0px",
-        }
+      <FlexItem>
+        First Section
+      </FlexItem>
+      <FlexItem
+        className="accordionPanel-icon"
+        onClick={[Function]}
+        shrink={true}
+      >
+        <Icon
+          shape="chevron-down"
+          size="xs"
+        />
+      </FlexItem>
+    </Flex>
+  </button>
+  <Chunk
+    aria-hidden={true}
+    aria-labelledby="label-firstsection"
+    className="accordionPanel-animator accordionPanel-animator--collapse"
+    onTransitionEnd={[Function]}
+    role="tabpanel"
+    style={
+      Object {
+        "height": "0px",
       }
+    }
+  >
+    <div
+      className="accordionPanel-content"
     >
       <div
-        className="accordionPanel-content"
+        className="runningText"
       >
-        <div
-          className="runningText"
-        >
-          <p>
-            Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.
-          </p>
-        </div>
+        <p>
+          Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.
+        </p>
       </div>
-    </Chunk>
-  </FlexItem>
-  <FlexItem
-    className="accordionPanel-icon"
-    onClick={[Function]}
-    shrink={true}
-  >
-    <Icon
-      shape="chevron-down"
-      size="xs"
-    />
-  </FlexItem>
-</Flex>
+    </div>
+  </Chunk>
+</div>
 `;
 
 exports[`AccordionPanel Panel with custom icon exists and renders a custom icon 1`] = `
-<Flex
-  className="accordionPanel"
-  direction="row"
-  rowReverse="all"
->
-  <FlexItem>
-    <button
-      aria-controls="panel-firstsection"
-      aria-expanded={false}
-      aria-selected={false}
-      className="accordionPanel-label display--block span--100 padding--bottom"
-      id="label-firstsection"
-      onClick={[Function]}
-      role="tab"
+<div>
+  <button
+    aria-controls="panel-firstsection"
+    aria-expanded={false}
+    aria-selected={false}
+    className="accordionPanel-label display--block span--100"
+    id="label-firstsection"
+    onClick={[Function]}
+    role="tab"
+  >
+    <Flex
+      className="padding--bottom padding--top accordionPanel"
+      direction="row"
+      rowReverse="all"
+      tabIndex={-1}
     >
-      First Section
-    </button>
-    <Chunk
-      aria-hidden={true}
-      aria-labelledby="label-firstsection"
-      className="accordionPanel-animator accordionPanel-animator--collapse"
-      onTransitionEnd={[Function]}
-      role="tabpanel"
-      style={
-        Object {
-          "height": "0px",
-        }
+      <FlexItem>
+        First Section
+      </FlexItem>
+      <FlexItem
+        className="accordionPanel-icon"
+        onClick={[Function]}
+        shrink={true}
+      >
+        <Icon
+          shape="plus"
+          size="xs"
+        />
+      </FlexItem>
+    </Flex>
+  </button>
+  <Chunk
+    aria-hidden={true}
+    aria-labelledby="label-firstsection"
+    className="accordionPanel-animator accordionPanel-animator--collapse"
+    onTransitionEnd={[Function]}
+    role="tabpanel"
+    style={
+      Object {
+        "height": "0px",
       }
+    }
+  >
+    <div
+      className="accordionPanel-content"
     >
       <div
-        className="accordionPanel-content"
+        className="runningText"
       >
-        <div
-          className="runningText"
-        >
-          <p>
-            Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.
-          </p>
-        </div>
+        <p>
+          Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.
+        </p>
       </div>
-    </Chunk>
-  </FlexItem>
-  <FlexItem
-    className="accordionPanel-icon"
-    onClick={[Function]}
-    shrink={true}
-  >
-    <Icon
-      shape="plus"
-      size="xs"
-    />
-  </FlexItem>
-</Flex>
+    </div>
+  </Chunk>
+</div>
 `;
 
 exports[`AccordionPanel Panel with right aligned icon exists and renders icon left 1`] = `
@@ -129,103 +135,109 @@ exports[`AccordionPanel Panel with right aligned icon exists and renders icon le
     </div>
   }
 >
-  <Flex
-    className="accordionPanel"
-    direction="row"
-    rowReverse="all"
-  >
-    <div
-      className="flex flex--row atAll_flex--rowReverse accordionPanel"
+  <div>
+    <button
+      aria-controls="panel-firstsection"
+      aria-expanded={false}
+      aria-selected={false}
+      className="accordionPanel-label display--block span--100"
+      id="label-firstsection"
+      onBlur={undefined}
+      onClick={[Function]}
+      onFocus={undefined}
+      role="tab"
     >
-      <FlexItem>
-        <div
-          className="flex-item"
-        >
-          <button
-            aria-controls="panel-firstsection"
-            aria-expanded={false}
-            aria-selected={false}
-            className="accordionPanel-label display--block span--100 padding--bottom"
-            id="label-firstsection"
-            onClick={[Function]}
-            role="tab"
-          >
-            First Section
-          </button>
-          <Chunk
-            aria-hidden={true}
-            aria-labelledby="label-firstsection"
-            className="accordionPanel-animator accordionPanel-animator--collapse"
-            onTransitionEnd={[Function]}
-            role="tabpanel"
-            style={
-              Object {
-                "height": "0px",
-              }
-            }
-          >
-            <div
-              aria-hidden={true}
-              aria-labelledby="label-firstsection"
-              className="chunk accordionPanel-animator accordionPanel-animator--collapse"
-              onTransitionEnd={[Function]}
-              role="tabpanel"
-              style={
-                Object {
-                  "height": "0px",
-                }
-              }
-            >
-              <div
-                className="accordionPanel-content"
-              >
-                <div
-                  className="runningText"
-                >
-                  <p>
-                    Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.
-                  </p>
-                </div>
-              </div>
-            </div>
-          </Chunk>
-        </div>
-      </FlexItem>
-      <FlexItem
-        className="accordionPanel-icon"
-        onClick={[Function]}
-        shrink={true}
+      <Flex
+        className="padding--bottom padding--top accordionPanel"
+        direction="row"
+        rowReverse="all"
+        tabIndex={-1}
       >
         <div
-          className="flex-item flex-item--shrink accordionPanel-icon"
-          onClick={[Function]}
+          className="flex flex--row atAll_flex--rowReverse padding--bottom padding--top accordionPanel"
+          tabIndex={-1}
         >
-          <Icon
-            shape="chevron-down"
-            size="xs"
-          >
-            <span
-              className="svg svg--chevron-down"
+          <FlexItem>
+            <div
+              className="flex-item"
             >
-              <svg
-                className="svg-icon valign--middle"
-                height="16"
-                preserveAspectRatio="xMinYMin meet"
-                role="img"
-                style={Object {}}
-                viewBox="0 0 16 16"
-                width="16"
+              First Section
+            </div>
+          </FlexItem>
+          <FlexItem
+            className="accordionPanel-icon"
+            onClick={[Function]}
+            shrink={true}
+          >
+            <div
+              className="flex-item flex-item--shrink accordionPanel-icon"
+              onClick={[Function]}
+            >
+              <Icon
+                shape="chevron-down"
+                size="xs"
               >
-                <use
-                  xlinkHref="#icon-chevron-down--small"
-                />
-              </svg>
-            </span>
-          </Icon>
+                <span
+                  className="svg svg--chevron-down"
+                >
+                  <svg
+                    className="svg-icon valign--middle"
+                    height="16"
+                    preserveAspectRatio="xMinYMin meet"
+                    role="img"
+                    style={Object {}}
+                    viewBox="0 0 16 16"
+                    width="16"
+                  >
+                    <use
+                      xlinkHref="#icon-chevron-down--small"
+                    />
+                  </svg>
+                </span>
+              </Icon>
+            </div>
+          </FlexItem>
         </div>
-      </FlexItem>
-    </div>
-  </Flex>
+      </Flex>
+    </button>
+    <Chunk
+      aria-hidden={true}
+      aria-labelledby="label-firstsection"
+      className="accordionPanel-animator accordionPanel-animator--collapse"
+      onTransitionEnd={[Function]}
+      role="tabpanel"
+      style={
+        Object {
+          "height": "0px",
+        }
+      }
+    >
+      <div
+        aria-hidden={true}
+        aria-labelledby="label-firstsection"
+        className="chunk accordionPanel-animator accordionPanel-animator--collapse"
+        onTransitionEnd={[Function]}
+        role="tabpanel"
+        style={
+          Object {
+            "height": "0px",
+          }
+        }
+      >
+        <div
+          className="accordionPanel-content"
+        >
+          <div
+            className="runningText"
+          >
+            <p>
+              Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.
+            </p>
+          </div>
+        </div>
+      </div>
+    </Chunk>
+  </div>
 </AccordionPanel>
 `;
 
@@ -247,165 +259,171 @@ exports[`AccordionPanel Panel with toggle switch exists and renders a toggle swi
     </div>
   }
 >
-  <Flex
-    className="accordionPanel"
-    direction="row"
-    rowReverse="all"
-  >
-    <div
-      className="flex flex--row atAll_flex--rowReverse accordionPanel"
+  <div>
+    <button
+      aria-controls="panel-firstsection"
+      aria-expanded={false}
+      aria-selected={false}
+      className="accordionPanel-label display--block span--100"
+      id="label-firstsection"
+      onBlur={undefined}
+      onClick={[Function]}
+      onFocus={undefined}
+      role="tab"
     >
-      <FlexItem>
-        <div
-          className="flex-item"
-        >
-          <button
-            aria-controls="panel-firstsection"
-            aria-expanded={false}
-            aria-selected={false}
-            className="accordionPanel-label display--block span--100 padding--bottom"
-            id="label-firstsection"
-            onClick={[Function]}
-            role="tab"
-          >
-            First Section
-          </button>
-          <Chunk
-            aria-hidden={true}
-            aria-labelledby="label-firstsection"
-            className="accordionPanel-animator accordionPanel-animator--collapse"
-            onTransitionEnd={[Function]}
-            role="tabpanel"
-            style={
-              Object {
-                "height": "0px",
-              }
-            }
-          >
-            <div
-              aria-hidden={true}
-              aria-labelledby="label-firstsection"
-              className="chunk accordionPanel-animator accordionPanel-animator--collapse"
-              onTransitionEnd={[Function]}
-              role="tabpanel"
-              style={
-                Object {
-                  "height": "0px",
-                }
-              }
-            >
-              <div
-                className="accordionPanel-content"
-              >
-                <div
-                  className="runningText"
-                >
-                  <p>
-                    Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.
-                  </p>
-                </div>
-              </div>
-            </div>
-          </Chunk>
-        </div>
-      </FlexItem>
-      <FlexItem
-        className="accordionPanel-icon"
-        onClick={[Function]}
-        shrink={true}
+      <Flex
+        className="padding--bottom padding--top accordionPanel"
+        direction="row"
+        rowReverse="all"
+        tabIndex={-1}
       >
         <div
-          className="flex-item flex-item--shrink accordionPanel-icon"
-          onClick={[Function]}
+          className="flex flex--row atAll_flex--rowReverse padding--bottom padding--top accordionPanel"
+          tabIndex={-1}
         >
-          <WithToggle
-            disabled={false}
-            id="firstsection-switch"
-            isActive={false}
-            name="firstsection"
-            onClick={[Function]}
-          >
-            <span
-              aria-pressed={false}
-              onKeyUp={[Function]}
-              role="button"
-              tabIndex="0"
+          <FlexItem>
+            <div
+              className="flex-item"
             >
-              <ToggleSwitch
+              First Section
+            </div>
+          </FlexItem>
+          <FlexItem
+            className="accordionPanel-icon"
+            onClick={[Function]}
+            shrink={true}
+          >
+            <div
+              className="flex-item flex-item--shrink accordionPanel-icon"
+              onClick={[Function]}
+            >
+              <WithToggle
                 disabled={false}
                 id="firstsection-switch"
                 isActive={false}
                 name="firstsection"
                 onClick={[Function]}
-                toggleActive={[Function]}
               >
-                <div
-                  id="firstsection-switch"
-                  onClick={[Function]}
+                <span
+                  aria-pressed={false}
+                  onKeyUp={[Function]}
+                  role="button"
+                  tabIndex="0"
                 >
-                  <Button
-                    aria-checked={false}
-                    aria-labelledby="firstsection-label"
-                    className="toggleSwitch"
-                    component="button"
+                  <ToggleSwitch
                     disabled={false}
+                    id="firstsection-switch"
+                    isActive={false}
+                    name="firstsection"
                     onClick={[Function]}
-                    reset={true}
-                    role="switch"
-                    tabIndex={-1}
-                    type="button"
+                    toggleActive={[Function]}
                   >
-                    <button
-                      aria-checked={false}
-                      aria-labelledby="firstsection-label"
-                      className="button button--reset toggleSwitch"
+                    <div
+                      id="firstsection-switch"
                       onClick={[Function]}
-                      role="switch"
-                      tabIndex={-1}
-                      type="button"
                     >
-                      <span
-                        className="toggleSwitch-knob flex flex--center flex--alignCenter"
+                      <Button
+                        aria-checked={false}
+                        aria-labelledby="firstsection-label"
+                        className="toggleSwitch"
+                        component="button"
+                        disabled={false}
+                        onClick={[Function]}
+                        reset={true}
+                        role="switch"
+                        tabIndex={-1}
+                        type="button"
                       >
-                        <Icon
-                          color="rgba(46,62,72,0.6)"
-                          label="Toggle switch label"
-                          shape="cross"
-                          size="xxs"
+                        <button
+                          aria-checked={false}
+                          aria-labelledby="firstsection-label"
+                          className="button button--reset toggleSwitch"
+                          onClick={[Function]}
+                          role="switch"
+                          tabIndex={-1}
+                          type="button"
                         >
                           <span
-                            className="svg svg--cross"
+                            className="toggleSwitch-knob flex flex--center flex--alignCenter"
                           >
-                            <svg
-                              className="svg-icon valign--middle"
-                              height="12"
+                            <Icon
+                              color="rgba(46,62,72,0.6)"
                               label="Toggle switch label"
-                              preserveAspectRatio="xMinYMin meet"
-                              role="img"
-                              style={
-                                Object {
-                                  "fill": "rgba(46,62,72,0.6)",
-                                }
-                              }
-                              viewBox="0 0 12 12"
-                              width="12"
+                              shape="cross"
+                              size="xxs"
                             >
-                              <use
-                                xlinkHref="#icon-cross--small"
-                              />
-                            </svg>
+                              <span
+                                className="svg svg--cross"
+                              >
+                                <svg
+                                  className="svg-icon valign--middle"
+                                  height="12"
+                                  label="Toggle switch label"
+                                  preserveAspectRatio="xMinYMin meet"
+                                  role="img"
+                                  style={
+                                    Object {
+                                      "fill": "rgba(46,62,72,0.6)",
+                                    }
+                                  }
+                                  viewBox="0 0 12 12"
+                                  width="12"
+                                >
+                                  <use
+                                    xlinkHref="#icon-cross--small"
+                                  />
+                                </svg>
+                              </span>
+                            </Icon>
                           </span>
-                        </Icon>
-                      </span>
-                    </button>
-                  </Button>
-                </div>
-              </ToggleSwitch>
-            </span>
-          </WithToggle>
+                        </button>
+                      </Button>
+                    </div>
+                  </ToggleSwitch>
+                </span>
+              </WithToggle>
+            </div>
+          </FlexItem>
         </div>
-      </FlexItem>
-    </div>
-  </Flex>
+      </Flex>
+    </button>
+    <Chunk
+      aria-hidden={true}
+      aria-labelledby="label-firstsection"
+      className="accordionPanel-animator accordionPanel-animator--collapse"
+      onTransitionEnd={[Function]}
+      role="tabpanel"
+      style={
+        Object {
+          "height": "0px",
+        }
+      }
+    >
+      <div
+        aria-hidden={true}
+        aria-labelledby="label-firstsection"
+        className="chunk accordionPanel-animator accordionPanel-animator--collapse"
+        onTransitionEnd={[Function]}
+        role="tabpanel"
+        style={
+          Object {
+            "height": "0px",
+          }
+        }
+      >
+        <div
+          className="accordionPanel-content"
+        >
+          <div
+            className="runningText"
+          >
+            <p>
+              Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.
+            </p>
+          </div>
+        </div>
+      </div>
+    </Chunk>
+  </div>
 </AccordionPanel>
 `;

--- a/src/interactive/__snapshots__/accordionPanel.test.jsx.snap
+++ b/src/interactive/__snapshots__/accordionPanel.test.jsx.snap
@@ -303,12 +303,13 @@ exports[`AccordionPanel Panel with toggle switch exists and renders a toggle swi
                 isActive={false}
                 name="firstsection"
                 onClick={[Function]}
+                tabIndex="-1"
               >
                 <span
                   aria-pressed={false}
                   onKeyUp={[Function]}
                   role="button"
-                  tabIndex="0"
+                  tabIndex="-1"
                 >
                   <ToggleSwitch
                     disabled={false}
@@ -316,11 +317,13 @@ exports[`AccordionPanel Panel with toggle switch exists and renders a toggle swi
                     isActive={false}
                     name="firstsection"
                     onClick={[Function]}
+                    tabIndex="-1"
                     toggleActive={[Function]}
                   >
                     <div
                       id="firstsection-switch"
                       onClick={[Function]}
+                      tabIndex="-1"
                     >
                       <Button
                         aria-checked={false}

--- a/src/interactive/__snapshots__/accordionPanelGroup.test.jsx.snap
+++ b/src/interactive/__snapshots__/accordionPanelGroup.test.jsx.snap
@@ -81,7 +81,7 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable gives panels a
     role="tabList"
   >
     <li
-      className="list-item"
+      className="list-item flush--top"
       key="0"
     >
       <AccordionPanel
@@ -104,107 +104,113 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable gives panels a
         }
         setClickedPanel={[Function]}
       >
-        <Flex
-          className="accordionPanel accordionPanel--active"
-          direction="row"
-          rowReverse={false}
-        >
-          <div
-            className="flex flex--row accordionPanel accordionPanel--active"
+        <div>
+          <button
+            aria-controls="panel-firstsection"
+            aria-expanded={true}
+            aria-selected={true}
+            className="accordionPanel-label display--block span--100"
+            id="label-firstsection"
+            onBlur={undefined}
+            onClick={[Function]}
+            onFocus={undefined}
+            role="tab"
           >
-            <FlexItem>
-              <div
-                className="flex-item"
-              >
-                <button
-                  aria-controls="panel-firstsection"
-                  aria-expanded={true}
-                  aria-selected={true}
-                  className="accordionPanel-label display--block span--100 padding--bottom"
-                  id="label-firstsection"
-                  onClick={[Function]}
-                  role="tab"
-                >
-                  First Section
-                </button>
-                <Chunk
-                  aria-hidden={false}
-                  aria-labelledby="label-firstsection"
-                  className="accordionPanel-animator"
-                  onTransitionEnd={[Function]}
-                  role="tabpanel"
-                  style={
-                    Object {
-                      "height": "auto",
-                    }
-                  }
-                >
-                  <div
-                    aria-hidden={false}
-                    aria-labelledby="label-firstsection"
-                    className="chunk accordionPanel-animator"
-                    onTransitionEnd={[Function]}
-                    role="tabpanel"
-                    style={
-                      Object {
-                        "height": "auto",
-                      }
-                    }
-                  >
-                    <div
-                      className="accordionPanel-content"
-                    >
-                      <div
-                        className="runningText"
-                      >
-                        <p>
-                          Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                </Chunk>
-              </div>
-            </FlexItem>
-            <FlexItem
-              className="accordionPanel-icon"
-              onClick={[Function]}
-              shrink={true}
+            <Flex
+              className="padding--bottom padding--top accordionPanel accordionPanel--active"
+              direction="row"
+              rowReverse={false}
+              tabIndex={-1}
             >
               <div
-                className="flex-item flex-item--shrink accordionPanel-icon"
-                onClick={[Function]}
+                className="flex flex--row padding--bottom padding--top accordionPanel accordionPanel--active"
+                tabIndex={-1}
               >
-                <Icon
-                  shape="chevron-down"
-                  size="xs"
-                >
-                  <span
-                    className="svg svg--chevron-down"
+                <FlexItem>
+                  <div
+                    className="flex-item"
                   >
-                    <svg
-                      className="svg-icon valign--middle"
-                      height="16"
-                      preserveAspectRatio="xMinYMin meet"
-                      role="img"
-                      style={Object {}}
-                      viewBox="0 0 16 16"
-                      width="16"
+                    First Section
+                  </div>
+                </FlexItem>
+                <FlexItem
+                  className="accordionPanel-icon"
+                  onClick={[Function]}
+                  shrink={true}
+                >
+                  <div
+                    className="flex-item flex-item--shrink accordionPanel-icon"
+                    onClick={[Function]}
+                  >
+                    <Icon
+                      shape="chevron-down"
+                      size="xs"
                     >
-                      <use
-                        xlinkHref="#icon-chevron-down--small"
-                      />
-                    </svg>
-                  </span>
-                </Icon>
+                      <span
+                        className="svg svg--chevron-down"
+                      >
+                        <svg
+                          className="svg-icon valign--middle"
+                          height="16"
+                          preserveAspectRatio="xMinYMin meet"
+                          role="img"
+                          style={Object {}}
+                          viewBox="0 0 16 16"
+                          width="16"
+                        >
+                          <use
+                            xlinkHref="#icon-chevron-down--small"
+                          />
+                        </svg>
+                      </span>
+                    </Icon>
+                  </div>
+                </FlexItem>
               </div>
-            </FlexItem>
-          </div>
-        </Flex>
+            </Flex>
+          </button>
+          <Chunk
+            aria-hidden={false}
+            aria-labelledby="label-firstsection"
+            className="accordionPanel-animator"
+            onTransitionEnd={[Function]}
+            role="tabpanel"
+            style={
+              Object {
+                "height": "auto",
+              }
+            }
+          >
+            <div
+              aria-hidden={false}
+              aria-labelledby="label-firstsection"
+              className="chunk accordionPanel-animator"
+              onTransitionEnd={[Function]}
+              role="tabpanel"
+              style={
+                Object {
+                  "height": "auto",
+                }
+              }
+            >
+              <div
+                className="accordionPanel-content"
+              >
+                <div
+                  className="runningText"
+                >
+                  <p>
+                    Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </Chunk>
+        </div>
       </AccordionPanel>
     </li>
     <li
-      className="list-item"
+      className="list-item flush--top"
       key="1"
     >
       <AccordionPanel
@@ -243,123 +249,129 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable gives panels a
         }
         setClickedPanel={[Function]}
       >
-        <Flex
-          className="accordionPanel"
-          direction="row"
-          rowReverse={false}
-        >
-          <div
-            className="flex flex--row accordionPanel"
+        <div>
+          <button
+            aria-controls="panel-nextsection"
+            aria-expanded={false}
+            aria-selected={false}
+            className="accordionPanel-label display--block span--100"
+            id="label-nextsection"
+            onBlur={undefined}
+            onClick={[Function]}
+            onFocus={undefined}
+            role="tab"
           >
-            <FlexItem>
-              <div
-                className="flex-item"
-              >
-                <button
-                  aria-controls="panel-nextsection"
-                  aria-expanded={false}
-                  aria-selected={false}
-                  className="accordionPanel-label display--block span--100 padding--bottom"
-                  id="label-nextsection"
-                  onClick={[Function]}
-                  role="tab"
-                >
-                  Next Section
-                </button>
-                <Chunk
-                  aria-hidden={true}
-                  aria-labelledby="label-nextsection"
-                  className="accordionPanel-animator accordionPanel-animator--collapse"
-                  onTransitionEnd={[Function]}
-                  role="tabpanel"
-                  style={
-                    Object {
-                      "height": "0px",
-                    }
-                  }
-                >
-                  <div
-                    aria-hidden={true}
-                    aria-labelledby="label-nextsection"
-                    className="chunk accordionPanel-animator accordionPanel-animator--collapse"
-                    onTransitionEnd={[Function]}
-                    role="tabpanel"
-                    style={
-                      Object {
-                        "height": "0px",
-                      }
-                    }
-                  >
-                    <div
-                      className="accordionPanel-content"
-                    >
-                      <div>
-                        <div
-                          className="runningText"
-                        >
-                          <p>
-                            Any kind of content can go in here, even inputs.
-                          </p>
-                        </div>
-                        <div
-                          className="chunk"
-                        >
-                          <label
-                            htmlFor="test-textinput"
-                          >
-                            Im a label
-                          </label>
-                          <input
-                            id="test-textinput"
-                            placeholder="Input placeholder"
-                            type="text"
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </Chunk>
-              </div>
-            </FlexItem>
-            <FlexItem
-              className="accordionPanel-icon"
-              onClick={[Function]}
-              shrink={true}
+            <Flex
+              className="padding--bottom padding--top accordionPanel"
+              direction="row"
+              rowReverse={false}
+              tabIndex={-1}
             >
               <div
-                className="flex-item flex-item--shrink accordionPanel-icon"
-                onClick={[Function]}
+                className="flex flex--row padding--bottom padding--top accordionPanel"
+                tabIndex={-1}
               >
-                <Icon
-                  shape="chevron-down"
-                  size="xs"
-                >
-                  <span
-                    className="svg svg--chevron-down"
+                <FlexItem>
+                  <div
+                    className="flex-item"
                   >
-                    <svg
-                      className="svg-icon valign--middle"
-                      height="16"
-                      preserveAspectRatio="xMinYMin meet"
-                      role="img"
-                      style={Object {}}
-                      viewBox="0 0 16 16"
-                      width="16"
+                    Next Section
+                  </div>
+                </FlexItem>
+                <FlexItem
+                  className="accordionPanel-icon"
+                  onClick={[Function]}
+                  shrink={true}
+                >
+                  <div
+                    className="flex-item flex-item--shrink accordionPanel-icon"
+                    onClick={[Function]}
+                  >
+                    <Icon
+                      shape="chevron-down"
+                      size="xs"
                     >
-                      <use
-                        xlinkHref="#icon-chevron-down--small"
-                      />
-                    </svg>
-                  </span>
-                </Icon>
+                      <span
+                        className="svg svg--chevron-down"
+                      >
+                        <svg
+                          className="svg-icon valign--middle"
+                          height="16"
+                          preserveAspectRatio="xMinYMin meet"
+                          role="img"
+                          style={Object {}}
+                          viewBox="0 0 16 16"
+                          width="16"
+                        >
+                          <use
+                            xlinkHref="#icon-chevron-down--small"
+                          />
+                        </svg>
+                      </span>
+                    </Icon>
+                  </div>
+                </FlexItem>
               </div>
-            </FlexItem>
-          </div>
-        </Flex>
+            </Flex>
+          </button>
+          <Chunk
+            aria-hidden={true}
+            aria-labelledby="label-nextsection"
+            className="accordionPanel-animator accordionPanel-animator--collapse"
+            onTransitionEnd={[Function]}
+            role="tabpanel"
+            style={
+              Object {
+                "height": "0px",
+              }
+            }
+          >
+            <div
+              aria-hidden={true}
+              aria-labelledby="label-nextsection"
+              className="chunk accordionPanel-animator accordionPanel-animator--collapse"
+              onTransitionEnd={[Function]}
+              role="tabpanel"
+              style={
+                Object {
+                  "height": "0px",
+                }
+              }
+            >
+              <div
+                className="accordionPanel-content"
+              >
+                <div>
+                  <div
+                    className="runningText"
+                  >
+                    <p>
+                      Any kind of content can go in here, even inputs.
+                    </p>
+                  </div>
+                  <div
+                    className="chunk"
+                  >
+                    <label
+                      htmlFor="test-textinput"
+                    >
+                      Im a label
+                    </label>
+                    <input
+                      id="test-textinput"
+                      placeholder="Input placeholder"
+                      type="text"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </Chunk>
+        </div>
       </AccordionPanel>
     </li>
     <li
-      className="list-item"
+      className="list-item flush--top"
       key="2"
     >
       <AccordionPanel
@@ -382,103 +394,109 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable gives panels a
         }
         setClickedPanel={[Function]}
       >
-        <Flex
-          className="accordionPanel"
-          direction="row"
-          rowReverse={false}
-        >
-          <div
-            className="flex flex--row accordionPanel"
+        <div>
+          <button
+            aria-controls="panel-thirdsection"
+            aria-expanded={false}
+            aria-selected={false}
+            className="accordionPanel-label display--block span--100"
+            id="label-thirdsection"
+            onBlur={undefined}
+            onClick={[Function]}
+            onFocus={undefined}
+            role="tab"
           >
-            <FlexItem>
-              <div
-                className="flex-item"
-              >
-                <button
-                  aria-controls="panel-thirdsection"
-                  aria-expanded={false}
-                  aria-selected={false}
-                  className="accordionPanel-label display--block span--100 padding--bottom"
-                  id="label-thirdsection"
-                  onClick={[Function]}
-                  role="tab"
-                >
-                  Third Section
-                </button>
-                <Chunk
-                  aria-hidden={true}
-                  aria-labelledby="label-thirdsection"
-                  className="accordionPanel-animator accordionPanel-animator--collapse"
-                  onTransitionEnd={[Function]}
-                  role="tabpanel"
-                  style={
-                    Object {
-                      "height": "0px",
-                    }
-                  }
-                >
-                  <div
-                    aria-hidden={true}
-                    aria-labelledby="label-thirdsection"
-                    className="chunk accordionPanel-animator accordionPanel-animator--collapse"
-                    onTransitionEnd={[Function]}
-                    role="tabpanel"
-                    style={
-                      Object {
-                        "height": "0px",
-                      }
-                    }
-                  >
-                    <div
-                      className="accordionPanel-content"
-                    >
-                      <div
-                        className="runningText"
-                      >
-                        <p>
-                          Classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                </Chunk>
-              </div>
-            </FlexItem>
-            <FlexItem
-              className="accordionPanel-icon"
-              onClick={[Function]}
-              shrink={true}
+            <Flex
+              className="padding--bottom padding--top accordionPanel"
+              direction="row"
+              rowReverse={false}
+              tabIndex={-1}
             >
               <div
-                className="flex-item flex-item--shrink accordionPanel-icon"
-                onClick={[Function]}
+                className="flex flex--row padding--bottom padding--top accordionPanel"
+                tabIndex={-1}
               >
-                <Icon
-                  shape="chevron-down"
-                  size="xs"
-                >
-                  <span
-                    className="svg svg--chevron-down"
+                <FlexItem>
+                  <div
+                    className="flex-item"
                   >
-                    <svg
-                      className="svg-icon valign--middle"
-                      height="16"
-                      preserveAspectRatio="xMinYMin meet"
-                      role="img"
-                      style={Object {}}
-                      viewBox="0 0 16 16"
-                      width="16"
+                    Third Section
+                  </div>
+                </FlexItem>
+                <FlexItem
+                  className="accordionPanel-icon"
+                  onClick={[Function]}
+                  shrink={true}
+                >
+                  <div
+                    className="flex-item flex-item--shrink accordionPanel-icon"
+                    onClick={[Function]}
+                  >
+                    <Icon
+                      shape="chevron-down"
+                      size="xs"
                     >
-                      <use
-                        xlinkHref="#icon-chevron-down--small"
-                      />
-                    </svg>
-                  </span>
-                </Icon>
+                      <span
+                        className="svg svg--chevron-down"
+                      >
+                        <svg
+                          className="svg-icon valign--middle"
+                          height="16"
+                          preserveAspectRatio="xMinYMin meet"
+                          role="img"
+                          style={Object {}}
+                          viewBox="0 0 16 16"
+                          width="16"
+                        >
+                          <use
+                            xlinkHref="#icon-chevron-down--small"
+                          />
+                        </svg>
+                      </span>
+                    </Icon>
+                  </div>
+                </FlexItem>
               </div>
-            </FlexItem>
-          </div>
-        </Flex>
+            </Flex>
+          </button>
+          <Chunk
+            aria-hidden={true}
+            aria-labelledby="label-thirdsection"
+            className="accordionPanel-animator accordionPanel-animator--collapse"
+            onTransitionEnd={[Function]}
+            role="tabpanel"
+            style={
+              Object {
+                "height": "0px",
+              }
+            }
+          >
+            <div
+              aria-hidden={true}
+              aria-labelledby="label-thirdsection"
+              className="chunk accordionPanel-animator accordionPanel-animator--collapse"
+              onTransitionEnd={[Function]}
+              role="tabpanel"
+              style={
+                Object {
+                  "height": "0px",
+                }
+              }
+            >
+              <div
+                className="accordionPanel-content"
+              >
+                <div
+                  className="runningText"
+                >
+                  <p>
+                    Classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </Chunk>
+        </div>
       </AccordionPanel>
     </li>
   </ul>
@@ -566,7 +584,7 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable renders panels
     role="tabList"
   >
     <li
-      className="list-item"
+      className="list-item flush--top"
       key="0"
     >
       <AccordionPanel
@@ -589,107 +607,113 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable renders panels
         }
         setClickedPanel={[Function]}
       >
-        <Flex
-          className="accordionPanel accordionPanel--active"
-          direction="row"
-          rowReverse={false}
-        >
-          <div
-            className="flex flex--row accordionPanel accordionPanel--active"
+        <div>
+          <button
+            aria-controls="panel-firstsection"
+            aria-expanded={true}
+            aria-selected={true}
+            className="accordionPanel-label display--block span--100"
+            id="label-firstsection"
+            onBlur={undefined}
+            onClick={[Function]}
+            onFocus={undefined}
+            role="tab"
           >
-            <FlexItem>
-              <div
-                className="flex-item"
-              >
-                <button
-                  aria-controls="panel-firstsection"
-                  aria-expanded={true}
-                  aria-selected={true}
-                  className="accordionPanel-label display--block span--100 padding--bottom"
-                  id="label-firstsection"
-                  onClick={[Function]}
-                  role="tab"
-                >
-                  First Section
-                </button>
-                <Chunk
-                  aria-hidden={false}
-                  aria-labelledby="label-firstsection"
-                  className="accordionPanel-animator"
-                  onTransitionEnd={[Function]}
-                  role="tabpanel"
-                  style={
-                    Object {
-                      "height": "auto",
-                    }
-                  }
-                >
-                  <div
-                    aria-hidden={false}
-                    aria-labelledby="label-firstsection"
-                    className="chunk accordionPanel-animator"
-                    onTransitionEnd={[Function]}
-                    role="tabpanel"
-                    style={
-                      Object {
-                        "height": "auto",
-                      }
-                    }
-                  >
-                    <div
-                      className="accordionPanel-content"
-                    >
-                      <div
-                        className="runningText"
-                      >
-                        <p>
-                          Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                </Chunk>
-              </div>
-            </FlexItem>
-            <FlexItem
-              className="accordionPanel-icon"
-              onClick={[Function]}
-              shrink={true}
+            <Flex
+              className="padding--bottom padding--top accordionPanel accordionPanel--active"
+              direction="row"
+              rowReverse={false}
+              tabIndex={-1}
             >
               <div
-                className="flex-item flex-item--shrink accordionPanel-icon"
-                onClick={[Function]}
+                className="flex flex--row padding--bottom padding--top accordionPanel accordionPanel--active"
+                tabIndex={-1}
               >
-                <Icon
-                  shape="chevron-down"
-                  size="xs"
-                >
-                  <span
-                    className="svg svg--chevron-down"
+                <FlexItem>
+                  <div
+                    className="flex-item"
                   >
-                    <svg
-                      className="svg-icon valign--middle"
-                      height="16"
-                      preserveAspectRatio="xMinYMin meet"
-                      role="img"
-                      style={Object {}}
-                      viewBox="0 0 16 16"
-                      width="16"
+                    First Section
+                  </div>
+                </FlexItem>
+                <FlexItem
+                  className="accordionPanel-icon"
+                  onClick={[Function]}
+                  shrink={true}
+                >
+                  <div
+                    className="flex-item flex-item--shrink accordionPanel-icon"
+                    onClick={[Function]}
+                  >
+                    <Icon
+                      shape="chevron-down"
+                      size="xs"
                     >
-                      <use
-                        xlinkHref="#icon-chevron-down--small"
-                      />
-                    </svg>
-                  </span>
-                </Icon>
+                      <span
+                        className="svg svg--chevron-down"
+                      >
+                        <svg
+                          className="svg-icon valign--middle"
+                          height="16"
+                          preserveAspectRatio="xMinYMin meet"
+                          role="img"
+                          style={Object {}}
+                          viewBox="0 0 16 16"
+                          width="16"
+                        >
+                          <use
+                            xlinkHref="#icon-chevron-down--small"
+                          />
+                        </svg>
+                      </span>
+                    </Icon>
+                  </div>
+                </FlexItem>
               </div>
-            </FlexItem>
-          </div>
-        </Flex>
+            </Flex>
+          </button>
+          <Chunk
+            aria-hidden={false}
+            aria-labelledby="label-firstsection"
+            className="accordionPanel-animator"
+            onTransitionEnd={[Function]}
+            role="tabpanel"
+            style={
+              Object {
+                "height": "auto",
+              }
+            }
+          >
+            <div
+              aria-hidden={false}
+              aria-labelledby="label-firstsection"
+              className="chunk accordionPanel-animator"
+              onTransitionEnd={[Function]}
+              role="tabpanel"
+              style={
+                Object {
+                  "height": "auto",
+                }
+              }
+            >
+              <div
+                className="accordionPanel-content"
+              >
+                <div
+                  className="runningText"
+                >
+                  <p>
+                    Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </Chunk>
+        </div>
       </AccordionPanel>
     </li>
     <li
-      className="list-item"
+      className="list-item flush--top"
       key="1"
     >
       <AccordionPanel
@@ -728,123 +752,129 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable renders panels
         }
         setClickedPanel={[Function]}
       >
-        <Flex
-          className="accordionPanel"
-          direction="row"
-          rowReverse={false}
-        >
-          <div
-            className="flex flex--row accordionPanel"
+        <div>
+          <button
+            aria-controls="panel-nextsection"
+            aria-expanded={false}
+            aria-selected={false}
+            className="accordionPanel-label display--block span--100"
+            id="label-nextsection"
+            onBlur={undefined}
+            onClick={[Function]}
+            onFocus={undefined}
+            role="tab"
           >
-            <FlexItem>
-              <div
-                className="flex-item"
-              >
-                <button
-                  aria-controls="panel-nextsection"
-                  aria-expanded={false}
-                  aria-selected={false}
-                  className="accordionPanel-label display--block span--100 padding--bottom"
-                  id="label-nextsection"
-                  onClick={[Function]}
-                  role="tab"
-                >
-                  Next Section
-                </button>
-                <Chunk
-                  aria-hidden={true}
-                  aria-labelledby="label-nextsection"
-                  className="accordionPanel-animator accordionPanel-animator--collapse"
-                  onTransitionEnd={[Function]}
-                  role="tabpanel"
-                  style={
-                    Object {
-                      "height": "0px",
-                    }
-                  }
-                >
-                  <div
-                    aria-hidden={true}
-                    aria-labelledby="label-nextsection"
-                    className="chunk accordionPanel-animator accordionPanel-animator--collapse"
-                    onTransitionEnd={[Function]}
-                    role="tabpanel"
-                    style={
-                      Object {
-                        "height": "0px",
-                      }
-                    }
-                  >
-                    <div
-                      className="accordionPanel-content"
-                    >
-                      <div>
-                        <div
-                          className="runningText"
-                        >
-                          <p>
-                            Any kind of content can go in here, even inputs.
-                          </p>
-                        </div>
-                        <div
-                          className="chunk"
-                        >
-                          <label
-                            htmlFor="test-textinput"
-                          >
-                            Im a label
-                          </label>
-                          <input
-                            id="test-textinput"
-                            placeholder="Input placeholder"
-                            type="text"
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </Chunk>
-              </div>
-            </FlexItem>
-            <FlexItem
-              className="accordionPanel-icon"
-              onClick={[Function]}
-              shrink={true}
+            <Flex
+              className="padding--bottom padding--top accordionPanel"
+              direction="row"
+              rowReverse={false}
+              tabIndex={-1}
             >
               <div
-                className="flex-item flex-item--shrink accordionPanel-icon"
-                onClick={[Function]}
+                className="flex flex--row padding--bottom padding--top accordionPanel"
+                tabIndex={-1}
               >
-                <Icon
-                  shape="chevron-down"
-                  size="xs"
-                >
-                  <span
-                    className="svg svg--chevron-down"
+                <FlexItem>
+                  <div
+                    className="flex-item"
                   >
-                    <svg
-                      className="svg-icon valign--middle"
-                      height="16"
-                      preserveAspectRatio="xMinYMin meet"
-                      role="img"
-                      style={Object {}}
-                      viewBox="0 0 16 16"
-                      width="16"
+                    Next Section
+                  </div>
+                </FlexItem>
+                <FlexItem
+                  className="accordionPanel-icon"
+                  onClick={[Function]}
+                  shrink={true}
+                >
+                  <div
+                    className="flex-item flex-item--shrink accordionPanel-icon"
+                    onClick={[Function]}
+                  >
+                    <Icon
+                      shape="chevron-down"
+                      size="xs"
                     >
-                      <use
-                        xlinkHref="#icon-chevron-down--small"
-                      />
-                    </svg>
-                  </span>
-                </Icon>
+                      <span
+                        className="svg svg--chevron-down"
+                      >
+                        <svg
+                          className="svg-icon valign--middle"
+                          height="16"
+                          preserveAspectRatio="xMinYMin meet"
+                          role="img"
+                          style={Object {}}
+                          viewBox="0 0 16 16"
+                          width="16"
+                        >
+                          <use
+                            xlinkHref="#icon-chevron-down--small"
+                          />
+                        </svg>
+                      </span>
+                    </Icon>
+                  </div>
+                </FlexItem>
               </div>
-            </FlexItem>
-          </div>
-        </Flex>
+            </Flex>
+          </button>
+          <Chunk
+            aria-hidden={true}
+            aria-labelledby="label-nextsection"
+            className="accordionPanel-animator accordionPanel-animator--collapse"
+            onTransitionEnd={[Function]}
+            role="tabpanel"
+            style={
+              Object {
+                "height": "0px",
+              }
+            }
+          >
+            <div
+              aria-hidden={true}
+              aria-labelledby="label-nextsection"
+              className="chunk accordionPanel-animator accordionPanel-animator--collapse"
+              onTransitionEnd={[Function]}
+              role="tabpanel"
+              style={
+                Object {
+                  "height": "0px",
+                }
+              }
+            >
+              <div
+                className="accordionPanel-content"
+              >
+                <div>
+                  <div
+                    className="runningText"
+                  >
+                    <p>
+                      Any kind of content can go in here, even inputs.
+                    </p>
+                  </div>
+                  <div
+                    className="chunk"
+                  >
+                    <label
+                      htmlFor="test-textinput"
+                    >
+                      Im a label
+                    </label>
+                    <input
+                      id="test-textinput"
+                      placeholder="Input placeholder"
+                      type="text"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </Chunk>
+        </div>
       </AccordionPanel>
     </li>
     <li
-      className="list-item"
+      className="list-item flush--top"
       key="2"
     >
       <AccordionPanel
@@ -867,103 +897,109 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable renders panels
         }
         setClickedPanel={[Function]}
       >
-        <Flex
-          className="accordionPanel"
-          direction="row"
-          rowReverse={false}
-        >
-          <div
-            className="flex flex--row accordionPanel"
+        <div>
+          <button
+            aria-controls="panel-thirdsection"
+            aria-expanded={false}
+            aria-selected={false}
+            className="accordionPanel-label display--block span--100"
+            id="label-thirdsection"
+            onBlur={undefined}
+            onClick={[Function]}
+            onFocus={undefined}
+            role="tab"
           >
-            <FlexItem>
-              <div
-                className="flex-item"
-              >
-                <button
-                  aria-controls="panel-thirdsection"
-                  aria-expanded={false}
-                  aria-selected={false}
-                  className="accordionPanel-label display--block span--100 padding--bottom"
-                  id="label-thirdsection"
-                  onClick={[Function]}
-                  role="tab"
-                >
-                  Third Section
-                </button>
-                <Chunk
-                  aria-hidden={true}
-                  aria-labelledby="label-thirdsection"
-                  className="accordionPanel-animator accordionPanel-animator--collapse"
-                  onTransitionEnd={[Function]}
-                  role="tabpanel"
-                  style={
-                    Object {
-                      "height": "0px",
-                    }
-                  }
-                >
-                  <div
-                    aria-hidden={true}
-                    aria-labelledby="label-thirdsection"
-                    className="chunk accordionPanel-animator accordionPanel-animator--collapse"
-                    onTransitionEnd={[Function]}
-                    role="tabpanel"
-                    style={
-                      Object {
-                        "height": "0px",
-                      }
-                    }
-                  >
-                    <div
-                      className="accordionPanel-content"
-                    >
-                      <div
-                        className="runningText"
-                      >
-                        <p>
-                          Classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                </Chunk>
-              </div>
-            </FlexItem>
-            <FlexItem
-              className="accordionPanel-icon"
-              onClick={[Function]}
-              shrink={true}
+            <Flex
+              className="padding--bottom padding--top accordionPanel"
+              direction="row"
+              rowReverse={false}
+              tabIndex={-1}
             >
               <div
-                className="flex-item flex-item--shrink accordionPanel-icon"
-                onClick={[Function]}
+                className="flex flex--row padding--bottom padding--top accordionPanel"
+                tabIndex={-1}
               >
-                <Icon
-                  shape="chevron-down"
-                  size="xs"
-                >
-                  <span
-                    className="svg svg--chevron-down"
+                <FlexItem>
+                  <div
+                    className="flex-item"
                   >
-                    <svg
-                      className="svg-icon valign--middle"
-                      height="16"
-                      preserveAspectRatio="xMinYMin meet"
-                      role="img"
-                      style={Object {}}
-                      viewBox="0 0 16 16"
-                      width="16"
+                    Third Section
+                  </div>
+                </FlexItem>
+                <FlexItem
+                  className="accordionPanel-icon"
+                  onClick={[Function]}
+                  shrink={true}
+                >
+                  <div
+                    className="flex-item flex-item--shrink accordionPanel-icon"
+                    onClick={[Function]}
+                  >
+                    <Icon
+                      shape="chevron-down"
+                      size="xs"
                     >
-                      <use
-                        xlinkHref="#icon-chevron-down--small"
-                      />
-                    </svg>
-                  </span>
-                </Icon>
+                      <span
+                        className="svg svg--chevron-down"
+                      >
+                        <svg
+                          className="svg-icon valign--middle"
+                          height="16"
+                          preserveAspectRatio="xMinYMin meet"
+                          role="img"
+                          style={Object {}}
+                          viewBox="0 0 16 16"
+                          width="16"
+                        >
+                          <use
+                            xlinkHref="#icon-chevron-down--small"
+                          />
+                        </svg>
+                      </span>
+                    </Icon>
+                  </div>
+                </FlexItem>
               </div>
-            </FlexItem>
-          </div>
-        </Flex>
+            </Flex>
+          </button>
+          <Chunk
+            aria-hidden={true}
+            aria-labelledby="label-thirdsection"
+            className="accordionPanel-animator accordionPanel-animator--collapse"
+            onTransitionEnd={[Function]}
+            role="tabpanel"
+            style={
+              Object {
+                "height": "0px",
+              }
+            }
+          >
+            <div
+              aria-hidden={true}
+              aria-labelledby="label-thirdsection"
+              className="chunk accordionPanel-animator accordionPanel-animator--collapse"
+              onTransitionEnd={[Function]}
+              role="tabpanel"
+              style={
+                Object {
+                  "height": "0px",
+                }
+              }
+            >
+              <div
+                className="accordionPanel-content"
+              >
+                <div
+                  className="runningText"
+                >
+                  <p>
+                    Classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </Chunk>
+        </div>
       </AccordionPanel>
     </li>
   </ul>

--- a/src/utils/components/WithToggleControl.jsx
+++ b/src/utils/components/WithToggleControl.jsx
@@ -46,7 +46,7 @@ export default function withToggleControl(WrappedComponent) {
 
 			return (
 				<span
-					tabIndex="0"
+					tabIndex={this.props.tabIndex || "0"}
 					role="button"
 					aria-pressed={this.state.isActive}
 					onKeyUp={this.onKeyUp}


### PR DESCRIPTION
Re Prelim tag:
* [x] Review design with Todd
* [x] On AccordionPanels with ToggleSwitch, should we _only_ keyboard navigate and show `:focus` on the ToggleSwitch? I think so, but I want a second opinion

#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-230

#### Description
A less severe focus state for `AccordionPanel` that only shows for users navigating with a keyboard

#### Screenshots (if applicable)
Interacting using a keyboard:
![accordionfocus_keyboard](https://user-images.githubusercontent.com/2313998/37528207-6de33c96-290a-11e8-80fc-76df3a7d5d5c.gif)

Interacting using a cursor:
![accordionfocus_mouse](https://user-images.githubusercontent.com/2313998/37528222-7a3be06a-290a-11e8-86f0-403c11584f64.gif)
