### PR TITLE
use meta.touched in all redux-form wrappers that handle errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 4.7.$(CI_BUILD_NUMBER)
+VERSION ?= 4.8.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/README.md
+++ b/README.md
@@ -224,6 +224,9 @@ column to show how different states affect the rendered component.
 
 ## Release notes
 
+### `v4.8.X`
+- Updated `redux-form` wrappers to prevent `error` prop from being passed to wrapped component unless the form field has been touched or form submit has failed.
+
 ### `v4.7.X`
 - Updated `TogglePill` styles per the design team's specifications. These updates will partially break in `mup-web` if the original style overrides are not removed
 

--- a/src/forms/redux-form/CalendarComponent.jsx
+++ b/src/forms/redux-form/CalendarComponent.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import CalendarComponent from '../CalendarComponent';
 
 /**
@@ -9,9 +10,17 @@ import CalendarComponent from '../CalendarComponent';
  */
 const ReduxFormCalendarComponent = props => {
 	const { meta, input, validateBeforeTouched, ...other } = props;
-	const error = (validateBeforeTouched || meta.touched) ? meta.error : null;
+	const error = (validateBeforeTouched || meta.touched || meta.submitFailed)
+		? meta.error
+		: null;
 
 	return <CalendarComponent error={error} {...input} {...other} />;
+};
+
+ReduxFormCalendarComponent.propTypes = {
+	meta: PropTypes.object.isRequired,
+	input: PropTypes.element.isRequired,
+	validateBeforeTouched: PropTypes.bool,
 };
 
 ReduxFormCalendarComponent.displayName = 'ReduxFormCalendarComponent';

--- a/src/forms/redux-form/CalendarComponent.jsx
+++ b/src/forms/redux-form/CalendarComponent.jsx
@@ -9,10 +9,8 @@ import CalendarComponent from '../CalendarComponent';
  * @return {Component} TextInput
  */
 const ReduxFormCalendarComponent = props => {
-	const { meta, input, validateBeforeTouched, ...other } = props;
-	const error = (validateBeforeTouched || meta.touched || meta.submitFailed)
-		? meta.error
-		: null;
+	const { meta, input, ...other } = props;
+	const error = (meta.touched || meta.submitFailed) ? meta.error : null;
 
 	return <CalendarComponent error={error} {...input} {...other} />;
 };
@@ -20,7 +18,6 @@ const ReduxFormCalendarComponent = props => {
 ReduxFormCalendarComponent.propTypes = {
 	meta: PropTypes.object.isRequired,
 	input: PropTypes.element.isRequired,
-	validateBeforeTouched: PropTypes.bool,
 };
 
 ReduxFormCalendarComponent.displayName = 'ReduxFormCalendarComponent';

--- a/src/forms/redux-form/CalendarComponent.jsx
+++ b/src/forms/redux-form/CalendarComponent.jsx
@@ -8,8 +8,10 @@ import CalendarComponent from '../CalendarComponent';
  * @return {Component} TextInput
  */
 const ReduxFormCalendarComponent = props => {
-	const { meta, input, ...other } = props;
-	return <CalendarComponent error={meta.error} {...input} {...other} />;
+	const { meta, input, validateBeforeTouched, ...other } = props;
+	const error = (validateBeforeTouched || meta.touched) ? meta.error : null;
+
+	return <CalendarComponent error={error} {...input} {...other} />;
 };
 
 ReduxFormCalendarComponent.displayName = 'ReduxFormCalendarComponent';

--- a/src/forms/redux-form/NumberInput.jsx
+++ b/src/forms/redux-form/NumberInput.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import NumberInput from '../NumberInput';
 
 /**
@@ -16,7 +17,9 @@ const ReduxFormNumberInput = props => {
 	// logic that will extract the simulated value from the NumberInput onChange
 	const wrappedOnChange = ({ target: { value } }) => input.onChange(value);
 
-	const error = (validateBeforeTouched || meta.touched) ? meta.error : null;
+	const error = (validateBeforeTouched || meta.touched || meta.submitFailed)
+		? meta.error
+		: null;
 
 	return (
 		<NumberInput
@@ -26,6 +29,12 @@ const ReduxFormNumberInput = props => {
 			{...other}
 		/>
 	);
+};
+
+ReduxFormNumberInput.propTypes = {
+	meta: PropTypes.object.isRequired,
+	input: PropTypes.element.isRequired,
+	validateBeforeTouched: PropTypes.bool,
 };
 
 ReduxFormNumberInput.displayName = 'ReduxFormNumberInput';

--- a/src/forms/redux-form/NumberInput.jsx
+++ b/src/forms/redux-form/NumberInput.jsx
@@ -9,7 +9,7 @@ import NumberInput from '../NumberInput';
  * @return {Component} NumberInput
  */
 const ReduxFormNumberInput = props => {
-	const { meta, input, validateBeforeTouched, ...other } = props;
+	const { meta, input, ...other } = props;
 
 	// NumberInput calls onChange with a plain object that simulates an Event.
 	// redux-form will treat anything other than a React SyntheticEvent instance
@@ -17,9 +17,7 @@ const ReduxFormNumberInput = props => {
 	// logic that will extract the simulated value from the NumberInput onChange
 	const wrappedOnChange = ({ target: { value } }) => input.onChange(value);
 
-	const error = (validateBeforeTouched || meta.touched || meta.submitFailed)
-		? meta.error
-		: null;
+	const error = (meta.touched || meta.submitFailed) ? meta.error : null;
 
 	return (
 		<NumberInput
@@ -34,7 +32,6 @@ const ReduxFormNumberInput = props => {
 ReduxFormNumberInput.propTypes = {
 	meta: PropTypes.object.isRequired,
 	input: PropTypes.element.isRequired,
-	validateBeforeTouched: PropTypes.bool,
 };
 
 ReduxFormNumberInput.displayName = 'ReduxFormNumberInput';

--- a/src/forms/redux-form/NumberInput.jsx
+++ b/src/forms/redux-form/NumberInput.jsx
@@ -8,16 +8,19 @@ import NumberInput from '../NumberInput';
  * @return {Component} NumberInput
  */
 const ReduxFormNumberInput = props => {
-	const { meta, input, ...other } = props;
+	const { meta, input, validateBeforeTouched, ...other } = props;
 
 	// NumberInput calls onChange with a plain object that simulates an Event.
 	// redux-form will treat anything other than a React SyntheticEvent instance
 	// as the input _value_, so we need to wrap its `onChange` handler with
 	// logic that will extract the simulated value from the NumberInput onChange
 	const wrappedOnChange = ({ target: { value } }) => input.onChange(value);
+
+	const error = (validateBeforeTouched || meta.touched) ? meta.error : null;
+
 	return (
 		<NumberInput
-			error={(meta || {}).error}
+			error={error}
 			{...input}
 			onChange={wrappedOnChange}
 			{...other}

--- a/src/forms/redux-form/SelectInput.jsx
+++ b/src/forms/redux-form/SelectInput.jsx
@@ -9,10 +9,8 @@ import SelectInput from '../SelectInput';
  * @return {React.Component} SelectInput
  */
 const ReduxFormSelectInput = props => {
-	const { meta, validateBeforeTouched, input, ...other } = props;
-	const error = (validateBeforeTouched || meta.touched || meta.submitFailed)
-		? meta.error
-		: null;
+	const { meta, input, ...other } = props;
+	const error = (meta.touched || meta.submitFailed) ? meta.error : null;
 
 	return <SelectInput error={error} {...input} {...other} />;
 };
@@ -20,7 +18,6 @@ const ReduxFormSelectInput = props => {
 ReduxFormSelectInput.propTypes = {
 	meta: PropTypes.object.isRequired,
 	input: PropTypes.element.isRequired,
-	validateBeforeTouched: PropTypes.bool,
 };
 
 ReduxFormSelectInput.displayName = 'ReduxFormSelectInput';

--- a/src/forms/redux-form/SelectInput.jsx
+++ b/src/forms/redux-form/SelectInput.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import SelectInput from '../SelectInput';
 
 /**
@@ -9,8 +10,17 @@ import SelectInput from '../SelectInput';
  */
 const ReduxFormSelectInput = props => {
 	const { meta, validateBeforeTouched, input, ...other } = props;
-	const error = (validateBeforeTouched || meta.touched) ? meta.error : null;
+	const error = (validateBeforeTouched || meta.touched || meta.submitFailed)
+		? meta.error
+		: null;
+
 	return <SelectInput error={error} {...input} {...other} />;
+};
+
+ReduxFormSelectInput.propTypes = {
+	meta: PropTypes.object.isRequired,
+	input: PropTypes.element.isRequired,
+	validateBeforeTouched: PropTypes.bool,
 };
 
 ReduxFormSelectInput.displayName = 'ReduxFormSelectInput';

--- a/src/forms/redux-form/TextInput.jsx
+++ b/src/forms/redux-form/TextInput.jsx
@@ -9,10 +9,8 @@ import TextInput from '../TextInput';
  * @return {Component} TextInput
  */
 const ReduxFormTextInput = props => {
-	const { meta, input, validateBeforeTouched, ...other } = props;
-	const error = (validateBeforeTouched || meta.touched || meta.submitFailed)
-		? meta.error
-		: null;
+	const { meta, input, ...other } = props;
+	const error = (meta.touched || meta.submitFailed) ? meta.error : null;
 
 	return <TextInput error={error} {...input} {...other} />;
 };
@@ -20,7 +18,6 @@ const ReduxFormTextInput = props => {
 ReduxFormTextInput.propTypes = {
 	meta: PropTypes.object.isRequired,
 	input: PropTypes.element.isRequired,
-	validateBeforeTouched: PropTypes.bool,
 };
 
 ReduxFormTextInput.displayName = 'ReduxFormTextInput';

--- a/src/forms/redux-form/TextInput.jsx
+++ b/src/forms/redux-form/TextInput.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import TextInput from '../TextInput';
 
 /**
@@ -9,9 +10,17 @@ import TextInput from '../TextInput';
  */
 const ReduxFormTextInput = props => {
 	const { meta, input, validateBeforeTouched, ...other } = props;
-	const error = (validateBeforeTouched || meta.touched) ? meta.error : null;
+	const error = (validateBeforeTouched || meta.touched || meta.submitFailed)
+		? meta.error
+		: null;
 
 	return <TextInput error={error} {...input} {...other} />;
+};
+
+ReduxFormTextInput.propTypes = {
+	meta: PropTypes.object.isRequired,
+	input: PropTypes.element.isRequired,
+	validateBeforeTouched: PropTypes.bool,
 };
 
 ReduxFormTextInput.displayName = 'ReduxFormTextInput';

--- a/src/forms/redux-form/Textarea.jsx
+++ b/src/forms/redux-form/Textarea.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Textarea from '../Textarea';
 
 /**
@@ -9,9 +10,17 @@ import Textarea from '../Textarea';
  */
 const ReduxFormTextarea = props => {
 	const { meta, input, validateBeforeTouched, ...other } = props;
-	const error = (validateBeforeTouched || meta.touched) ? meta.error : null;
+	const error = (validateBeforeTouched || meta.touched || meta.submitFailed)
+		? meta.error
+		: null;
 
 	return <Textarea error={error} {...input} {...other} />;
+};
+
+ReduxFormTextarea.propTypes = {
+	meta: PropTypes.object.isRequired,
+	input: PropTypes.element.isRequired,
+	validateBeforeTouched: PropTypes.bool,
 };
 
 ReduxFormTextarea.displayName = 'ReduxFormTextarea';

--- a/src/forms/redux-form/Textarea.jsx
+++ b/src/forms/redux-form/Textarea.jsx
@@ -8,8 +8,8 @@ import Textarea from '../Textarea';
  * @return {React.Component} Textarea
  */
 const ReduxFormTextarea = props => {
-	const { meta, input, ...other } = props;
-	const error = meta.touched ? meta.error : null;
+	const { meta, input, validateBeforeTouched, ...other } = props;
+	const error = (validateBeforeTouched || meta.touched) ? meta.error : null;
 
 	return <Textarea error={error} {...input} {...other} />;
 };

--- a/src/forms/redux-form/Textarea.jsx
+++ b/src/forms/redux-form/Textarea.jsx
@@ -9,10 +9,8 @@ import Textarea from '../Textarea';
  * @return {React.Component} Textarea
  */
 const ReduxFormTextarea = props => {
-	const { meta, input, validateBeforeTouched, ...other } = props;
-	const error = (validateBeforeTouched || meta.touched || meta.submitFailed)
-		? meta.error
-		: null;
+	const { meta, input, ...other } = props;
+	const error = (meta.touched || meta.submitFailed) ? meta.error : null;
 
 	return <Textarea error={error} {...input} {...other} />;
 };
@@ -20,7 +18,6 @@ const ReduxFormTextarea = props => {
 ReduxFormTextarea.propTypes = {
 	meta: PropTypes.object.isRequired,
 	input: PropTypes.element.isRequired,
-	validateBeforeTouched: PropTypes.bool,
 };
 
 ReduxFormTextarea.displayName = 'ReduxFormTextarea';

--- a/src/forms/redux-form/TimeInput.jsx
+++ b/src/forms/redux-form/TimeInput.jsx
@@ -8,9 +8,10 @@ import TimeInput from '../TimeInput';
  * @return {React.Component} TimeInput
  */
 const ReduxFormTimeInput = props => {
-	const { input, meta, ...other } = props;
+	const { input, meta, validateBeforeTouched, ...other } = props;
+	const error = (validateBeforeTouched || meta.touched) ? meta.error : null;
 
-	return <TimeInput {...input} error={meta.error} {...other} />;
+	return <TimeInput {...input} error={error} {...other} />;
 };
 
 ReduxFormTimeInput.displayName = 'ReduxFormTimeInput';

--- a/src/forms/redux-form/TimeInput.jsx
+++ b/src/forms/redux-form/TimeInput.jsx
@@ -9,8 +9,8 @@ import TimeInput from '../TimeInput';
  * @return {React.Component} TimeInput
  */
 const ReduxFormTimeInput = props => {
-	const { input, meta, validateBeforeTouched, ...other } = props;
-	const error = (validateBeforeTouched || meta.touched) ? meta.error : null;
+	const { input, meta, ...other } = props;
+	const error = (meta.touched || meta.submitFailed) ? meta.error : null;
 
 	return <TimeInput {...input} error={error} {...other} />;
 };
@@ -18,7 +18,6 @@ const ReduxFormTimeInput = props => {
 ReduxFormTimeInput.propTypes = {
 	meta: PropTypes.object.isRequired,
 	input: PropTypes.element.isRequired,
-	validateBeforeTouched: PropTypes.bool,
 };
 
 ReduxFormTimeInput.displayName = 'ReduxFormTimeInput';

--- a/src/forms/redux-form/TimeInput.jsx
+++ b/src/forms/redux-form/TimeInput.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import TimeInput from '../TimeInput';
 
 /**
@@ -12,6 +13,12 @@ const ReduxFormTimeInput = props => {
 	const error = (validateBeforeTouched || meta.touched) ? meta.error : null;
 
 	return <TimeInput {...input} error={error} {...other} />;
+};
+
+ReduxFormTimeInput.propTypes = {
+	meta: PropTypes.object.isRequired,
+	input: PropTypes.element.isRequired,
+	validateBeforeTouched: PropTypes.bool,
 };
 
 ReduxFormTimeInput.displayName = 'ReduxFormTimeInput';

--- a/src/forms/redux-form/__snapshots__/calendarComponent.test.jsx.snap
+++ b/src/forms/redux-form/__snapshots__/calendarComponent.test.jsx.snap
@@ -3,7 +3,7 @@
 exports[`redux-form Calendar Component renders a Calendar component with expected attributes from mock data 1`] = `
 <WithErrorList(CalendarComponent)
   className="beyonce-halo"
-  error="pick a different album"
+  error={null}
   id="beyonce"
   name="halo"
   onBlur={[Function]}

--- a/src/forms/redux-form/__snapshots__/numberInput.test.jsx.snap
+++ b/src/forms/redux-form/__snapshots__/numberInput.test.jsx.snap
@@ -2,6 +2,7 @@
 
 exports[`redux-form NumberInput renders a NumberInput component with expected attributes from mock data 1`] = `
 <WithErrorList(NumberInput)
+  error={null}
   label="Number of internets"
   name="internets"
   onChange={[Function]}

--- a/src/forms/redux-form/__snapshots__/timeInput.test.jsx.snap
+++ b/src/forms/redux-form/__snapshots__/timeInput.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`redux-form TimeInput renders a TimeInput component with expected attributes from mock data 1`] = `
 <WithErrorList(TimeInput)
-  error="Now approaching midnight!!?"
+  error={null}
   label="What time is it?"
   name="partytime"
   required={true}

--- a/src/forms/redux-form/numberInput.test.jsx
+++ b/src/forms/redux-form/numberInput.test.jsx
@@ -5,6 +5,7 @@ import ReduxFormNumberInput from './NumberInput';
 describe('redux-form NumberInput', function() {
 	// props structured to match what redux-form provides to <Field> `component`
 	const props = {
+		meta: {},
 		input: {
 			label: 'Number of internets',
 			name: 'internets',

--- a/src/forms/redux-form/selectInput.test.jsx
+++ b/src/forms/redux-form/selectInput.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import ReduxFormSelectInput from './SelectInput';
 
 describe('redux-form SelectInput', () => {
@@ -22,18 +22,5 @@ describe('redux-form SelectInput', () => {
 	it('renders a SelectInput component with expected attributes from mock data', () => {
 		const component = shallow(<ReduxFormSelectInput {...formAttrs} />);
 		expect(component).toMatchSnapshot();
-	});
-
-	it('does not render error if field is not touched and validateBeforeTouched is false', () => {
-		const props = {
-			...formAttrs,
-			validateBeforeTouched: false,
-			meta: {
-				...formAttrs.meta,
-				touched: false
-			}
-		};
-		const component = mount(<ReduxFormSelectInput {...props} />);
-		expect(component.find('.field--error').exists()).toBe(false);
 	});
 });

--- a/src/forms/redux-form/textInput.test.jsx
+++ b/src/forms/redux-form/textInput.test.jsx
@@ -23,35 +23,4 @@ describe('redux-form TextInput', function() {
 		expect(component).toMatchSnapshot();
 	});
 
-	describe('validateBeforeTouched', () => {
-		describe('when true', () => {
-			const props = {
-				...formAttrs,
-				meta: {
-					touched: false,
-					error: MOCK_ERROR
-				},
-				validateBeforeTouched: false
-			};
-			it('does not render the error when touched is false', () => {
-				const component = shallow(<ReduxFormTextInput {...props} />);
-				expect(component.prop('error')).toBe(null);
-			});
-			it('does render the error when touched is true', () => {
-				props.meta.touched = true;
-				props.validateBeforeTouched = false;
-
-				const component = shallow(<ReduxFormTextInput {...props} />);
-				expect(component.prop('error')).toBe(MOCK_ERROR);
-			});
-			it('always renders the error when validateBeforeTouched is true', () => {
-				props.meta.touched = false;
-				props.validateBeforeTouched = true;
-
-				const component = shallow(<ReduxFormTextInput {...props} />);
-				expect(component.prop('error')).toBe(MOCK_ERROR);
-			});
-		});
-	});
-
 });


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-204

#### Description
For all `redux-form` wrappers that handle errors, check `meta.touched`. This ensures validation on the field will not show an error until a user has interacted with it unless the `validateBeforeTouched` prop is passed.

