### PR TITLE
Icon-only button padding

### DIFF
--- a/assets/scss/components/_button.scss
+++ b/assets/scss/components/_button.scss
@@ -310,3 +310,7 @@ Applies button color-related styles using a mixin.
 	}
 
 }
+
+.button--iconOnly {
+	padding: $space-half $space;
+}

--- a/src/forms/Button.jsx
+++ b/src/forms/Button.jsx
@@ -45,7 +45,8 @@ class Button extends React.PureComponent {
 					'button--bordered': bordered,
 					'button--hasHoverShadow': hasHoverShadow,
 					'button--neutral': neutral,
-					'button--disabled': disabled
+					'button--disabled': disabled,
+					'button--iconOnly': icon && !children
 				},
 				className
 			),

--- a/src/forms/button.story.jsx
+++ b/src/forms/button.story.jsx
@@ -126,6 +126,9 @@ storiesOf('Button', module)
 	.add('Icon Right', () => (
 		<Button onClick={action('clicked')} icon={<Icon shape='search' size='xxs' />} right>Button Label</Button>
 	))
+	.add('Icon Only', () => (
+		<Button onClick={action('clicked')} icon={<Icon shape='search' size='xxs' />} />
+	))
 	.add('No Label', () => (
 		<Button></Button>
 	));


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-542

#### Description
Most of our designs override the left and right padding on buttons that _only_ contain an icon

#### Screenshots (if applicable)
Before:
<img width="100" alt="screen shot 2018-03-21 at 5 48 29 pm" src="https://user-images.githubusercontent.com/2313998/37739332-1e1bac46-2d30-11e8-87df-645dbfe74b10.png">

After:
<img width="77" alt="screen shot 2018-03-21 at 5 48 07 pm" src="https://user-images.githubusercontent.com/2313998/37739341-254df244-2d30-11e8-9e02-2282f3f65d07.png">

