### PR TITLE
only show opened results if there are any results

### DIFF
--- a/src/forms/Typeahead.jsx
+++ b/src/forms/Typeahead.jsx
@@ -36,7 +36,7 @@ class Typeahead extends React.PureComponent {
 							...inputProps
 						})}
 					/>
-					{isOpen
+					{Boolean(isOpen && items && items.length)
 						&&
 							<div
 								className={TA_DROPDOWN_CLASSNAME}


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/MG-710

#### Description
- Typeahead component was staying open when no results were found. It should not display the results box unless results are found.

#### Screenshots (if applicable)
BEFORE:
![image](https://user-images.githubusercontent.com/5428933/37852767-3f47ba5a-2eba-11e8-9659-c2229a63082e.png)


AFTER:
![image](https://user-images.githubusercontent.com/5428933/37852799-5801588a-2eba-11e8-8542-b511b91a7a81.png)


