### PR TITLE
Make entire dropdown menu item area clickable

### DIFF
--- a/assets/scss/components/_dropdown.scss
+++ b/assets/scss/components/_dropdown.scss
@@ -116,8 +116,10 @@ $spaceFromTrigger: $space-3 + $triangleSize;
 }
 
 .dropdownMenu-item {
+	box-sizing: border-box;
 	border-bottom: 1px solid $C_border;
 	cursor: pointer;
+	justify-content: flex-start;
 	padding: calc(var(--responsiveSpace)/2);
 	&:hover {
 		background-color: $C_coolGrayLight;

--- a/src/interactive/Dropdown.jsx
+++ b/src/interactive/Dropdown.jsx
@@ -290,7 +290,7 @@ Dropdown.defaultProps = {
 Dropdown.propTypes = {
 	trigger: PropTypes.element.isRequired,
 	content: PropTypes.element,
-	menuItems: PropTypes.array,
+	menuItems: PropTypes.arrayOf(PropTypes.element),
 	align: PropTypes.oneOf(["left", "right", "center"]).isRequired,
 	className: PropTypes.string,
 	isActive: PropTypes.bool,

--- a/src/interactive/Dropdown.jsx
+++ b/src/interactive/Dropdown.jsx
@@ -10,18 +10,9 @@ import {
 
 import bindAll from "../utils/bindAll";
 
-const ConditionalWrap = ({condition, wrap, children}) => condition ? wrap(children) : children;
+export const DROPDOWN_MENU_ITEM_CLASS = 'dropdownMenu-item';
 
-export const Item = ({isActive, isSelected, children}) => (
-	<div
-		className="dropdownMenu-item"
-		style={{
-			backgroundColor: isActive && C_COOLGRAYLIGHTTRANSP
-		}}
-	>
-		{children}
-	</div>
-);
+const ConditionalWrap = ({condition, wrap, children}) => condition ? wrap(children) : children;
 
 /**
  * @module Dropdown
@@ -262,16 +253,19 @@ class Dropdown extends React.PureComponent {
 										{
 											menuItems
 											?
-												menuItems.map((item, index) => (
-													<Item
-														{...getItemProps({
-															item,
-															isActive: highlightedIndex === index,
-														})}
-														key={`menuItem-${index}`}
-													>
-														{item}
-													</Item>
+												menuItems.map((item, index) => React.cloneElement(
+													item,
+													{
+														key: `menuItem-${index}`,
+														className: cx(
+															item.props.className,
+															DROPDOWN_MENU_ITEM_CLASS,
+															'display--flex span--100'
+														),
+														style: {
+															backgroundColor: highlightedIndex === index && C_COOLGRAYLIGHTTRANSP
+														}
+													}
 												))
 											:
 												content

--- a/src/interactive/dropdown.story.jsx
+++ b/src/interactive/dropdown.story.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { storiesOf } from "@storybook/react";
+import { storiesOf, action } from '@storybook/react';
 import { decorateWithBasics } from "../utils/decorators";
 import Dropdown from "./Dropdown";
 import Section from "../layout/Section";
@@ -150,9 +150,9 @@ storiesOf("Dropdown", module)
 				maxWidth="384px"
 				trigger={<Button small>Open</Button>}
 				menuItems={[
-					'Red',
-					'White',
-					'Swarm'
+					<div onClick={action('red click')}>Red</div>,
+					<div onClick={action('white click')}>White</div>,
+					<div onClick={action('swarm click')}>Swarm</div>
 				]}
 			/>
 		)

--- a/src/interactive/dropdown.test.jsx
+++ b/src/interactive/dropdown.test.jsx
@@ -125,7 +125,7 @@ describe('Dropdown', () => {
 			<Dropdown
 				align="center"
 				trigger={dropdownTrigger}
-				menuItems={['one', 'two', 'three']}
+				menuItems={[<div>one</div>, <div>two</div>, <div>three</div>]}
 			/>
 		);
 		const menuItemDropdownWrapper = mount(menuItemDropdown);

--- a/src/interactive/dropdown.test.jsx
+++ b/src/interactive/dropdown.test.jsx
@@ -5,7 +5,7 @@ import Section from '../layout/Section';
 import Chunk from '../layout/Chunk';
 import Button from '../forms/Button';
 
-import Dropdown, { Item } from './Dropdown';
+import Dropdown, { DROPDOWN_MENU_ITEM_CLASS } from './Dropdown';
 
 const dropdownContent = (
 	<Section noSeparator>
@@ -134,7 +134,7 @@ describe('Dropdown', () => {
 		it('renders the menuItems', () => {
 			trigger.simulate('click');
 			const menuItemsProp = menuItemDropdownWrapper.find(Downshift).prop('menuItems');
-			const menuItemsRendered = menuItemDropdownWrapper.find(Item);
+			const menuItemsRendered = menuItemDropdownWrapper.find(`.${DROPDOWN_MENU_ITEM_CLASS}`);
 
 			expect(menuItemsRendered.length).toBe(menuItemsProp.length);
 		});


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-568

#### Description
The padding on `dropdownMenu-item` was causing it's children not to be clickable unless you clicked directly on the child element. It's even harder to click on the child element when it's an inline element.

#### Screenshots (if applicable)

