### PR TITLE
check value for undefined instead of boolean coercion

### DIFF
--- a/src/forms/TextInput.jsx
+++ b/src/forms/TextInput.jsx
@@ -88,7 +88,7 @@ export const TextInput = (props) => {
 	// WC-158
 	// Only add a `value` prop if it is defined.
 	// Workaround for IE11 support (see ticket)
-	if (value || typeof value === 'string') {
+	if (value !== undefined) {
 		other.value = value;
 	}
 


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-212

#### Description
Prevents number values from causing `TextInput` to switch between controlled and uncontrolled in the event `0` is passed.
