### PR TITLE
Manually update Typeahead's highlighted index

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "autosize": "3.0.21",
-    "downshift": "1.26.1",
+    "downshift": "1.31.2",
     "file-loader": "1.1.8",
     "lint-staged": "7.0.0",
     "raf-schd": "2.1.0",

--- a/src/forms/Typeahead.jsx
+++ b/src/forms/Typeahead.jsx
@@ -15,39 +15,41 @@ class Typeahead extends React.PureComponent {
 	constructor(props) {
 		super(props);
 		this.onItemMouseEnter = this.onItemMouseEnter.bind(this);
-		this.onItemKeyUp = this.onItemKeyUp.bind(this);
+		this.stateReducer = this.stateReducer.bind(this);
 
 		this.state = {
-			actualHighlightedIndex: 0
+			highlightedIndex: -1
 		};
 	}
 
 	onItemMouseEnter (i) {
-		this.setState({actualHighlightedIndex: i});
+		this.setState({highlightedIndex: i});
 	}
 
-	onItemKeyUp(e) {
-		switch (e.key) {
-			case 'ArrowDown':
+	stateReducer(state, changes) {
+		switch (changes.type) {
+			case Downshift.stateChangeTypes.keyDownArrowDown:
 				this.setState({
-					actualHighlightedIndex:
-						parseInt(this.state.actualHighlightedIndex + 1) >= this.props.items.length
+					highlightedIndex:
+						parseInt(this.state.highlightedIndex + 1) >= this.props.items.length
 							?
 								0
 							:
-								parseInt(this.state.actualHighlightedIndex+1)
+								parseInt(this.state.highlightedIndex+1)
 				});
-				break;
-			case 'ArrowUp':
+				return changes;
+			case Downshift.stateChangeTypes.keyDownArrowUp:
 				this.setState({
-					actualHighlightedIndex:
-						this.state.actualHighlightedIndex < 1
+					highlightedIndex:
+						this.state.highlightedIndex < 1
 							?
-								0
+								parseInt(this.props.items.length-1)
 							:
-								parseInt(this.state.actualHighlightedIndex-1)
+								parseInt(this.state.highlightedIndex-1)
 				});
-				break;
+				return changes;
+			default:
+				return changes;
 		}
 	}
 
@@ -60,7 +62,10 @@ class Typeahead extends React.PureComponent {
 		} = this.props;
 
 		return (
-			<Downshift {...other}>
+			<Downshift
+				stateReducer={this.stateReducer}
+				{...other}
+			>
 				{({
 					getInputProps,
 					getItemProps,
@@ -70,8 +75,7 @@ class Typeahead extends React.PureComponent {
 					<TextInput
 						{...getInputProps({
 							...inputProps,
-							className: 'typeahead-input',
-							onKeyUp: this.onItemKeyUp
+							className: 'typeahead-input'
 						})}
 					/>
 					{Boolean(isOpen && items && items.length)
@@ -96,7 +100,7 @@ class Typeahead extends React.PureComponent {
 													TA_ITEM_CLASSNAME,
 													item.props.className,
 													{
-														'typeahead-item--isActive': this.state.actualHighlightedIndex == i,
+														'typeahead-item--isActive': this.state.highlightedIndex == i,
 													}
 												)
 											})}

--- a/src/forms/Typeahead.jsx
+++ b/src/forms/Typeahead.jsx
@@ -37,13 +37,10 @@ class Typeahead extends React.PureComponent {
 							0
 						:
 							parseInt(this.state.highlightedIndex+1);
-				this.setState({
-					highlightedIndex: highlightedIndexState
-				});
-				return {
-					...changes,
-					highlightedIndex: highlightedIndexState
-				};
+					this.setState({
+						highlightedIndex: highlightedIndexState
+					});
+				break;
 			case Downshift.stateChangeTypes.keyDownArrowUp:
 				highlightedIndexState =
 					this.state.highlightedIndex < 1
@@ -51,16 +48,17 @@ class Typeahead extends React.PureComponent {
 							parseInt(this.props.items.length-1)
 						:
 							parseInt(this.state.highlightedIndex-1);
-				this.setState({
-					highlightedIndex: highlightedIndexState
-				});
-				return {
-					...changes,
-					highlightedIndex: highlightedIndexState
-				};
-			default:
-				return changes;
+					this.setState({
+						highlightedIndex: highlightedIndexState
+					});
+				break;
 		}
+
+		return {
+			...changes,
+			highlightedIndex: highlightedIndexState
+		};
+
 	}
 
 	render() {

--- a/src/forms/Typeahead.jsx
+++ b/src/forms/Typeahead.jsx
@@ -12,6 +12,44 @@ export const TA_ITEM_CLASSNAME = 'typeahead-item';
  * @module Typeahead
  */
 class Typeahead extends React.PureComponent {
+	constructor(props) {
+		super(props);
+		this.onItemMouseEnter = this.onItemMouseEnter.bind(this);
+		this.onItemKeyUp = this.onItemKeyUp.bind(this);
+
+		this.state = {
+			actualHighlightedIndex: 0
+		};
+	}
+
+	onItemMouseEnter (i) {
+		this.setState({actualHighlightedIndex: i});
+	}
+
+	onItemKeyUp(e) {
+		switch (e.key) {
+			case 'ArrowDown':
+				this.setState({
+					actualHighlightedIndex:
+						parseInt(this.state.actualHighlightedIndex + 1) >= this.props.items.length
+							?
+								0
+							:
+								parseInt(this.state.actualHighlightedIndex+1)
+				});
+				break;
+			case 'ArrowUp':
+				this.setState({
+					actualHighlightedIndex:
+						this.state.actualHighlightedIndex < 1
+							?
+								0
+							:
+								parseInt(this.state.actualHighlightedIndex-1)
+				});
+				break;
+		}
+	}
 
 	render() {
 		const {
@@ -27,13 +65,13 @@ class Typeahead extends React.PureComponent {
 					getInputProps,
 					getItemProps,
 					isOpen,
-					highlightedIndex,
 				}) =>
 				(<div className="typeahead">
 					<TextInput
-						className="typeahead-input"
 						{...getInputProps({
-							...inputProps
+							...inputProps,
+							className: 'typeahead-input',
+							onKeyUp: this.onItemKeyUp
 						})}
 					/>
 					{Boolean(isOpen && items && items.length)
@@ -51,15 +89,17 @@ class Typeahead extends React.PureComponent {
 											{...getItemProps({
 												item: item.props.value,
 												i,
+												key: `typeaheadItem-${i}-${Date.now()}`,
+												id: `typeaheadItem-${i}-${Date.now()}`,
+												onMouseMove: () => {this.onItemMouseEnter(i);},
+												className: cx(
+													TA_ITEM_CLASSNAME,
+													item.props.className,
+													{
+														'typeahead-item--isActive': this.state.actualHighlightedIndex == i,
+													}
+												)
 											})}
-											key={`typeaheadItem-${i}`}
-											className={cx(
-												TA_ITEM_CLASSNAME,
-												item.props.className,
-												{
-													'typeahead-item--isActive': highlightedIndex === i
-												}
-											)}
 										>
 											{item.props.children}
 										</div>

--- a/src/forms/Typeahead.jsx
+++ b/src/forms/Typeahead.jsx
@@ -27,27 +27,37 @@ class Typeahead extends React.PureComponent {
 	}
 
 	stateReducer(state, changes) {
+		let highlightedIndexState;
+
 		switch (changes.type) {
 			case Downshift.stateChangeTypes.keyDownArrowDown:
+				highlightedIndexState =
+					parseInt(this.state.highlightedIndex + 1) >= this.props.items.length
+						?
+							0
+						:
+							parseInt(this.state.highlightedIndex+1);
 				this.setState({
-					highlightedIndex:
-						parseInt(this.state.highlightedIndex + 1) >= this.props.items.length
-							?
-								0
-							:
-								parseInt(this.state.highlightedIndex+1)
+					highlightedIndex: highlightedIndexState
 				});
-				return changes;
+				return {
+					...changes,
+					highlightedIndex: highlightedIndexState
+				};
 			case Downshift.stateChangeTypes.keyDownArrowUp:
+				highlightedIndexState =
+					this.state.highlightedIndex < 1
+						?
+							parseInt(this.props.items.length-1)
+						:
+							parseInt(this.state.highlightedIndex-1);
 				this.setState({
-					highlightedIndex:
-						this.state.highlightedIndex < 1
-							?
-								parseInt(this.props.items.length-1)
-							:
-								parseInt(this.state.highlightedIndex-1)
+					highlightedIndex: highlightedIndexState
 				});
-				return changes;
+				return {
+					...changes,
+					highlightedIndex: highlightedIndexState
+				};
 			default:
 				return changes;
 		}

--- a/src/forms/typeahead.test.jsx
+++ b/src/forms/typeahead.test.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Downshift from 'downshift';
 import { shallow, mount } from 'enzyme';
 
 import Typeahead, {
@@ -39,7 +40,7 @@ const TA_ITEMS = [
 
 describe('Typeahead', () => {
 	const closedComponent = mount(
-		<Typeahead inputProps={{name: INPUT_NAME}} />);
+		<Typeahead items={TA_ITEMS} inputProps={{name: INPUT_NAME}} />);
 
 	const openComponent = mount(
 		<Typeahead
@@ -71,6 +72,34 @@ describe('Typeahead', () => {
 
 	it('should render `items` passed in', () => {
 		expect(dropdownArea.find(`.${TA_ITEM_CLASSNAME}`).length).toBe(TA_ITEMS.length);
+	});
+
+	it('should update state on keyDownArrowDown', () => {
+		expect(openComponent.state('highlightedIndex')).toBe(-1);
+		openComponent.instance().stateReducer({}, {type: Downshift.stateChangeTypes.keyDownArrowDown});
+		expect(openComponent.state('highlightedIndex')).toBe(0);
+
+		// test whether it moves select to the beginning of the list
+		dropdownArea.find(`.${TA_ITEM_CLASSNAME}`).forEach(()=>{
+			openComponent.instance().stateReducer({}, {type: Downshift.stateChangeTypes.keyDownArrowDown});
+		});
+		expect(openComponent.state('highlightedIndex')).toBe(0);
+	});
+
+	it('should update state on keyDownArrowUp', () => {
+		openComponent.instance().stateReducer({}, {type: Downshift.stateChangeTypes.keyDownArrowDown});
+		expect(openComponent.state('highlightedIndex')).toBe(1);
+		openComponent.instance().stateReducer({}, {type: Downshift.stateChangeTypes.keyDownArrowUp});
+		expect(openComponent.state('highlightedIndex')).toBe(0);
+
+		// test whether it moves select to the end of the list
+		openComponent.instance().stateReducer({}, {type: Downshift.stateChangeTypes.keyDownArrowUp});
+		expect(openComponent.state('highlightedIndex')).toBe(dropdownArea.find(`.${TA_ITEM_CLASSNAME}`).length - 1);
+	});
+
+	it('should update state on mouseMove', () => {
+		dropdownArea.find(`.${TA_ITEM_CLASSNAME}`).first().simulate('mouseMove');
+		expect(openComponent.state('highlightedIndex')).toBe(0);
 	});
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3056,9 +3056,9 @@ dot-prop@^4.1.0:
   dependencies:
     is-obj "^1.0.0"
 
-downshift@1.26.1:
-  version "1.26.1"
-  resolved "https://registry.yarnpkg.com/downshift/-/downshift-1.26.1.tgz#ae45a016f211d02f8000584d0b466142fde2dd6b"
+downshift@1.31.2:
+  version "1.31.2"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-1.31.2.tgz#6f638e9720d7540d9dffa0b4c4587cf10811cf8c"
 
 duplexer3@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-208

#### Description
For some reason, the Typeahead isn't reliably changing it's internal state when a user hovers a new item in the dropdown. I think this might be an issue with [Downshift](https://github.com/paypal/downshift), but I can't identify what it is in order to submit a PR to them.
This is a bit "brute force", but I'd love to hear

#### Screenshots (if applicable)

