### PR TITLE
Make the browser-native clear button work on TimeInput

### DIFF
--- a/src/forms/TimeInput.jsx
+++ b/src/forms/TimeInput.jsx
@@ -107,13 +107,14 @@ export class TimeInput extends React.PureComponent {
 	 * 	handler prop, if there is one provided (eg supplied by redux-form or DateTimePicker)
 	 */
 	onTimeInputChange(e) {
-		const { value } = e.target;
-		const isValid = /^([0-1]?[1-9]|2[0-4]):([0-5][0-9])(:[0-5][0-9])?$/.test(value);
+		let { value } = e.target;
 
 		// Time inputs are allowed to return an empty string for invalid input.
 		// We should ignore all invalid input and return immediately
 		// Reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time#Validation
-		if (!isValid) return;
+		if (value === '') {
+			value = '00:00';
+		}
 
 		this.setState(() => ({ value }));
 

--- a/src/forms/TimeInput.jsx
+++ b/src/forms/TimeInput.jsx
@@ -108,10 +108,12 @@ export class TimeInput extends React.PureComponent {
 	 */
 	onTimeInputChange(e) {
 		const { value } = e.target;
+		const isValid = /^([0-1]?[1-9]|2[0-4]):([0-5][0-9])(:[0-5][0-9])?$/.test(value);
+
 		// Time inputs are allowed to return an empty string for invalid input.
 		// We should ignore all invalid input and return immediately
 		// Reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time#Validation
-		if (value === '') return;
+		if (!isValid) return;
 
 		this.setState(() => ({ value }));
 


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-209

#### Description
Firefox has no good way of hiding the native clear button in `input[type="time"]`, so I decided to just keep it around and make it clear the input.
However, Malik made a change to `return` if the input value was empty on change. Instead of throwing out the change entirely, I set it to `00:00`.

#### Screenshots (if applicable)

