### PR TITLE
Pass localeCode to getSocialLinks and update snaps

### DIFF
--- a/src/Footer.jsx
+++ b/src/Footer.jsx
@@ -36,7 +36,7 @@ export const FooterCategory = (props) => (
 );
 
 
-export const SocialIconsList = (localeCode) => {
+export const SocialIconsList = ({localeCode}) => {
 	const socialLinks = getSocialLinks(localeCode);
 	const socialIcons = [
 		<a href={socialLinks.facebook}>

--- a/src/__snapshots__/footer.test.jsx.snap
+++ b/src/__snapshots__/footer.test.jsx.snap
@@ -340,7 +340,749 @@ exports[`LanguageSelectInput exists 1`] = `
 />
 `;
 
-exports[`SocialIconsList exists 1`] = `
+exports[`SocialIconsList renders for de-DE locale 1`] = `
+<InlineBlockList
+  items={
+    Array [
+      <a
+        href="https://www.facebook.com/meetupDE/"
+    >
+        <Icon
+            shape="external-facebookboxed"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://twitter.com/MeetupDE/"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-twitter"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://www.youtube.com/meetup"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-youtube"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://www.instagram.com/meetup/"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-instagram"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://medium.com/meetup"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-medium"
+            size="s"
+        />
+    </a>,
+    ]
+  }
+/>
+`;
+
+exports[`SocialIconsList renders for en-AU locale 1`] = `
+<InlineBlockList
+  items={
+    Array [
+      <a
+        href="https://www.facebook.com/meetup/"
+    >
+        <Icon
+            shape="external-facebookboxed"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://twitter.com/Meetup/"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-twitter"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://www.youtube.com/meetup"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-youtube"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://www.instagram.com/meetup/"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-instagram"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://medium.com/meetup"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-medium"
+            size="s"
+        />
+    </a>,
+    ]
+  }
+/>
+`;
+
+exports[`SocialIconsList renders for en-US locale 1`] = `
+<InlineBlockList
+  items={
+    Array [
+      <a
+        href="https://www.facebook.com/meetup/"
+    >
+        <Icon
+            shape="external-facebookboxed"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://twitter.com/Meetup/"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-twitter"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://www.youtube.com/meetup"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-youtube"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://www.instagram.com/meetup/"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-instagram"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://medium.com/meetup"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-medium"
+            size="s"
+        />
+    </a>,
+    ]
+  }
+/>
+`;
+
+exports[`SocialIconsList renders for es locale 1`] = `
+<InlineBlockList
+  items={
+    Array [
+      <a
+        href="https://www.facebook.com/meetup/"
+    >
+        <Icon
+            shape="external-facebookboxed"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://twitter.com/MeetupES/"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-twitter"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://www.youtube.com/meetup"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-youtube"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://www.instagram.com/meetup/"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-instagram"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://medium.com/meetup"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-medium"
+            size="s"
+        />
+    </a>,
+    ]
+  }
+/>
+`;
+
+exports[`SocialIconsList renders for es-ES locale 1`] = `
+<InlineBlockList
+  items={
+    Array [
+      <a
+        href="https://www.facebook.com/meetup/"
+    >
+        <Icon
+            shape="external-facebookboxed"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://twitter.com/MeetupES/"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-twitter"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://www.youtube.com/meetup"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-youtube"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://www.instagram.com/meetup/"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-instagram"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://medium.com/meetup"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-medium"
+            size="s"
+        />
+    </a>,
+    ]
+  }
+/>
+`;
+
+exports[`SocialIconsList renders for fr-FR locale 1`] = `
+<InlineBlockList
+  items={
+    Array [
+      <a
+        href="https://www.facebook.com/MeetupFR/"
+    >
+        <Icon
+            shape="external-facebookboxed"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://twitter.com/MeetupFR/"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-twitter"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://www.youtube.com/meetup"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-youtube"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://www.instagram.com/meetup/"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-instagram"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://medium.com/meetup"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-medium"
+            size="s"
+        />
+    </a>,
+    ]
+  }
+/>
+`;
+
+exports[`SocialIconsList renders for it-IT locale 1`] = `
+<InlineBlockList
+  items={
+    Array [
+      <a
+        href="https://www.facebook.com/meetup/"
+    >
+        <Icon
+            shape="external-facebookboxed"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://twitter.com/MeetupIT/"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-twitter"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://www.youtube.com/meetup"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-youtube"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://www.instagram.com/meetup/"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-instagram"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://medium.com/meetup"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-medium"
+            size="s"
+        />
+    </a>,
+    ]
+  }
+/>
+`;
+
+exports[`SocialIconsList renders for ja-JP locale 1`] = `
+<InlineBlockList
+  items={
+    Array [
+      <a
+        href="https://www.facebook.com/meetupjp/"
+    >
+        <Icon
+            shape="external-facebookboxed"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://twitter.com/MeetupJP/"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-twitter"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://www.youtube.com/meetup"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-youtube"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://www.instagram.com/meetup/"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-instagram"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://medium.com/meetup"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-medium"
+            size="s"
+        />
+    </a>,
+    ]
+  }
+/>
+`;
+
+exports[`SocialIconsList renders for ko-KR locale 1`] = `
+<InlineBlockList
+  items={
+    Array [
+      <a
+        href="https://www.facebook.com/meetup/"
+    >
+        <Icon
+            shape="external-facebookboxed"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://twitter.com/Meetup/"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-twitter"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://www.youtube.com/meetup"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-youtube"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://www.instagram.com/meetup/"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-instagram"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://medium.com/meetup"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-medium"
+            size="s"
+        />
+    </a>,
+    ]
+  }
+/>
+`;
+
+exports[`SocialIconsList renders for nl-NL locale 1`] = `
+<InlineBlockList
+  items={
+    Array [
+      <a
+        href="https://www.facebook.com/meetup/"
+    >
+        <Icon
+            shape="external-facebookboxed"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://twitter.com/Meetup/"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-twitter"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://www.youtube.com/meetup"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-youtube"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://www.instagram.com/meetup/"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-instagram"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://medium.com/meetup"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-medium"
+            size="s"
+        />
+    </a>,
+    ]
+  }
+/>
+`;
+
+exports[`SocialIconsList renders for pl-PL locale 1`] = `
+<InlineBlockList
+  items={
+    Array [
+      <a
+        href="https://www.facebook.com/meetup/"
+    >
+        <Icon
+            shape="external-facebookboxed"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://twitter.com/Meetup/"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-twitter"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://www.youtube.com/meetup"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-youtube"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://www.instagram.com/meetup/"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-instagram"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://medium.com/meetup"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-medium"
+            size="s"
+        />
+    </a>,
+    ]
+  }
+/>
+`;
+
+exports[`SocialIconsList renders for pt-BR locale 1`] = `
+<InlineBlockList
+  items={
+    Array [
+      <a
+        href="https://www.facebook.com/meetup/"
+    >
+        <Icon
+            shape="external-facebookboxed"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://twitter.com/MeetupBR/"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-twitter"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://www.youtube.com/meetup"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-youtube"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://www.instagram.com/meetup/"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-instagram"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://medium.com/meetup"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-medium"
+            size="s"
+        />
+    </a>,
+    ]
+  }
+/>
+`;
+
+exports[`SocialIconsList renders for ru-RU locale 1`] = `
+<InlineBlockList
+  items={
+    Array [
+      <a
+        href="https://www.facebook.com/meetup/"
+    >
+        <Icon
+            shape="external-facebookboxed"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://twitter.com/Meetup/"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-twitter"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://www.youtube.com/meetup"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-youtube"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://www.instagram.com/meetup/"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-instagram"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://medium.com/meetup"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-medium"
+            size="s"
+        />
+    </a>,
+    ]
+  }
+/>
+`;
+
+exports[`SocialIconsList renders for th-TH locale 1`] = `
+<InlineBlockList
+  items={
+    Array [
+      <a
+        href="https://www.facebook.com/meetup/"
+    >
+        <Icon
+            shape="external-facebookboxed"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://twitter.com/Meetup/"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-twitter"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://www.youtube.com/meetup"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-youtube"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://www.instagram.com/meetup/"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-instagram"
+            size="s"
+        />
+    </a>,
+      <a
+        href="https://medium.com/meetup"
+    >
+        <Icon
+            className="margin--left"
+            shape="external-medium"
+            size="s"
+        />
+    </a>,
+    ]
+  }
+/>
+`;
+
+exports[`SocialIconsList renders for tr-TR locale 1`] = `
 <InlineBlockList
   items={
     Array [

--- a/src/footer.test.jsx
+++ b/src/footer.test.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 
+import config from 'mwp-config';
+
 import {
 	Footer,
 	FooterCategory,
@@ -9,7 +11,6 @@ import {
 } from './Footer';
 
 const DEFAULT_LANG = 'en-US';
-const FRENCH_LANG = 'fr-FR';
 const onLanguageSelect = jest.fn();
 
 const footerLinkSets = [
@@ -116,9 +117,12 @@ describe('LanguageSelectInput', () => {
 });
 
 describe('SocialIconsList', () => {
-	it('exists', () => {
-		const socialIconList = shallow(<SocialIconsList language={FRENCH_LANG} />);
-		expect(socialIconList).toMatchSnapshot();
+	const allLocales = config.locales;
+	allLocales.forEach(localeCode => {
+		it(`renders for ${localeCode} locale`, () => {
+			const socialIconList = shallow(<SocialIconsList localeCode={localeCode} />);
+			expect(socialIconList).toMatchSnapshot();
+		});
 	});
 });
 


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-215

#### Description

Noticing that the social icons in the site footer don't link to language-specific social sites anymore.

Steps to reproduce:

1. log out
2. go to the footer on meetup.com
3. pick french language
4. click on Twitter icon

It should go to https://twitter.com/MeetupFR/ but is instead going to https://twitter.com/Meetup/. Some other languages also have their own language-specific fb and twitter pages.