### PR TITLE
Footer: adding legalCopy prop for GDPR

### DIFF
--- a/assets/scss/components/_footer.scss
+++ b/assets/scss/components/_footer.scss
@@ -13,6 +13,13 @@
 	background-color: $C_collectionBG;
 }
 
+.footerList-legal li:after {
+	content: '';
+	@include atMediaUp(medium) {
+		content: attr(data-separator);
+	}
+}
+
 .footerStripe-legal {
 	background-color: darken($C_darkGray, 03%);
 }

--- a/src/Footer.jsx
+++ b/src/Footer.jsx
@@ -20,8 +20,6 @@ import withMatchMedia from './utils/components/withMatchMedia';
 
 import { getSocialLinks } from './utils/getSocialLinks';
 
-export const defaultLegalCopy = 'Meetup is a wholly owned subsidiary of WeWork Companies, Inc.';
-
 export const FooterCategory = (props) => (
 	<Chunk>
 		<h4 className="text--bold margin--bottom">{props.header}</h4>
@@ -186,12 +184,12 @@ export const Footer = ({
 				<Bounds>
 					<div className="padding--all">
 						<InlineBlockList
-							className="text--small align--center atMedium_align--left"
+							className="text--small align--center atMedium_align--left footerList-legal"
 							separator="·"
 							items={[
 								<span>{`© Meetup ${new Date().getFullYear()}`}</span>,
-								<span>{legalCopy}</span>,
-							]}
+								(legalCopy && <span>{legalCopy}</span>),
+							].filter(item => item)}
 						/>
 						<InlineBlockList
 							className="text--small align--center atMedium_align--left margin--top"
@@ -212,7 +210,6 @@ Footer.defaultProps = {
 		text: 'Create a Meetup',
 		link: '/create/'
 	},
-	legalCopy: defaultLegalCopy,
 	linkSets: [
 		{
 			header: 'Your Account',

--- a/src/Footer.jsx
+++ b/src/Footer.jsx
@@ -20,6 +20,8 @@ import withMatchMedia from './utils/components/withMatchMedia';
 
 import { getSocialLinks } from './utils/getSocialLinks';
 
+export const defaultLegalCopy = 'Meetup is a wholly owned subsidiary of WeWork Companies, Inc.';
+
 export const FooterCategory = (props) => (
 	<Chunk>
 		<h4 className="text--bold margin--bottom">{props.header}</h4>
@@ -78,6 +80,7 @@ export const Footer = ({
 	createMeetup,
 	isLight,
 	isLoggedIn,
+	legalCopy,
 	localeCode,
 	linkSets,
 	media,
@@ -187,6 +190,13 @@ export const Footer = ({
 							separator="·"
 							items={[
 								<span>{`© Meetup ${new Date().getFullYear()}`}</span>,
+								<span>{legalCopy}</span>,
+							]}
+						/>
+						<InlineBlockList
+							className="text--small align--center atMedium_align--left margin--top"
+							separator="·"
+							items={[
 								...subFooterLinks
 							]}
 						/>
@@ -202,6 +212,7 @@ Footer.defaultProps = {
 		text: 'Create a Meetup',
 		link: '/create/'
 	},
+	legalCopy: defaultLegalCopy,
 	linkSets: [
 		{
 			header: 'Your Account',
@@ -247,6 +258,7 @@ Footer.propTypes = {
 	}).isRequired,
 	isLight: PropTypes.bool,
 	isLoggedIn: PropTypes.bool,
+	legalCopy: PropTypes.string,
 	localeCode: PropTypes.string.isRequired,
 	linkSets: PropTypes.arrayOf(PropTypes.shape({
 		header: PropTypes.string.isRequired,

--- a/src/__snapshots__/footer.test.jsx.snap
+++ b/src/__snapshots__/footer.test.jsx.snap
@@ -204,6 +204,17 @@ exports[`Footer exists 1`] = `
               <span>
                 © Meetup 2018
             </span>,
+              <span>
+                Meetup is a wholly owned subsidiary of WeWork Companies, Inc.
+            </span>,
+            ]
+          }
+          separator="·"
+        />
+        <InlineBlockList
+          className="text--small align--center atMedium_align--left margin--top"
+          items={
+            Array [
               <a
                 href="/terms"
             >

--- a/src/__snapshots__/footer.test.jsx.snap
+++ b/src/__snapshots__/footer.test.jsx.snap
@@ -204,6 +204,9 @@ exports[`Footer exists 1`] = `
               <span>
                 © Meetup 2018
             </span>,
+              <span>
+                Mock legal copy
+            </span>,
             ]
           }
           separator="·"

--- a/src/__snapshots__/footer.test.jsx.snap
+++ b/src/__snapshots__/footer.test.jsx.snap
@@ -198,14 +198,11 @@ exports[`Footer exists 1`] = `
         className="padding--all"
       >
         <InlineBlockList
-          className="text--small align--center atMedium_align--left"
+          className="text--small align--center atMedium_align--left footerList-legal"
           items={
             Array [
               <span>
                 © Meetup 2018
-            </span>,
-              <span>
-                Meetup is a wholly owned subsidiary of WeWork Companies, Inc.
             </span>,
             ]
           }

--- a/src/footer.story.jsx
+++ b/src/footer.story.jsx
@@ -4,9 +4,11 @@ import { storiesOf, action } from '@storybook/react';
 import withMatchMedia from './utils/components/withMatchMedia';
 
 import { decorateWithBasics } from './utils/decorators';
-import { Footer, defaultLegalCopy } from './Footer';
+import { Footer } from './Footer';
 
 const TestFooter = withMatchMedia(Footer);
+
+const legalCopy = 'Meetup is a wholly owned subsidiary of WeWork Companies, Inc.';
 
 const footerLinkSets = [
 	{
@@ -54,10 +56,10 @@ const subFooterLinks = [
 ];
 
 const DEFAULT_PROPS = {
+	legalCopy,
 	linkSets: footerLinkSets,
 	localeCode: "en-US",
 	onLanguageSelect: action('language changed'),
-	legalCopy: defaultLegalCopy,
 	subFooterLinks: subFooterLinks,
 	createMeetup: {
 		text: 'Create a Meetup',

--- a/src/footer.story.jsx
+++ b/src/footer.story.jsx
@@ -4,7 +4,7 @@ import { storiesOf, action } from '@storybook/react';
 import withMatchMedia from './utils/components/withMatchMedia';
 
 import { decorateWithBasics } from './utils/decorators';
-import { Footer } from './Footer';
+import { Footer, defaultLegalCopy } from './Footer';
 
 const TestFooter = withMatchMedia(Footer);
 
@@ -57,6 +57,7 @@ const DEFAULT_PROPS = {
 	linkSets: footerLinkSets,
 	localeCode: "en-US",
 	onLanguageSelect: action('language changed'),
+	legalCopy: defaultLegalCopy,
 	subFooterLinks: subFooterLinks,
 	createMeetup: {
 		text: 'Create a Meetup',

--- a/src/footer.test.jsx
+++ b/src/footer.test.jsx
@@ -50,6 +50,7 @@ const subFooterLinks = [
 ];
 
 const MOCK_DEFAULT_STATE = {
+	legalCopy: 'Mock legal copy',
 	localeCode: 'en-US',
 	linkSets: footerLinkSets,
 	onLanguageSelect: onLanguageSelect,


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-216

#### Description

Adds a `legalCopy` prop to the `Footer` comp for GDPR compliance.

#### Screenshots (if applicable)

See ticket, but here is the idea...

<img width="851" alt="gdpr-footer-copy" src="https://user-images.githubusercontent.com/5428092/38333574-4421952c-3816-11e8-93ba-e571b8fb73a7.png">


