### PR TITLE
Port FormSection from mup-web

### DIFF
--- a/src/layout/FormSection.jsx
+++ b/src/layout/FormSection.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import cx from 'classnames';
+
+import Card from './Card';
+import Bounds from './Bounds';
+import Section from './Section';
+
+/**
+ * Wrapping component to standardize the structure of form sections.
+ * @module FormSection
+ * @param {object} props React props
+ * @return {React.element} Form section wrapping component
+ */
+function FormSection({ withSeparator, className, children }) {
+	return (
+		<Section hasSeparator={withSeparator} className={cx(className, 'border--none')}>
+			<Card initialHeight flushUntil="large">
+				<Bounds narrow>
+					<Section hasSeparator className="border--none padding--top">
+						{children}
+					</Section>
+				</Bounds>
+			</Card>
+		</Section>
+	);
+}
+
+export default FormSection;

--- a/src/layout/__snapshots__/formSection.test.jsx.snap
+++ b/src/layout/__snapshots__/formSection.test.jsx.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FormSection exists and contains form section wrapping elements with proper attributes 1`] = `
+<Section
+  className="border--none"
+>
+  <Card
+    flushUntil="large"
+    initialHeight={true}
+  >
+    <Bounds
+      narrow={true}
+    >
+      <Section
+        className="border--none padding--top"
+        hasSeparator={true}
+      />
+    </Bounds>
+  </Card>
+</Section>
+`;

--- a/src/layout/formSection.story.jsx
+++ b/src/layout/formSection.story.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import Bounds from './Bounds';
+import Chunk from './Chunk';
+import FormSection from './FormSection';
+import TextInput from '../forms/TextInput';
+
+storiesOf('FormSection', module).add('default', () => (
+	<Bounds>
+		<FormSection>
+			<Chunk>
+				<h2 className="text--sectionTitle">Part one</h2>
+			</Chunk>
+			<Chunk>
+				<TextInput
+					label="Your name"
+					id="fullname"
+					name="name"
+					placeholder="enter your name here"
+				/>
+			</Chunk>
+		</FormSection>
+		<FormSection>
+			<Chunk>
+				<h2 className="text--sectionTitle">Part two</h2>
+			</Chunk>
+			<Chunk>
+				<TextInput
+					label="Your name"
+					id="fullname"
+					name="name"
+					placeholder="enter your name here"
+				/>
+			</Chunk>
+		</FormSection>
+	</Bounds>
+));

--- a/src/layout/formSection.test.jsx
+++ b/src/layout/formSection.test.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import FormSection from './FormSection';
+
+describe('FormSection', () => {
+	it('exists and contains form section wrapping elements with proper attributes', () => {
+		expect(shallow(<FormSection />)).toMatchSnapshot();
+	});
+});


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-97

#### Description
Making `<FormSection />` available to all Meetup web apps.
After this is merged, we'll need to follow up to remove `FormSection` code from `mup-web` and replace usage with this

#### Screenshots (if applicable)
![screen shot 2018-04-05 at 3 03 44 pm](https://user-images.githubusercontent.com/2313998/38386548-fb25a034-38e2-11e8-925b-293a26bf7f79.png)

