### PR TITLE
Better handling of text wrapping on Dropdown menuItems

### DIFF
--- a/assets/scss/components/_dropdown.scss
+++ b/assets/scss/components/_dropdown.scss
@@ -115,6 +115,10 @@ $spaceFromTrigger: $space-3 + $triangleSize;
 	-webkit-transform: translateX(-50%);
 }
 
+.dropdownMenu {
+	width: max-content;
+}
+
 .dropdownMenu-item {
 	box-sizing: border-box;
 	border-bottom: 1px solid $C_border;

--- a/src/interactive/dropdown.story.jsx
+++ b/src/interactive/dropdown.story.jsx
@@ -150,9 +150,9 @@ storiesOf("Dropdown", module)
 				maxWidth="250px"
 				trigger={<Button small>Open</Button>}
 				menuItems={[
-					<div onClick={action('red click')}>Item one has text that is really long and should wrap once we reach max width</div>,
-					<div onClick={action('white click')}>Item two</div>,
-					<div onClick={action('swarm click')}>Item three</div>
+					<div onClick={action('item one click')}>Item one has text that is really long and should wrap once we reach max width</div>,
+					<div onClick={action('item two click')}>Item two</div>,
+					<div onClick={action('item three click')}>Item three</div>
 				]}
 				noPortal // to test text-wrapping
 			/>

--- a/src/interactive/dropdown.story.jsx
+++ b/src/interactive/dropdown.story.jsx
@@ -147,13 +147,14 @@ storiesOf("Dropdown", module)
 			<Dropdown
 				align="center"
 				minWidth="160px"
-				maxWidth="384px"
+				maxWidth="250px"
 				trigger={<Button small>Open</Button>}
 				menuItems={[
-					<div onClick={action('red click')}>Red</div>,
-					<div onClick={action('white click')}>White</div>,
-					<div onClick={action('swarm click')}>Swarm</div>
+					<div onClick={action('red click')}>Item one has text that is really long and should wrap once we reach max width</div>,
+					<div onClick={action('white click')}>Item two</div>,
+					<div onClick={action('swarm click')}>Item three</div>
 				]}
+				noPortal // to test text-wrapping
 			/>
 		)
 	)


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-214

#### Description
Instead of always wrapping on word breaks or using `white-space: nowrap` to make sure text in Dropdown menuItems doesn't ever wrap, have the text wrap only when the text has made use of all available space decided by `max-width`

#### Screenshots (if applicable)
Before (wrapping too soon):
<img width="211" alt="screen shot 2018-04-09 at 3 00 18 pm" src="https://user-images.githubusercontent.com/2313998/38517170-12a5fc28-3c07-11e8-9683-6e7d0855689a.png">

After:
<img width="324" alt="screen shot 2018-04-09 at 2 56 19 pm" src="https://user-images.githubusercontent.com/2313998/38517179-1826c02e-3c07-11e8-9b1d-9d4421158555.png">
