### PR TITLE
TogglePill radio keyboard nav

### DIFF
--- a/assets/scss/components/_togglePill.scss
+++ b/assets/scss/components/_togglePill.scss
@@ -46,4 +46,8 @@
 		);
 		font-weight: $W_medium;
 	}
+
+	&:focus + .toggleButton-label {
+		outline: 1px dotted $C_borderDark;
+	}
 }

--- a/src/forms/TogglePill.jsx
+++ b/src/forms/TogglePill.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
 import Icon from '../media/Icon';
-import withToggleControl from '../utils/components/WithToggleControl';
+import ToggleWrapper from '../utils/components/ToggleWrapper';
 
 export const TOGGLE_PILL_CLASS = 'toggleButton';
 
@@ -12,21 +12,7 @@ export const TOGGLE_PILL_CLASS = 'toggleButton';
  * @see {@link http://meetup.github.io/sassquatch2/ui_components.html#togglePills}
  * @module TogglePill
  */
-class TogglePill extends React.Component {
-	constructor (props) {
-		super(props);
-
-		this.onChange = this.onChange.bind(this);
-	}
-
-	onChange(e) {
-		this.props.toggleActive();
-
-		if (this.props.onChange) {
-			this.props.onChange(e);
-		}
-	}
-
+class TogglePill extends React.PureComponent {
 	render() {
 		const {
 			isActive,
@@ -39,11 +25,9 @@ class TogglePill extends React.Component {
 			name,
 			useRadio,
 			value,
-			toggleActive, // eslint-disable-line no-unused-vars
+			onChange,
 			...other
 		} = this.props;
-
-		delete other.onChange; // onChange is consumed in this.onChange - do not pass it along to children
 
 		const inputType = useRadio ? 'radio' : 'checkbox';
 
@@ -86,24 +70,38 @@ class TogglePill extends React.Component {
 		// ---
 
 		return (
-			<div className={classNames}>
-				<input
-					className='toggleButton-input visibility--a11yHide'
-					type={inputType}
-					id={id}
-					name={name}
-					value={value}
-					checked={isActive}
-					onChange={this.onChange}
-					tabIndex={-1}
-					{...other} />
-				<label
-					className={labelClassNames}
-					htmlFor={id}>
-					{children}
-					{(topic) ? topicChildren : null}
-				</label>
-			</div>
+			<ToggleWrapper
+				type={inputType}
+				isActive={isActive}
+				onToggle={onChange}
+			>
+				{({
+					tabIndex,
+					isActive,
+					toggleActive,
+					onKeyUp,
+				}) => (
+					<div className={classNames}>
+						<input
+							className='toggleButton-input visibility--a11yHide'
+							type={inputType}
+							id={id}
+							name={name}
+							value={value}
+							checked={isActive}
+							onChange={toggleActive}
+							onKeyUp={onKeyUp}
+							tabIndex={tabIndex}
+							{...other} />
+						<label
+							className={labelClassNames}
+							htmlFor={id}>
+							{children}
+							{(topic) ? topicChildren : null}
+						</label>
+					</div>
+				)}
+			</ToggleWrapper>
 		);
 	}
 }
@@ -123,5 +121,5 @@ TogglePill.defaultProps = {
 	isActive: false
 };
 
-export default withToggleControl(TogglePill);
+export default TogglePill;
 

--- a/src/forms/__snapshots__/togglePill.test.jsx.snap
+++ b/src/forms/__snapshots__/togglePill.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TogglePill renders a component with expected attributes 1`] = `
-<WithToggle
+<TogglePill
   id="hikingCategory"
   isActive={false}
   labelClassName="someClass"
@@ -10,21 +10,14 @@ exports[`TogglePill renders a component with expected attributes 1`] = `
   onChange={[Function]}
   value="hiking"
 >
-  <span
-    aria-pressed={false}
-    onKeyUp={[Function]}
-    role="button"
-    tabIndex="0"
+  <ToggleWrapper
+    isActive={false}
+    onToggle={[Function]}
+    type="checkbox"
   >
-    <TogglePill
-      id="hikingCategory"
-      isActive={false}
-      labelClassName="someClass"
-      large={true}
-      name="meetupCategories"
-      onChange={[Function]}
-      toggleActive={[Function]}
-      value="hiking"
+    <ConditionalWrap
+      condition={false}
+      wrap={[Function]}
     >
       <div
         className="toggleButton"
@@ -35,7 +28,8 @@ exports[`TogglePill renders a component with expected attributes 1`] = `
           id="hikingCategory"
           name="meetupCategories"
           onChange={[Function]}
-          tabIndex={-1}
+          onKeyUp={[Function]}
+          tabIndex="0"
           type="checkbox"
           value="hiking"
         />
@@ -46,7 +40,7 @@ exports[`TogglePill renders a component with expected attributes 1`] = `
           Hiking!
         </label>
       </div>
-    </TogglePill>
-  </span>
-</WithToggle>
+    </ConditionalWrap>
+  </ToggleWrapper>
+</TogglePill>
 `;

--- a/src/forms/radioButtonGroup.story.jsx
+++ b/src/forms/radioButtonGroup.story.jsx
@@ -48,13 +48,12 @@ storiesOf('RadioButtonGroup', module)
 			onChange={action('radio button change')}
 			onBlur={action('radio button blur')}
 			onFocus={action('radio button focus')}
-			selectedValue="third"
+			selectedValue="first"
 		>
 			<TogglePill
 				id='toggle1'
 				name='ranking'
 				value='first'
-				isActive
 				useRadio
 			>
 				First
@@ -63,7 +62,6 @@ storiesOf('RadioButtonGroup', module)
 				id='toggle2'
 				name='ranking'
 				value='second'
-				isActive
 				useRadio
 			>
 				I'm Second
@@ -72,7 +70,6 @@ storiesOf('RadioButtonGroup', module)
 				id='toggle3'
 				name='ranking'
 				value='third'
-				isActive
 				useRadio
 			>
 				3rd.

--- a/src/forms/redux-form/__snapshots__/togglePill.test.jsx.snap
+++ b/src/forms/redux-form/__snapshots__/togglePill.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`redux-form TogglePill renders a TogglePill component with expected attributes from mock data 1`] = `
-<WithToggle
+<TogglePill
   isActive={false}
   label="Parenting"
   name="parenting"

--- a/src/utils/components/ToggleWrapper.jsx
+++ b/src/utils/components/ToggleWrapper.jsx
@@ -42,7 +42,7 @@ class ToggleWrapper extends React.Component {
 			'Enter'
 		].some(key => e.key === key);
 
-		if (isActivatingButton) { // && this.props.type !== 'radio'
+		if (isActivatingButton) {
 			this.toggleActive();
 		}
 	}

--- a/src/utils/components/ToggleWrapper.jsx
+++ b/src/utils/components/ToggleWrapper.jsx
@@ -1,0 +1,81 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import ConditionalWrap from './ConditionalWrap';
+
+/**
+ * Provides boolean isActive prop to wrapped component.
+ * Prop name can also be customized if need be
+ *
+ * @param {React.element} ToggleComponent - the component to wrap
+ * @returns {React.element}
+ */
+// export default function withToggleControl(WrappedComponent) {
+/**
+ * @module ToggleWrapper
+ */
+class ToggleWrapper extends React.Component {
+	constructor(props) {
+		super(props);
+
+		this.state = { isActive: props.isActive };
+		this.toggleActive = this.toggleBool.bind(this);
+		this.onKeyUp = this.onKeyUp.bind(this);
+	}
+
+	componentWillReceiveProps(nextProps) {
+		if (nextProps.isActive !== this.props.isActive) {
+			this.toggleActive();
+		}
+	}
+
+	toggleBool(e) {
+		this.setState({ isActive: !this.state.isActive });
+		if (this.props.onToggle) {
+			this.props.onToggle(e);
+		}
+	}
+
+	onKeyUp(e) {
+		const isActivatingButton = [
+			' ', /* space bar */
+			'Enter'
+		].some(key => e.key === key);
+
+		if (isActivatingButton && this.props.type !== 'radio') {
+			this.toggleActive();
+		}
+	}
+
+	render() {
+		return (
+			<ConditionalWrap
+				condition={this.props.type !== 'radio' || this.props.type !== 'checkbox'}
+				wrap={children => (
+					<div
+						role="button"
+						aria-pressed={this.state.isActive}
+						onKeyUp={this.onKeyUp}
+					>
+						{children}
+					</div>
+				)}
+			>
+				{this.props.children({
+					tabIndex: this.props.type !== 'radio' && this.props.tabIndex || "0",
+					isActive: this.state.isActive,
+					toggleActive: this.toggleActive,
+					onKeyUp: this.props.type !== 'radio' && this.onKeyUp
+				})}
+			</ConditionalWrap>
+		);
+	}
+}
+
+ToggleWrapper.defaultProps = {
+	isActive: false
+};
+ToggleWrapper.propTypes = {
+	isActive: PropTypes.bool
+};
+
+export default ToggleWrapper;

--- a/src/utils/components/ToggleWrapper.jsx
+++ b/src/utils/components/ToggleWrapper.jsx
@@ -30,6 +30,7 @@ class ToggleWrapper extends React.Component {
 
 	toggleBool(e) {
 		this.setState({ isActive: !this.state.isActive });
+
 		if (this.props.onToggle) {
 			this.props.onToggle(e);
 		}
@@ -41,27 +42,33 @@ class ToggleWrapper extends React.Component {
 			'Enter'
 		].some(key => e.key === key);
 
-		if (isActivatingButton && this.props.type !== 'radio') {
+		if (isActivatingButton) { // && this.props.type !== 'radio'
 			this.toggleActive();
 		}
 	}
 
 	render() {
+		const isInput = this.props.type == 'radio' || this.props.type == 'checkbox';
+
 		return (
 			<ConditionalWrap
-				condition={this.props.type !== 'radio' || this.props.type !== 'checkbox'}
+				condition={!isInput}
 				wrap={children => (
 					<div
 						role="button"
 						aria-pressed={this.state.isActive}
 						onKeyUp={this.onKeyUp}
+						tabIndex={this.props.tabIndex || "0"}
 					>
-						{children}
+						{this.props.children({
+							isActive: this.state.isActive,
+							toggleActive: this.toggleActive,
+						})}
 					</div>
 				)}
 			>
 				{this.props.children({
-					tabIndex: this.props.type !== 'radio' && this.props.tabIndex || "0",
+					tabIndex: isInput && this.props.tabIndex || "0",
 					isActive: this.state.isActive,
 					toggleActive: this.toggleActive,
 					onKeyUp: this.props.type !== 'radio' && this.onKeyUp

--- a/src/utils/components/WithToggleControl.jsx
+++ b/src/utils/components/WithToggleControl.jsx
@@ -32,32 +32,29 @@ export default function withToggleControl(WrappedComponent) {
 		}
 
 		onKeyUp(e) {
-			const { target } = e;
-
 			const isActivatingButton = [
 				' ', /* space bar */
 				'Enter'
 			].some(key => e.key === key);
 
-			if (isActivatingButton && target.type !== 'radio') {
+			if (isActivatingButton) {
 				this.toggleActive();
 			}
 		}
 
 		render() {
+
 			return (
 				<span
-					// tabIndex={this.props.tabIndex || "0"}
+					tabIndex={this.props.tabIndex || "0"}
 					role="button"
 					aria-pressed={this.state.isActive}
-					// onKeyUp={this.onKeyUp}
+					onKeyUp={this.onKeyUp}
 				>
 					<WrappedComponent
 						{...this.props}
-						tabIndex={this.props.tabIndex || "0"}
 						isActive={this.state.isActive}
 						toggleActive={this.toggleActive}
-						onKeyUp={this.onKeyUp}
 					/>
 				</span>
 			);

--- a/src/utils/components/WithToggleControl.jsx
+++ b/src/utils/components/WithToggleControl.jsx
@@ -32,29 +32,32 @@ export default function withToggleControl(WrappedComponent) {
 		}
 
 		onKeyUp(e) {
+			const { target } = e;
+
 			const isActivatingButton = [
 				' ', /* space bar */
 				'Enter'
 			].some(key => e.key === key);
 
-			if (isActivatingButton) {
+			if (isActivatingButton && target.type !== 'radio') {
 				this.toggleActive();
 			}
 		}
 
 		render() {
-
 			return (
 				<span
-					tabIndex={this.props.tabIndex || "0"}
+					// tabIndex={this.props.tabIndex || "0"}
 					role="button"
 					aria-pressed={this.state.isActive}
-					onKeyUp={this.onKeyUp}
+					// onKeyUp={this.onKeyUp}
 				>
 					<WrappedComponent
 						{...this.props}
+						tabIndex={this.props.tabIndex || "0"}
 						isActive={this.state.isActive}
 						toggleActive={this.toggleActive}
+						onKeyUp={this.onKeyUp}
 					/>
 				</span>
 			);

--- a/src/utils/components/__snapshots__/toggleWrapper.test.jsx.snap
+++ b/src/utils/components/__snapshots__/toggleWrapper.test.jsx.snap
@@ -1,0 +1,81 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`withLoading when this.props.type is checkbox matches snapshot 1`] = `
+<InputComponent
+  inputType="checkbox"
+>
+  <ToggleWrapper
+    isActive={false}
+    type="checkbox"
+  >
+    <ConditionalWrap
+      condition={false}
+      wrap={[Function]}
+    >
+      <input
+        checked={false}
+        inputType="checkbox"
+        onChange={[Function]}
+        onKeyUp={[Function]}
+        tabIndex="0"
+        type="checkbox"
+        value="lol nothing matters"
+      />
+    </ConditionalWrap>
+  </ToggleWrapper>
+</InputComponent>
+`;
+
+exports[`withLoading when this.props.type is not checkbox or radio matches snapshot 1`] = `
+<PlainComponent>
+  <ToggleWrapper
+    isActive={false}
+    onToggle={[Function]}
+    tabIndex={undefined}
+  >
+    <ConditionalWrap
+      condition={true}
+      wrap={[Function]}
+    >
+      <div
+        aria-pressed={false}
+        onKeyUp={[Function]}
+        role="button"
+        tabIndex="0"
+      >
+        <div
+          aria-pressed={false}
+          className="plainComponent"
+          onClick={[Function]}
+        />
+      </div>
+    </ConditionalWrap>
+  </ToggleWrapper>
+</PlainComponent>
+`;
+
+exports[`withLoading when this.props.type is radio matches snapshot 1`] = `
+<InputComponent
+  inputType="radio"
+>
+  <ToggleWrapper
+    isActive={false}
+    type="radio"
+  >
+    <ConditionalWrap
+      condition={false}
+      wrap={[Function]}
+    >
+      <input
+        checked={false}
+        inputType="radio"
+        onChange={[Function]}
+        onKeyUp={false}
+        tabIndex="0"
+        type="radio"
+        value="lol nothing matters"
+      />
+    </ConditionalWrap>
+  </ToggleWrapper>
+</InputComponent>
+`;

--- a/src/utils/components/toggleWrapper.test.jsx
+++ b/src/utils/components/toggleWrapper.test.jsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import ToggleWrapper from './ToggleWrapper';
+import ConditionalWrap from './ConditionalWrap';
+
+const PLAIN_COMPONENT_CLASS = 'plainComponent';
+
+const onToggle = jest.fn();
+
+/**
+ * @module PlainComponent
+ */
+class PlainComponent extends React.PureComponent {
+	render() {
+
+		return(
+			<ToggleWrapper
+				onToggle={onToggle}
+				tabIndex={this.props.tabIndex}
+			>
+				{({
+					tabIndex,
+					isActive,
+					toggleActive,
+					onKeyUp,
+				}) => (
+					<div
+						aria-pressed={isActive}
+						onClick={toggleActive}
+						className={PLAIN_COMPONENT_CLASS}
+						{...this.props}
+					/>
+				)}
+			</ToggleWrapper>
+		);
+	}
+}
+
+/**
+ * @module InputComponent
+ */
+class InputComponent extends React.PureComponent {
+	render() {
+		return(
+			<ToggleWrapper
+				type={this.props.inputType}
+				isActive={this.props.isActive}
+			>
+				{({
+					tabIndex,
+					isActive,
+					toggleActive,
+					onKeyUp,
+				}) => (
+					<input
+						type={this.props.inputType}
+						checked={isActive}
+						onChange={toggleActive}
+						onKeyUp={onKeyUp}
+						tabIndex={tabIndex}
+						value="lol nothing matters"
+						{...this.props}
+					/>
+				)}
+			</ToggleWrapper>
+		);
+	}
+}
+
+describe('withLoading', function() {
+	it('calls onToggle if it is passed', () => {
+		const plainComponent = mount(<PlainComponent />);
+		const plainComponentNode = plainComponent.find(`.${PLAIN_COMPONENT_CLASS}`);
+
+		expect(onToggle).not.toHaveBeenCalled();
+		plainComponentNode.simulate('click');
+		expect(onToggle).toHaveBeenCalled();
+	});
+
+	describe('when this.props.type is not checkbox or radio', () => {
+		let plainComponent, plainComponentNode;
+
+		beforeEach(() => {
+			plainComponent = mount(<PlainComponent />);
+			plainComponentNode = plainComponent.find(`.${PLAIN_COMPONENT_CLASS}`);
+		});
+		afterEach(() => {
+			plainComponent = null;
+			plainComponentNode = null;
+		});
+
+		it('matches snapshot', () => {
+			expect(plainComponent).toMatchSnapshot();
+		});
+
+		it('wraps children in an accessible wrapper component', () => {
+			const wrapperComponent = plainComponent.find(ConditionalWrap).find('[role="button"]');
+
+			expect(wrapperComponent.length).toBe(1);
+		});
+
+		it('passes props wrapper component', () => {
+			const plainComponent = mount(<PlainComponent tabIndex="1" />);
+			const wrapperComponent = plainComponent.find(ConditionalWrap).find('[role="button"]');
+
+			expect(wrapperComponent.prop('tabIndex')).toBe("1");
+		});
+
+		it('isActive state updates using child component handler', () => {
+			expect(plainComponent.find(ToggleWrapper).instance().state.isActive).toBe(false);
+			plainComponentNode.simulate('click');
+			expect(plainComponent.find(ToggleWrapper).instance().state.isActive).toBe(true);
+		});
+
+		it('isActive state updates on valid key press (Enter or Space bar)', () => {
+			expect(plainComponent.find(ToggleWrapper).instance().state.isActive).toBe(false);
+			plainComponentNode.simulate('keyUp', {key: 'Enter'});
+			expect(plainComponent.find(ToggleWrapper).instance().state.isActive).toBe(true);
+		});
+	});
+
+	describe('when this.props.type is checkbox', () => {
+		let checkboxComponent;
+
+		beforeEach(() => {
+			checkboxComponent = mount(<InputComponent inputType="checkbox" />);
+		});
+		afterEach(() => {
+			checkboxComponent = null;
+		});
+
+		it('matches snapshot', () => {
+			expect(checkboxComponent).toMatchSnapshot();
+		});
+
+		it('isActive state updates onChange', () => {
+			expect(checkboxComponent.find(ToggleWrapper).instance().state.isActive).toBe(false);
+			checkboxComponent.find('input').simulate('change');
+			expect(checkboxComponent.find(ToggleWrapper).instance().state.isActive).toBe(true);
+		});
+
+	});
+
+	describe('when this.props.type is radio', () => {
+		let radioComponent;
+
+		beforeEach(() => {
+			radioComponent = mount(<InputComponent inputType="radio" />);
+		});
+		afterEach(() => {
+			radioComponent = null;
+		});
+
+		it('matches snapshot', () => {
+			expect(radioComponent).toMatchSnapshot();
+		});
+
+		it('does not pass internal onKeyUp to children', () => {
+			const checkboxKeyUp = radioComponent.find('input').prop('onKeyUp');
+			const toggleWrapperKeyUp = radioComponent.find(ToggleWrapper).instance().onKeyUp;
+
+			expect(checkboxKeyUp == toggleWrapperKeyUp).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-191

#### Description
Radio-style `TogglePill`s are now keyboard navigable. I built a wrapper component as a part of this fix, and I created a [follow-up ticket](https://meetup.atlassian.net/browse/SDS-589) to replace `withToggleControl` usage

#### Screenshots (if applicable)
![radio_keyboardnav](https://user-images.githubusercontent.com/2313998/38960709-9ea73d1c-4333-11e8-8d6c-eaaecb1fd312.gif)

