### PR TITLE
Fix Accordion keyboard navigation

### DIFF
--- a/src/interactive/AccordionPanel.jsx
+++ b/src/interactive/AccordionPanel.jsx
@@ -71,8 +71,6 @@ class AccordionPanel extends React.Component {
 	onToggleClick(e) {
 		e.preventDefault();
 
-		// console.log(this.props.onToggleClick ? 'this.props.onToggleClick(e)' : 'this._handleToggle(e);');
-
 		this.props.onToggleClick ? this.props.onToggleClick(e) : this._handleToggle(e);
 	}
 
@@ -190,8 +188,6 @@ class AccordionPanel extends React.Component {
 					tabIndex={0}
 					onKeyUp={this.onKeyUp}
 					onClick={this.onToggleClick}
-					// onFocus={this.handleFocus}
-					// onBlur={this.handleBlur}
 				>
 					<Flex
 						className={classNames.accordionPanel}

--- a/src/interactive/AccordionPanel.jsx
+++ b/src/interactive/AccordionPanel.jsx
@@ -11,6 +11,7 @@ import ToggleSwitch from '../forms/ToggleSwitch';
 export const PANEL_CLASS = 'accordionPanel';
 export const ACTIVEPANEL_CLASS = 'accordionPanel--active';
 export const ACCORDION_LABEL_CLASS = 'accordionPanel-label';
+export const ACCORDIONPANEL_CONTENT_CLASS = 'accordionPanel-content';
 
 /**
  * @module AccordionPanel
@@ -19,6 +20,7 @@ class AccordionPanel extends React.Component {
 	constructor(props) {
 		super(props);
 		this._handleToggle = this._handleToggle.bind(this);
+		this.onKeyUp = this.onKeyUp.bind(this);
 		this.onToggleClick = this.onToggleClick.bind(this);
 		this.onTransitionEnd = this.onTransitionEnd.bind(this);
 
@@ -69,7 +71,24 @@ class AccordionPanel extends React.Component {
 	onToggleClick(e) {
 		e.preventDefault();
 
+		// console.log(this.props.onToggleClick ? 'this.props.onToggleClick(e)' : 'this._handleToggle(e);');
+
 		this.props.onToggleClick ? this.props.onToggleClick(e) : this._handleToggle(e);
+	}
+
+	/**
+	 * @description forceUpdate allows us to calculate height again now that contentEl is set
+	 * @returns {undefined}
+	 */
+	onKeyUp(e) {
+		const isActivatingButton = [
+			' ', /* space bar */
+			'Enter'
+		].some(key => e.key === key);
+
+		if (isActivatingButton) {
+			this._handleToggle(e);
+		}
 	}
 
 	/**
@@ -168,9 +187,11 @@ class AccordionPanel extends React.Component {
 					aria-expanded={isOpen}
 					aria-selected={isOpen}
 					className={classNames.trigger}
+					tabIndex={0}
+					onKeyUp={this.onKeyUp}
 					onClick={this.onToggleClick}
-					onFocus={this.handleFocus}
-					onBlur={this.handleBlur}
+					// onFocus={this.handleFocus}
+					// onBlur={this.handleBlur}
 				>
 					<Flex
 						className={classNames.accordionPanel}
@@ -213,7 +234,7 @@ class AccordionPanel extends React.Component {
 					onTransitionEnd={this.onTransitionEnd}
 				>
 					<div
-						className="accordionPanel-content"
+						className={ACCORDIONPANEL_CONTENT_CLASS}
 						ref={div => {
 							this.contentEl = div;
 						}}

--- a/src/interactive/AccordionPanel.jsx
+++ b/src/interactive/AccordionPanel.jsx
@@ -75,7 +75,7 @@ class AccordionPanel extends React.Component {
 	}
 
 	/**
-	 * @description forceUpdate allows us to calculate height again now that contentEl is set
+	 * @description allows the AccordionPanel content to be toggled with the "Enter" and "space" keys
 	 * @returns {undefined}
 	 */
 	onKeyUp(e) {

--- a/src/interactive/__snapshots__/accordionPanel.test.jsx.snap
+++ b/src/interactive/__snapshots__/accordionPanel.test.jsx.snap
@@ -9,7 +9,9 @@ exports[`AccordionPanel Panel basic behavior exists and renders with mock props 
     className="accordionPanel-label display--block span--100"
     id="label-firstsection"
     onClick={[Function]}
+    onKeyUp={[Function]}
     role="tab"
+    tabIndex={0}
   >
     <Flex
       className="padding--bottom padding--top accordionPanel"
@@ -67,7 +69,9 @@ exports[`AccordionPanel Panel with custom icon exists and renders a custom icon 
     className="accordionPanel-label display--block span--100"
     id="label-firstsection"
     onClick={[Function]}
+    onKeyUp={[Function]}
     role="tab"
+    tabIndex={0}
   >
     <Flex
       className="padding--bottom padding--top accordionPanel"
@@ -140,10 +144,10 @@ exports[`AccordionPanel Panel with right aligned icon exists and renders icon le
       aria-selected={false}
       className="accordionPanel-label display--block span--100"
       id="label-firstsection"
-      onBlur={undefined}
       onClick={[Function]}
-      onFocus={undefined}
+      onKeyUp={[Function]}
       role="tab"
+      tabIndex={0}
     >
       <Flex
         className="padding--bottom padding--top accordionPanel"
@@ -304,10 +308,10 @@ exports[`AccordionPanel Panel with toggle switch exists and renders a toggle swi
       aria-selected={false}
       className="accordionPanel-label display--block span--100"
       id="label-firstsection"
-      onBlur={undefined}
       onClick={[Function]}
-      onFocus={undefined}
+      onKeyUp={[Function]}
       role="tab"
+      tabIndex={0}
     >
       <Flex
         className="padding--bottom padding--top accordionPanel"

--- a/src/interactive/__snapshots__/accordionPanelGroup.test.jsx.snap
+++ b/src/interactive/__snapshots__/accordionPanelGroup.test.jsx.snap
@@ -111,10 +111,10 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable gives panels a
             aria-selected={true}
             className="accordionPanel-label display--block span--100"
             id="label-firstsection"
-            onBlur={undefined}
             onClick={[Function]}
-            onFocus={undefined}
+            onKeyUp={[Function]}
             role="tab"
+            tabIndex={0}
           >
             <Flex
               className="padding--bottom padding--top accordionPanel accordionPanel--active"
@@ -296,10 +296,10 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable gives panels a
             aria-selected={false}
             className="accordionPanel-label display--block span--100"
             id="label-nextsection"
-            onBlur={undefined}
             onClick={[Function]}
-            onFocus={undefined}
+            onKeyUp={[Function]}
             role="tab"
+            tabIndex={0}
           >
             <Flex
               className="padding--bottom padding--top accordionPanel"
@@ -481,10 +481,10 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable gives panels a
             aria-selected={false}
             className="accordionPanel-label display--block span--100"
             id="label-thirdsection"
-            onBlur={undefined}
             onClick={[Function]}
-            onFocus={undefined}
+            onKeyUp={[Function]}
             role="tab"
+            tabIndex={0}
           >
             <Flex
               className="padding--bottom padding--top accordionPanel"
@@ -734,10 +734,10 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable renders panels
             aria-selected={true}
             className="accordionPanel-label display--block span--100"
             id="label-firstsection"
-            onBlur={undefined}
             onClick={[Function]}
-            onFocus={undefined}
+            onKeyUp={[Function]}
             role="tab"
+            tabIndex={0}
           >
             <Flex
               className="padding--bottom padding--top accordionPanel accordionPanel--active"
@@ -919,10 +919,10 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable renders panels
             aria-selected={false}
             className="accordionPanel-label display--block span--100"
             id="label-nextsection"
-            onBlur={undefined}
             onClick={[Function]}
-            onFocus={undefined}
+            onKeyUp={[Function]}
             role="tab"
+            tabIndex={0}
           >
             <Flex
               className="padding--bottom padding--top accordionPanel"
@@ -1104,10 +1104,10 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable renders panels
             aria-selected={false}
             className="accordionPanel-label display--block span--100"
             id="label-thirdsection"
-            onBlur={undefined}
             onClick={[Function]}
-            onFocus={undefined}
+            onKeyUp={[Function]}
             role="tab"
+            tabIndex={0}
           >
             <Flex
               className="padding--bottom padding--top accordionPanel"

--- a/src/interactive/accordion.story.jsx
+++ b/src/interactive/accordion.story.jsx
@@ -329,19 +329,4 @@ storiesOf('Accordion', module)
 					]}/>
 			</div>
 		)
-	)
-	.addWithInfo(
-		'Standalone AccordionPanel',
-		'An AccordionPanel can be used outside an AccordionPanelGroup as a simple summary/detail component',
-		() => (
-			<div className='span--100 padding--all'>
-				<AccordionPanel
-					label='Trigger label'
-					panelContent={
-						<div className='runningText'>
-							<p>Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.</p>
-						</div>
-					} />
-			</div>
-		)
 	);

--- a/src/interactive/accordionPanel.test.jsx
+++ b/src/interactive/accordionPanel.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 
-import AccordionPanel, { ACTIVEPANEL_CLASS } from './AccordionPanel';
+import AccordionPanel, { ACTIVEPANEL_CLASS, ACCORDIONPANEL_CONTENT_CLASS } from './AccordionPanel';
 import Icon from '../media/Icon';
 import ToggleSwitch from '../forms/ToggleSwitch';
 
@@ -18,8 +18,6 @@ describe('AccordionPanel', function() {
 	beforeEach(() => {
 		panelStateCallback = jest.fn();
 		onClickCallback = jest.fn();
-
-		jest.spyOn(AccordionPanel.prototype, 'getPanelStyle').mockImplementation(() => {});
 
 		panel = shallow(
 			<AccordionPanel
@@ -64,26 +62,35 @@ describe('AccordionPanel', function() {
 		});
 
 		it('calls setPanelState callback onClick', function() {
-			const btn = panel.find('button');
+			const accPanel = panel.find('[role="tab"]');
 			const isOpen = panel.prop('isOpen');
+			const panelContent = panel.find(`.${ACCORDIONPANEL_CONTENT_CLASS}`);
+			const getPanelStyle = panel.instance().getPanelStyle;
 
-			setTimeout(() => {
-				expect(panelStateCallback).not.toHaveBeenCalled();
-				btn.simulate('click', { target: panel, preventDefault: jest.fn(), stopPropagation: jest.fn() });
-				expect(panelStateCallback).toHaveBeenCalledWith(panel.prop('clickId'), !isOpen);
-			}, 1);
+			expect(panelStateCallback).not.toHaveBeenCalled();
+			accPanel.simulate('click', { target: accPanel, preventDefault: jest.fn(), stopPropagation: jest.fn() });
+			expect(panelStateCallback).toHaveBeenCalledWith(panel.prop('clickId'), !isOpen, getPanelStyle(isOpen, panelContent));
+		});
+
+		it('calls setPanelState callback onKeyUp', function() {
+			const accPanel = panel.find('[role="tab"]');
+			const isOpen = panel.prop('isOpen');
+			const panelContent = panel.find(`.${ACCORDIONPANEL_CONTENT_CLASS}`);
+			const getPanelStyle = panel.instance().getPanelStyle;
+
+			expect(panelStateCallback).not.toHaveBeenCalled();
+			accPanel.simulate('keyUp', {key: 'Enter', preventDefault: jest.fn()});
+			expect(panelStateCallback).toHaveBeenCalledWith(panel.prop('clickId'), !isOpen, getPanelStyle(isOpen, panelContent));
 		});
 
 		it('calls onClickCallback onClick', function() {
-			const btn = panel.find('button');
+			const accPanel = panel.find('[role="tab"]');
 			const isOpen = panel.prop('isOpen');
 			const fakeEvent = { target: panel, preventDefault: jest.fn(), stopPropagation: jest.fn() };
 
-			setTimeout(() => {
-				expect(onClickCallback).not.toHaveBeenCalled();
-				btn.simulate('click', fakeEvent);
-				expect(onClickCallback).toHaveBeenCalledWith(fakeEvent, !isOpen);
-			}, 1);
+			expect(onClickCallback).not.toHaveBeenCalled();
+			accPanel.simulate('click', fakeEvent);
+			expect(onClickCallback).toHaveBeenCalledWith(fakeEvent, !isOpen);
 		});
 
 


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-588

#### Description
Focus styles are visible again, and panels can be toggled using the keyboard. Also did a little cleanup, especially in tests.

#### Screenshots (if applicable)
![screen shot 2018-04-24 at 2 30 38 pm](https://user-images.githubusercontent.com/2313998/39206702-2042d2d6-47cc-11e8-8bd6-0d7fff894bdb.png)

