### PR TITLE
Address Typeahead selection issues when clicking an item

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "autosize": "3.0.21",
-    "downshift": "1.31.2",
+    "downshift": "1.31.12",
     "file-loader": "1.1.8",
     "focus-trap-react": "3.1.2",
     "lint-staged": "7.0.0",

--- a/src/forms/Typeahead.jsx
+++ b/src/forms/Typeahead.jsx
@@ -12,54 +12,6 @@ export const TA_ITEM_CLASSNAME = 'typeahead-item';
  * @module Typeahead
  */
 class Typeahead extends React.PureComponent {
-	constructor(props) {
-		super(props);
-		this.onItemMouseEnter = this.onItemMouseEnter.bind(this);
-		this.stateReducer = this.stateReducer.bind(this);
-
-		this.state = {
-			highlightedIndex: -1
-		};
-	}
-
-	onItemMouseEnter (i) {
-		this.setState({highlightedIndex: i});
-	}
-
-	stateReducer(state, changes) {
-		let highlightedIndexState;
-
-		switch (changes.type) {
-			case Downshift.stateChangeTypes.keyDownArrowDown:
-				highlightedIndexState =
-					parseInt(this.state.highlightedIndex + 1) >= this.props.items.length
-						?
-							0
-						:
-							parseInt(this.state.highlightedIndex+1);
-					this.setState({
-						highlightedIndex: highlightedIndexState
-					});
-				break;
-			case Downshift.stateChangeTypes.keyDownArrowUp:
-				highlightedIndexState =
-					this.state.highlightedIndex < 1
-						?
-							parseInt(this.props.items.length-1)
-						:
-							parseInt(this.state.highlightedIndex-1);
-					this.setState({
-						highlightedIndex: highlightedIndexState
-					});
-				break;
-		}
-
-		return {
-			...changes,
-			highlightedIndex: highlightedIndexState
-		};
-
-	}
 
 	render() {
 		const {
@@ -70,14 +22,12 @@ class Typeahead extends React.PureComponent {
 		} = this.props;
 
 		return (
-			<Downshift
-				stateReducer={this.stateReducer}
-				{...other}
-			>
+			<Downshift {...other}>
 				{({
 					getInputProps,
 					getItemProps,
 					isOpen,
+					highlightedIndex
 				}) =>
 				(<div className="typeahead">
 					<TextInput
@@ -101,14 +51,13 @@ class Typeahead extends React.PureComponent {
 											{...getItemProps({
 												item: item.props.value,
 												i,
-												key: `typeaheadItem-${i}-${Date.now()}`,
-												id: `typeaheadItem-${i}-${Date.now()}`,
-												onMouseMove: () => {this.onItemMouseEnter(i);},
+												key: `typeaheadItem-${i}`,
+												id: `typeaheadItem-${i}`,
 												className: cx(
 													TA_ITEM_CLASSNAME,
 													item.props.className,
 													{
-														'typeahead-item--isActive': this.state.highlightedIndex == i,
+														'typeahead-item--isActive': highlightedIndex == i,
 													}
 												)
 											})}

--- a/src/forms/typeahead.story.jsx
+++ b/src/forms/typeahead.story.jsx
@@ -88,18 +88,6 @@ storiesOf("Typeahead", module)
 		)
 	)
 	.addWithInfo(
-		"with label",
-		() => (
-			<Typeahead
-				items={typeaheadItems}
-				inputProps={{
-					label: 'Labeled typeahead',
-					name: 'typeaheadInputName'
-				}}
-			/>
-		)
-	)
-	.addWithInfo(
 		"with helperText",
 		() => (
 			<Typeahead

--- a/src/forms/typeahead.test.jsx
+++ b/src/forms/typeahead.test.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Downshift from 'downshift';
 import { shallow, mount } from 'enzyme';
 
 import Typeahead, {
@@ -72,34 +71,6 @@ describe('Typeahead', () => {
 
 	it('should render `items` passed in', () => {
 		expect(dropdownArea.find(`.${TA_ITEM_CLASSNAME}`).length).toBe(TA_ITEMS.length);
-	});
-
-	it('should update state on keyDownArrowDown', () => {
-		expect(openComponent.state('highlightedIndex')).toBe(-1);
-		openComponent.instance().stateReducer({}, {type: Downshift.stateChangeTypes.keyDownArrowDown});
-		expect(openComponent.state('highlightedIndex')).toBe(0);
-
-		// test whether it moves select to the beginning of the list
-		dropdownArea.find(`.${TA_ITEM_CLASSNAME}`).forEach(()=>{
-			openComponent.instance().stateReducer({}, {type: Downshift.stateChangeTypes.keyDownArrowDown});
-		});
-		expect(openComponent.state('highlightedIndex')).toBe(0);
-	});
-
-	it('should update state on keyDownArrowUp', () => {
-		openComponent.instance().stateReducer({}, {type: Downshift.stateChangeTypes.keyDownArrowDown});
-		expect(openComponent.state('highlightedIndex')).toBe(1);
-		openComponent.instance().stateReducer({}, {type: Downshift.stateChangeTypes.keyDownArrowUp});
-		expect(openComponent.state('highlightedIndex')).toBe(0);
-
-		// test whether it moves select to the end of the list
-		openComponent.instance().stateReducer({}, {type: Downshift.stateChangeTypes.keyDownArrowUp});
-		expect(openComponent.state('highlightedIndex')).toBe(dropdownArea.find(`.${TA_ITEM_CLASSNAME}`).length - 1);
-	});
-
-	it('should update state on mouseMove', () => {
-		dropdownArea.find(`.${TA_ITEM_CLASSNAME}`).first().simulate('mouseMove');
-		expect(openComponent.state('highlightedIndex')).toBe(0);
 	});
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3216,9 +3216,9 @@ dotenv@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-5.0.1.tgz#a5317459bd3d79ab88cff6e44057a6a3fbb1fcef"
 
-downshift@1.31.2:
-  version "1.31.2"
-  resolved "https://registry.yarnpkg.com/downshift/-/downshift-1.31.2.tgz#6f638e9720d7540d9dffa0b4c4587cf10811cf8c"
+downshift@1.31.12:
+  version "1.31.12"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-1.31.12.tgz#78be425583234f18774fc37643eba17a776a91db"
 
 duplexer3@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/MG-1159

#### Description
This bug is hard to reproduce, but sometimes clicking a Typeahead item would not update the selected item. I've had luck reproducing in Safari with lots of reloading.
These changes may bring back an issue where hovering a TypeaheadItem that was added after mount doesn't get a visual hover state, but I was unable to reproduce using `setTimeout` to add new items.

#### Screenshots (if applicable)
https://giphy.com/gifs/mobile-test-case-orTE5JSA9j0rh5JLCu
