### PR TITLE
Fix TypeaheadItem PropType warning

### DIFF
--- a/src/forms/TypeaheadItem.jsx
+++ b/src/forms/TypeaheadItem.jsx
@@ -10,7 +10,7 @@ export default TypeaheadItem;
 TypeaheadItem.propTypes = {
 	value: PropTypes.oneOfType([
 		PropTypes.string,
-		PropTypes.element,
+		PropTypes.array,
 		PropTypes.object
 	]).isRequired,
 	className: PropTypes.string,

--- a/src/forms/TypeaheadItem.jsx
+++ b/src/forms/TypeaheadItem.jsx
@@ -8,7 +8,11 @@ const TypeaheadItem = ({value, className, children}) => children;
 export default TypeaheadItem;
 
 TypeaheadItem.propTypes = {
-	value: PropTypes.string.isRequired,
+	value: PropTypes.oneOfType([
+		PropTypes.string,
+		PropTypes.element,
+		PropTypes.object
+	]).isRequired,
 	className: PropTypes.string,
 	children: PropTypes.node.isRequired
 };

--- a/src/forms/typeahead.test.jsx
+++ b/src/forms/typeahead.test.jsx
@@ -23,13 +23,13 @@ const TA_ITEMS = [
 			<p>Is super cool</p>
 		</div>
 	</TypeaheadItem>,
-	<TypeaheadItem value="Item Three">
+	<TypeaheadItem value={[{text: "Item Three"}]}>
 		<div>
 			<h3 className="text--bold">Item Three</h3>
 			<p>Is super cool</p>
 		</div>
 	</TypeaheadItem>,
-	<TypeaheadItem value="Item Four">
+	<TypeaheadItem value={{text: "Item Four"}}>
 		<div>
 			<h3 className="text--bold">Item Four</h3>
 			<p>Is super cool</p>


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-224

#### Description
Updated PropType for `TypeaheadItem`'s value prop

#### Screenshots (if applicable)
Tested with an object and got no warnings:
<img width="448" alt="screen shot 2018-05-03 at 12 27 03 pm" src="https://user-images.githubusercontent.com/2313998/39589895-6e7aaf48-4ecd-11e8-9aed-c117fa5b5285.png">
<img width="378" alt="screen shot 2018-05-03 at 12 27 48 pm" src="https://user-images.githubusercontent.com/2313998/39589900-70b96952-4ecd-11e8-9f51-a0f915075b9b.png">

