### PR TITLE
Get rid of `itemsToString` warnings

### DIFF
--- a/src/forms/Typeahead.jsx
+++ b/src/forms/Typeahead.jsx
@@ -8,6 +8,8 @@ import TextInput from './TextInput';
 export const TA_DROPDOWN_CLASSNAME = 'typeahead-dropdown';
 export const TA_ITEM_CLASSNAME = 'typeahead-item';
 
+const defaultItemToString = itemValue => (typeof itemValue === 'string' ? itemValue : '');
+
 /**
  * @module Typeahead
  */
@@ -18,11 +20,15 @@ class Typeahead extends React.PureComponent {
 			inputProps,
 			height,
 			items,
+			itemToString,
 			...other
 		} = this.props;
 
 		return (
-			<Downshift {...other}>
+			<Downshift
+				itemToString={itemToString}
+				{...other}
+			>
 				{({
 					getInputProps,
 					getItemProps,
@@ -74,9 +80,14 @@ class Typeahead extends React.PureComponent {
 	}
 }
 
+Typeahead.defaultProps = {
+	itemToString: defaultItemToString
+};
+
 Typeahead.propTypes = {
 	inputProps: PropTypes.object,
 	items: PropTypes.arrayOf(PropTypes.element),
+	itemToString: PropTypes.func,
 	height: PropTypes.string
 };
 

--- a/src/forms/typeahead.story.jsx
+++ b/src/forms/typeahead.story.jsx
@@ -32,6 +32,33 @@ const typeaheadItems = [
 	</TypeaheadItem>
 ];
 
+const typeaheadItemsObjValues = [
+	<TypeaheadItem value={{name: "Item One", id: 0}}>
+		<div>
+			<h3 className="text--bold">Item One</h3>
+			<p>Is super cool</p>
+		</div>
+	</TypeaheadItem>,
+	<TypeaheadItem value={{name: "Item Two", id: 1}}>
+		<div>
+			<h3 className="text--bold">Item Two</h3>
+			<p>Is super cool</p>
+		</div>
+	</TypeaheadItem>,
+	<TypeaheadItem value={{name: "Item Three", id: 2}}>
+		<div>
+			<h3 className="text--bold">Item Three</h3>
+			<p>Is super cool</p>
+		</div>
+	</TypeaheadItem>,
+	<TypeaheadItem value={{name: "Item Four", id: 3}}>
+		<div>
+			<h3 className="text--bold">Item Four</h3>
+			<p>Is super cool</p>
+		</div>
+	</TypeaheadItem>
+];
+
 storiesOf("Typeahead", module)
 	.addDecorator(decorateWithBasics)
 	.addWithInfo(
@@ -159,6 +186,19 @@ storiesOf("Typeahead", module)
 				items={typeaheadItems}
 				inputProps={{
 					iconShape: 'search',
+					label: 'Labeled typeahead',
+					name: 'typeaheadInputName'
+				}}
+			/>
+		)
+	)
+	.addWithInfo(
+		"using itemToString (useful for value as Object)",
+		() => (
+			<Typeahead
+				items={typeaheadItemsObjValues}
+				itemToString={i => i ? i.name : ''}
+				inputProps={{
 					label: 'Labeled typeahead',
 					name: 'typeaheadInputName'
 				}}

--- a/src/forms/typeahead.test.jsx
+++ b/src/forms/typeahead.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
+import Downshift from 'downshift';
 
 import Typeahead, {
 	TA_DROPDOWN_CLASSNAME,
@@ -30,6 +31,33 @@ const TA_ITEMS = [
 		</div>
 	</TypeaheadItem>,
 	<TypeaheadItem value={{text: "Item Four"}}>
+		<div>
+			<h3 className="text--bold">Item Four</h3>
+			<p>Is super cool</p>
+		</div>
+	</TypeaheadItem>
+];
+
+const TA_ITEMS_OBJ_VALUES = [
+	<TypeaheadItem value={{name: "Item One", id: 0}}>
+		<div>
+			<h3 className="text--bold">Item One</h3>
+			<p>Is super cool</p>
+		</div>
+	</TypeaheadItem>,
+	<TypeaheadItem value={{name: "Item Two", id: 1}}>
+		<div>
+			<h3 className="text--bold">Item Two</h3>
+			<p>Is super cool</p>
+		</div>
+	</TypeaheadItem>,
+	<TypeaheadItem value={{name: "Item Three", id: 2}}>
+		<div>
+			<h3 className="text--bold">Item Three</h3>
+			<p>Is super cool</p>
+		</div>
+	</TypeaheadItem>,
+	<TypeaheadItem value={{name: "Item Four", id: 3}}>
 		<div>
 			<h3 className="text--bold">Item Four</h3>
 			<p>Is super cool</p>
@@ -71,6 +99,37 @@ describe('Typeahead', () => {
 
 	it('should render `items` passed in', () => {
 		expect(dropdownArea.find(`.${TA_ITEM_CLASSNAME}`).length).toBe(TA_ITEMS.length);
+	});
+
+	it('should set value to empty string if value passed is not a string and no itemToString prop is provided', () => {
+		const openComponentObjValues = mount(
+			<Typeahead
+				isOpen
+				items={TA_ITEMS_OBJ_VALUES}
+				inputProps={{name: INPUT_NAME}}
+			/>
+		);
+		const dropdownArea = openComponentObjValues.find(`.${TA_DROPDOWN_CLASSNAME}`);
+
+		dropdownArea.find(`.${TA_ITEM_CLASSNAME}`).first().simulate('click');
+		expect(openComponentObjValues.find(Downshift).instance().state.inputValue.length).toBe(0);
+	});
+
+	it('should set correct value if itemToString prop is provided', () => {
+		const openComponentObjValues = mount(
+			<Typeahead
+				isOpen
+				items={TA_ITEMS_OBJ_VALUES}
+				itemToString={i => i ? i.name : ''}
+				inputProps={{name: INPUT_NAME}}
+			/>
+		);
+		const dropdownArea = openComponentObjValues.find(`.${TA_DROPDOWN_CLASSNAME}`);
+		const firstItem = dropdownArea.find(`.${TA_ITEM_CLASSNAME}`).first();
+		const firstItemVal = TA_ITEMS_OBJ_VALUES[0].props.value;
+
+		firstItem.simulate('click');
+		expect(openComponentObjValues.find(Downshift).instance().state.inputValue).toBe(firstItemVal.name);
 	});
 });
 


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-595

#### Description
Passed a default `itemsToString` function to handle warnings from Downshift for TypeaheadItem values that are not strings.

#### Screenshots (if applicable)

