### PR TITLE
Ensure Dropdowns and Tooltips are not clipped by the viewport

### DIFF
--- a/src/interactive/Dropdown.jsx
+++ b/src/interactive/Dropdown.jsx
@@ -130,6 +130,10 @@ class Dropdown extends React.PureComponent {
 			return this.triggerRef;
 		};
 
+		const getContent = () => {
+			return this.contentRef;
+		};
+
 		return (
 			<Downshift
 				menuItems={menuItems}
@@ -162,12 +166,14 @@ class Dropdown extends React.PureComponent {
 							{ isOpen &&
 								<FloatingPosition
 									getTrigger={getTrigger}
+									getContent={getContent}
 									noPortal={noPortal}
 									align={align}
 								>
 									{({
 										top,
-										left
+										left,
+										align
 									}) => (
 										<div
 											ref={el => (this.contentRef = el)}

--- a/src/interactive/Tooltip.jsx
+++ b/src/interactive/Tooltip.jsx
@@ -116,7 +116,8 @@ class Tooltip extends React.PureComponent {
 					>
 						{({
 							top,
-							left
+							left,
+							align
 						}) => (
 							<div
 								ref={el => (this.contentRef = el)}

--- a/src/interactive/dropdown.story.jsx
+++ b/src/interactive/dropdown.story.jsx
@@ -165,4 +165,31 @@ storiesOf("Dropdown", module)
 				<DropdownWithToggle />
 			</FlexItem>
 		</Flex>
-	));
+	))
+	.addWithInfo(
+		"Overflowing viewport",
+		"Aligned right by default, but switches to left",
+		() => (
+			<div
+				style={{
+					textAlign: 'left',
+					width: '100vw'
+				}}
+			>
+				<Dropdown
+					minWidth="0"
+					maxWidth="384px"
+					align="right"
+					trigger={<Button small>Open</Button>}
+					content={
+						<div className="runningText padding--all">
+							<p>
+								This Dropdown component's `align` prop is set to 'right', but because
+								it would overflow the viewport, it gets switched to 'left'
+							</p>
+						</div>
+					}
+				/>
+			</div>
+		)
+	);

--- a/src/interactive/tooltip.story.jsx
+++ b/src/interactive/tooltip.story.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from '@storybook/react';
-import { decorateWithBasics } from "../utils/decorators";
+// import { decorateWithBasics } from "../utils/decorators";
 import Tooltip from "./Tooltip";
 import Button from "../forms/Button";
 
@@ -53,7 +53,7 @@ class ManualToggleDropdown extends React.PureComponent {
 }
 
 storiesOf("Tooltip", module)
-	.addDecorator(decorateWithBasics)
+	// .addDecorator(decorateWithBasics)
 	.addWithInfo(
 		"Basic Tooltip component",
 		"Aligned right by default",
@@ -81,14 +81,7 @@ storiesOf("Tooltip", module)
 		"Tooltip above trigger",
 		"Aligned right and appearing above the trigger",
 		() => (
-			<div
-				style={{
-					marginTop: "800px",
-					width: "500px",
-					height: "1000px",
-					marginLeft: "600px"
-				}}
-			>
+			<div style={{textAlign: 'center'}}>
 				<Tooltip
 					direction="top"
 					minWidth="0"
@@ -105,14 +98,7 @@ storiesOf("Tooltip", module)
 		"Opened Tooltip component",
 		"Aligned center and opened by default",
 		() => (
-			<div
-				style={{
-					marginTop: "800px",
-					width: "500px",
-					height: "1000px",
-					marginLeft: "600px"
-				}}
-			>
+			<div style={{textAlign: 'center'}}>
 				<Tooltip
 					isActive
 					minWidth="0"
@@ -129,43 +115,49 @@ storiesOf("Tooltip", module)
 		"Tooltip component (no Portal)",
 		"Use the `noPortal` prop to decide whether a the content should render in document body",
 		() => (
-			<Tooltip
-				noPortal
-				minWidth="0"
-				maxWidth="384px"
-				align="right"
-				id="testTooltip"
-				trigger={<Button small>Open</Button>}
-				content={dropdownContent}
-			/>
+			<div style={{textAlign: 'center'}}>
+				<Tooltip
+					noPortal
+					minWidth="0"
+					maxWidth="384px"
+					align="right"
+					id="testTooltip"
+					trigger={<Button small>Open</Button>}
+					content={dropdownContent}
+				/>
+			</div>
 		)
 	)
 	.addWithInfo(
 		"Left aligned tooltip",
 		"Use the `align` prop to change alignment to left",
 		() => (
-			<Tooltip
-				align="left"
-				minWidth="0"
-				maxWidth="384px"
-				id="testTooltip"
-				trigger={<Button small>Open</Button>}
-				content={dropdownContent}
-			/>
+			<div style={{textAlign: 'center'}}>
+				<Tooltip
+					align="left"
+					minWidth="0"
+					maxWidth="384px"
+					id="testTooltip"
+					trigger={<Button small>Open</Button>}
+					content={dropdownContent}
+				/>
+			</div>
 		)
 	)
 	.addWithInfo(
 		"Center aligned tooltip",
 		"Use the `align` prop to change alignment to left",
 		() => (
-			<Tooltip
-				align="center"
-				minWidth="0"
-				maxWidth="384px"
-				id="testTooltip"
-				trigger={<Button small>Open</Button>}
-				content={dropdownContent}
-			/>
+			<div style={{textAlign: 'center'}}>
+				<Tooltip
+					align="center"
+					minWidth="0"
+					maxWidth="384px"
+					id="testTooltip"
+					trigger={<Button small>Open</Button>}
+					content={dropdownContent}
+				/>
+			</div>
 		)
 	)
 	.addWithInfo(
@@ -173,5 +165,29 @@ storiesOf("Tooltip", module)
 		"rely on the `isActive` prop to open and close the tooltip",
 		() => (
 			<ManualToggleDropdown/>
+		)
+	)
+	.addWithInfo(
+		"Overflowing viewport",
+		"Aligned right by default, but switches to left",
+		() => (
+			<div style={{textAlign: 'left'}}>
+				<Tooltip
+					isActive
+					minWidth="0"
+					maxWidth="384px"
+					align="right"
+					id="testTooltip"
+					trigger={<Button small>Open</Button>}
+					content={
+						<div className="runningText padding--all">
+							<p>
+								This Tooltip component's `align` prop is set to 'right', but because
+								it would overflow the viewport, it gets switched to 'left'
+							</p>
+						</div>
+					}
+				/>
+			</div>
 		)
 	);

--- a/src/interactive/tooltip.story.jsx
+++ b/src/interactive/tooltip.story.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { storiesOf } from '@storybook/react';
-// import { decorateWithBasics } from "../utils/decorators";
 import Tooltip from "./Tooltip";
 import Button from "../forms/Button";
 
@@ -53,7 +52,6 @@ class ManualToggleDropdown extends React.PureComponent {
 }
 
 storiesOf("Tooltip", module)
-	// .addDecorator(decorateWithBasics)
 	.addWithInfo(
 		"Basic Tooltip component",
 		"Aligned right by default",

--- a/src/utils/components/FloatingPosition.jsx
+++ b/src/utils/components/FloatingPosition.jsx
@@ -5,6 +5,32 @@ import rafSchedule from 'raf-schd';
 
 import ConditionalWrap from './ConditionalWrap';
 
+export const getAdjustedAlignment = (
+	preferredAlignment,
+	triggerPositionData,
+	contentWidth,
+	viewportWidth
+) => {
+	const {
+		left,
+		width,
+	} = triggerPositionData;
+	const overflowLeft = left + contentWidth > viewportWidth;
+	const overflowRight = (left + width) - contentWidth < 0;
+
+	// if overflows viewport on the right side, go left
+	if (overflowRight && !overflowLeft) {
+		return 'left';
+	// if overflows viewport on the left side, go right
+	} else if (overflowLeft && !overflowRight) {
+		return 'right';
+	// but if there's no overflow OR there's overflow on
+	// both sides, just use whatever alignment was passed
+	} else {
+		return preferredAlignment;
+	}
+};
+
 /**
  * @module FloatingPosition
  */
@@ -46,31 +72,17 @@ class FloatingPosition extends React.PureComponent {
 			width,
 			height
 		} = positionData;
-		const getAdjustedAlignment = alignment => {
-			const overflowLeft = left + contentWidth > window.innerWidth;
-			const overflowRight = (left + width) - contentWidth < 0;
-
-			// if of viewport on the left side, go right
-			if (overflowRight && !overflowLeft) {
-				return 'left';
-			// if of viewport on the right side, go left
-			} else if (overflowLeft && !overflowRight) {
-				return 'right';
-			// but if there's no overflow OR there's overflow on
-			// both sides, just use whatever alignment was passed
-			} else {
-				return alignment;
-			}
-		};
 
 		const getLeftPos = (alignment, noPortal) => {
+			const adjustedAlignment = getAdjustedAlignment(alignment, positionData, contentWidth, window.innerWidth);
+
 			if (!noPortal) {
 
 				this.setState(() => ({
-					align: getAdjustedAlignment(alignment)
+					align: adjustedAlignment
 				}));
 
-				switch (getAdjustedAlignment(alignment)) {
+				switch (adjustedAlignment) {
 					case 'left':
 						return `${left + scrollLeft}px`;
 					case 'center':

--- a/src/utils/components/floatingPosition.test.jsx
+++ b/src/utils/components/floatingPosition.test.jsx
@@ -47,4 +47,12 @@ describe('FloatingPosition', function() {
 
 		expect(actual).toBe(expected);
 	});
+
+	it('does not adjust popup content position if it fits in the viewport', () => {
+		const MOCK_POSITION_DATA = {left: 500, width: 70};
+		const expected = 'right';
+		const actual = getAdjustedAlignment('right', MOCK_POSITION_DATA, 384, 1000);
+
+		expect(actual).toBe(expected);
+	});
 });

--- a/src/utils/components/floatingPosition.test.jsx
+++ b/src/utils/components/floatingPosition.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import FloatingPosition from './FloatingPosition';
+import FloatingPosition, { getAdjustedAlignment } from './FloatingPosition';
 
 /**
  * @module TestComponent
@@ -38,5 +38,13 @@ describe('FloatingPosition', function() {
 
 	it('matches snapshot', () => {
 		expect(floatingPosition).toMatchSnapshot();
+	});
+
+	it('adjusts popup content position if it overflows the viewport', () => {
+		const MOCK_POSITION_DATA = {left: 0, width: 70};
+		const expected = 'left';
+		const actual = getAdjustedAlignment('right', MOCK_POSITION_DATA, 384, 1000);
+
+		expect(actual).toBe(expected);
 	});
 });


### PR DESCRIPTION
Re Prelim label:
~Still need to add tests~

#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-225

#### Description
Added functionality to `FloatingPosition` to reposition popup content if it overflows the viewport

#### Screenshots (if applicable)
![screen shot 2018-05-07 at 1 41 04 pm](https://user-images.githubusercontent.com/2313998/39715785-5965c480-51fc-11e8-96c8-0210598f4200.png)

