### PR TITLE
Typeahead with menu that opens in document-flow

### DIFF
--- a/assets/scss/components/_typeahead.scss
+++ b/assets/scss/components/_typeahead.scss
@@ -17,6 +17,10 @@
 	z-index: map-get($zindex-map, "floating-content")
 }
 
+.typeahead-dropdown--inline {
+	position: relative;
+}
+
 .typeahead-item {
 	cursor: pointer;
 	padding: $space-half $space;

--- a/src/forms/Typeahead.jsx
+++ b/src/forms/Typeahead.jsx
@@ -11,7 +11,7 @@ export const TA_ITEM_CLASSNAME = 'typeahead-item';
 const defaultItemToString = itemValue => (typeof itemValue === 'string' ? itemValue : '');
 
 /**
- * @module Typeahead
+ * @module typeahead
  */
 class Typeahead extends React.PureComponent {
 	constructor(props) {
@@ -73,6 +73,7 @@ class Typeahead extends React.PureComponent {
 			multiSelectValues,
 			openOnFocus,
 			openOnSelect,
+			openInline,
 			itemToString,
 			onSelect, // eslint-disable-line no-unused-vars
 			...other
@@ -105,7 +106,12 @@ class Typeahead extends React.PureComponent {
 					{Boolean(isOpen && items && items.length)
 						&&
 							<div
-								className={TA_DROPDOWN_CLASSNAME}
+								className={cx(
+									TA_DROPDOWN_CLASSNAME,
+									{
+										[`${TA_DROPDOWN_CLASSNAME}--inline`] : openInline
+									}
+								)}
 								style={height && {
 									height: height,
 									overflowY: 'scroll'
@@ -161,6 +167,7 @@ Typeahead.propTypes = {
 	multiSelect: PropTypes.bool,
 	openOnFocus: PropTypes.bool,
 	openOnSelect: PropTypes.bool,
+	openInline: PropTypes.bool,
 	onSelect: (props, propName, componentName) => {
 		if (props['multiSelect'] && !props[propName]) {
 			return new Error(

--- a/src/forms/typeahead.story.jsx
+++ b/src/forms/typeahead.story.jsx
@@ -299,6 +299,22 @@ storiesOf("Typeahead", module)
 		)
 	)
 	.addWithInfo(
+		"openInline",
+		() => (
+			<div>
+				<Typeahead
+					openInline
+					items={typeaheadItems}
+					inputProps={{
+						label: 'Labeled typeahead',
+						name: 'typeaheadInputName'
+					}}
+				/>
+				<p>The menu will not hide this text</p>
+			</div>
+		)
+	)
+	.addWithInfo(
 		"using itemToString (useful for value as Object)",
 		() => (
 			<Typeahead


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-227

#### Description
Added a prop to Typeahead that lets the menu open in document flow instead of appearing above things

#### Screenshots (if applicable)
![typeaheadinline](https://user-images.githubusercontent.com/2313998/40008968-b1b4b840-576e-11e8-957b-819fecd7613d.gif)

