### PR TITLE
pass along date string and instance

### DIFF
--- a/src/forms/CalendarComponent.jsx
+++ b/src/forms/CalendarComponent.jsx
@@ -28,8 +28,8 @@ export class CalendarComponent extends React.Component {
 	 * `redux-form` however, expects a single value. This function ensures that any `onChange`
 	 * prop passed to this component invokes with a single date object.
 	 */
-	onFlatPickerChange(selectedDates) {
-		this.props.onChange && this.props.onChange(selectedDates[0]);
+	onFlatPickerChange(selectedDates, dateStr, instance) {
+		this.props.onChange && this.props.onChange(selectedDates[0], dateStr, instance);
 	}
 
 	render() {
@@ -49,13 +49,10 @@ export class CalendarComponent extends React.Component {
 		} = this.props;
 
 		const classNames = {
-			label: cx(
-				{
-					'label--required': required,
-					'flush--bottom': helperText,
-				},
-				labelClassName
-			),
+			label: cx({
+				required,
+				'flush--bottom': helperText,
+			}),
 			helperText: cx('helperTextContainer', { required }),
 			field: cx(
 				'input--dateTimePicker select--reset',
@@ -113,7 +110,8 @@ CalendarComponent.propTypes = {
 	id: PropTypes.string,
 	name: PropTypes.string,
 	datepickerOptions: PropTypes.object,
-	error: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.bool]),
+	required: PropTypes.bool,
+	error: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 	helperText: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 	onChange: PropTypes.func, // provided by `redux-form`
 	required: PropTypes.bool,
@@ -121,7 +119,6 @@ CalendarComponent.propTypes = {
 };
 
 CalendarComponent.defaultProps = {
-	requiredText: '*',
 	datepickerOptions: {},
 };
 

--- a/src/forms/CalendarComponent.jsx
+++ b/src/forms/CalendarComponent.jsx
@@ -28,8 +28,9 @@ export class CalendarComponent extends React.Component {
 	 * `redux-form` however, expects a single value. This function ensures that any `onChange`
 	 * prop passed to this component invokes with a single date object.
 	 */
-	onFlatPickerChange(selectedDates, dateStr, instance) {
-		this.props.onChange && this.props.onChange(selectedDates[0], dateStr, instance);
+	onFlatPickerChange(selectedDates, dateString, instance) {
+		this.props.onChange &&
+			this.props.onChange(selectedDates[0], dateString, instance);
 	}
 
 	render() {
@@ -37,14 +38,12 @@ export class CalendarComponent extends React.Component {
 			id,
 			name,
 			label,
-			labelClassName,
 			helperText,
 			error,
+			required,
 			datepickerOptions,
 			className,
 			onChange, // eslint-disable-line no-unused-vars
-			required,
-			requiredText,
 			...other
 		} = this.props;
 
@@ -82,11 +81,7 @@ export class CalendarComponent extends React.Component {
 		return (
 			<span>
 				{label && (
-					<label
-						htmlFor={id || name}
-						className={classNames.label}
-						data-requiredtext={required && requiredText}
-					>
+					<label htmlFor={id || name} className={classNames.label}>
 						{label}
 					</label>
 				)}
@@ -106,7 +101,6 @@ export class CalendarComponent extends React.Component {
 
 CalendarComponent.propTypes = {
 	label: PropTypes.string,
-	labelClassName: PropTypes.string,
 	id: PropTypes.string,
 	name: PropTypes.string,
 	datepickerOptions: PropTypes.object,
@@ -114,8 +108,6 @@ CalendarComponent.propTypes = {
 	error: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 	helperText: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 	onChange: PropTypes.func, // provided by `redux-form`
-	required: PropTypes.bool,
-	requiredText: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 };
 
 CalendarComponent.defaultProps = {

--- a/src/forms/CalendarComponent.jsx
+++ b/src/forms/CalendarComponent.jsx
@@ -28,9 +28,9 @@ export class CalendarComponent extends React.Component {
 	 * `redux-form` however, expects a single value. This function ensures that any `onChange`
 	 * prop passed to this component invokes with a single date object.
 	 */
-	onFlatPickerChange(selectedDates, dateString, instance) {
+	onFlatPickerChange(selectedDates, dateString, flatpickrInstance) {
 		this.props.onChange &&
-			this.props.onChange(selectedDates[0], dateString, instance);
+			this.props.onChange(selectedDates[0], dateString, flatpickrInstance);
 	}
 
 	render() {
@@ -38,20 +38,25 @@ export class CalendarComponent extends React.Component {
 			id,
 			name,
 			label,
+			labelClassName,
 			helperText,
 			error,
-			required,
 			datepickerOptions,
 			className,
 			onChange, // eslint-disable-line no-unused-vars
+			required,
+			requiredText,
 			...other
 		} = this.props;
 
 		const classNames = {
-			label: cx({
-				required,
-				'flush--bottom': helperText,
-			}),
+			label: cx(
+				{
+					'label--required': required,
+					'flush--bottom': helperText,
+				},
+				labelClassName
+			),
 			helperText: cx('helperTextContainer', { required }),
 			field: cx(
 				'input--dateTimePicker select--reset',
@@ -81,7 +86,11 @@ export class CalendarComponent extends React.Component {
 		return (
 			<span>
 				{label && (
-					<label htmlFor={id || name} className={classNames.label}>
+					<label
+						htmlFor={id || name}
+						className={classNames.label}
+						data-requiredtext={required && requiredText}
+					>
 						{label}
 					</label>
 				)}
@@ -101,16 +110,19 @@ export class CalendarComponent extends React.Component {
 
 CalendarComponent.propTypes = {
 	label: PropTypes.string,
+	labelClassName: PropTypes.string,
 	id: PropTypes.string,
 	name: PropTypes.string,
 	datepickerOptions: PropTypes.object,
-	required: PropTypes.bool,
-	error: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+	error: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.bool]),
 	helperText: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 	onChange: PropTypes.func, // provided by `redux-form`
+	required: PropTypes.bool,
+	requiredText: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 };
 
 CalendarComponent.defaultProps = {
+	requiredText: '*',
 	datepickerOptions: {},
 };
 

--- a/src/forms/calendarComponent.test.jsx
+++ b/src/forms/calendarComponent.test.jsx
@@ -3,7 +3,6 @@ import { shallow, mount } from 'enzyme';
 import { CalendarComponent } from './CalendarComponent';
 
 describe('CalendarComponent', () => {
-
 	// Flatpickr invokes `onChange` with an array arg of `selectedDates`.
 	// the first index is the latest date selected.
 	const MOCK_VALUE = [new Date('2020-10-12')];
@@ -11,7 +10,7 @@ describe('CalendarComponent', () => {
 	const MOCK_PROPS = {
 		id: 'beyonce',
 		name: 'halo',
-		label: "Enter Your Favorite Day",
+		label: 'Enter Your Favorite Day',
 		helperText: "I'm here to help",
 		className: 'beyonce-halo',
 		value: new Date('2012-10-12'),
@@ -19,14 +18,9 @@ describe('CalendarComponent', () => {
 		error: 'this is an error',
 	};
 
-	const calendarComponent = shallow(
-		<CalendarComponent {...MOCK_PROPS} />
-	);
+	const calendarComponent = shallow(<CalendarComponent {...MOCK_PROPS} />);
 	const suppressErrorComponent = shallow(
-		<CalendarComponent
-			suppressError
-			{...MOCK_PROPS}
-		/>
+		<CalendarComponent suppressError {...MOCK_PROPS} />
 	);
 
 	it('standard props matches snapshot', () => {
@@ -41,14 +35,15 @@ describe('CalendarComponent', () => {
 		const spyableChange = jest.fn();
 		const expectedOnChangeArg = MOCK_VALUE[0];
 		const component = mount(
-			<CalendarComponent
-				onChange={spyableChange}
-				{...MOCK_PROPS}
-			/>
+			<CalendarComponent onChange={spyableChange} {...MOCK_PROPS} />
 		);
 
 		expect(spyableChange).not.toHaveBeenCalled();
 		component.instance().onFlatPickerChange(MOCK_VALUE);
-		expect(spyableChange).toHaveBeenCalledWith(expectedOnChangeArg);
+		expect(spyableChange).toHaveBeenCalledWith(
+			expectedOnChangeArg,
+			undefined,
+			undefined
+		);
 	});
 });


### PR DESCRIPTION
The Flatpickr onChange callback is called with some additional args that are currently being swallowed - this PR makes sure they are available to any passed-in `onChange`

This is non-breaking for all current uses of CalendarComponent that only care about the first arg