### PR TITLE
Return unwrapped InlineBlockList by default

### DIFF
--- a/src/layout/GridList.jsx
+++ b/src/layout/GridList.jsx
@@ -56,8 +56,8 @@ export class GridList extends React.Component {
 
 		return (
 			<ConditionalWrap
-				condition={this.props.children}
-				wrap={children => <div className={isLoading && 'component--isLoading'}>{[children, this.props.children]}</div>}
+				condition={this.props.children && isLoading}
+				wrap={children => <div className="component--isLoading">{[children, this.props.children]}</div>}
 			>
 				<ul
 					className={autoHeight || autoHeightWithWrap ? autoHeightClassNames : classNames}

--- a/src/layout/InlineBlockList.jsx
+++ b/src/layout/InlineBlockList.jsx
@@ -37,9 +37,9 @@ export class InlineBlockList extends React.Component {
 
 		return (
 			<ConditionalWrap
-				condition={this.props.children}
+				condition={this.props.children && isLoading}
 				wrap={children => (
-					<div className={isLoading && 'component--isLoading'}>{[children, this.props.children]}</div>
+					<div className="component--isLoading">{[children, this.props.children]}</div>
 				)}
 			>
 				<ul


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-232

#### Description
Return list layout components unwrapped by default - only wrap them when `isLoading` is true

#### Screenshots (if applicable)

