### PR TITLE
navbar flickering on pro pages fix

### DIFF
--- a/src/navigation/Nav.jsx
+++ b/src/navigation/Nav.jsx
@@ -81,7 +81,15 @@ export class Nav extends React.Component {
 	 * @return {React.element} the navbar component
 	 */
 	render() {
-		const { media, self, navItems, localeCode, className, ...other } = this.props;
+		const {
+			parentMedia,
+			media: _media,
+			self,
+			navItems,
+			localeCode,
+			className,
+			...other
+		} = this.props;
 		const {
 			login,
 			signup,
@@ -95,6 +103,7 @@ export class Nav extends React.Component {
 			logo,
 			dropdownLoaderLabel,
 		} = navItems;
+		const media = parentMedia || _media;
 		const isLoggedOut = self.status === 'prereg' || !self.name;
 		const classNames = cx('padding--all', className);
 		const proLogo = ((proDashboard.mainAccount || {}).group_photo || {}).thumb_link;
@@ -378,6 +387,7 @@ Nav.defaultProps = {
 Nav.propTypes = {
 	self: PropTypes.object,
 	media: PropTypes.object,
+	parentMedia: PropTypes.object,
 	navItems: PropTypes.object,
 };
 

--- a/src/navigation/Nav.jsx
+++ b/src/navigation/Nav.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
+import { renameProp, compose } from 'recompose';
 
 import swarmLogo from '../../assets/svg/logo--mSwarm--2color.svg';
 import scriptLogo from '../../assets/svg/logo--script.svg';
@@ -391,4 +392,6 @@ Nav.propTypes = {
 	navItems: PropTypes.object,
 };
 
-export default withMatchMedia(Nav);
+const enhance = compose(renameProp('media', 'parentMedia'), withMatchMedia);
+
+export default enhance(Nav);


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/MP-1203
#### Description
SSR does not support withmatchMedia HOC, so first render of navbar has the wrong size state rendered.
This fix is to provide parent media object from connectWithMatchMedia which is supported on the server side.

There is a link to a thread on slack around that problem
https://meetuphq.slack.com/archives/C2GLWSMAA/p1527075866000363
