### PR TITLE
Revert "Navbar Flickering on Pro Pages Fix"

### DIFF
--- a/src/navigation/Nav.jsx
+++ b/src/navigation/Nav.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
-import { renameProp, compose } from 'recompose';
 
 import swarmLogo from '../../assets/svg/logo--mSwarm--2color.svg';
 import scriptLogo from '../../assets/svg/logo--script.svg';
@@ -82,15 +81,7 @@ export class Nav extends React.Component {
 	 * @return {React.element} the navbar component
 	 */
 	render() {
-		const {
-			parentMedia,
-			media: _media,
-			self,
-			navItems,
-			localeCode,
-			className,
-			...other
-		} = this.props;
+		const { media, self, navItems, localeCode, className, ...other } = this.props;
 		const {
 			login,
 			signup,
@@ -104,7 +95,6 @@ export class Nav extends React.Component {
 			logo,
 			dropdownLoaderLabel,
 		} = navItems;
-		const media = parentMedia || _media;
 		const isLoggedOut = self.status === 'prereg' || !self.name;
 		const classNames = cx('padding--all', className);
 		const proLogo = ((proDashboard.mainAccount || {}).group_photo || {}).thumb_link;
@@ -388,10 +378,7 @@ Nav.defaultProps = {
 Nav.propTypes = {
 	self: PropTypes.object,
 	media: PropTypes.object,
-	parentMedia: PropTypes.object,
 	navItems: PropTypes.object,
 };
 
-const enhance = compose(renameProp('media', 'parentMedia'), withMatchMedia);
-
-export default enhance(Nav);
+export default withMatchMedia(Nav);


### PR DESCRIPTION
#### Related issues
Relates to https://meetup.atlassian.net/browse/MP-1203
Fixes https://meetup.atlassian.net/browse/MP-1226

#### Description
SSR does not support withmatchMedia HOC, so first render of navbar has the wrong size state rendered.
The initial fix was to provide parent media object from connectWithMatchMedia which is supported on the server side. There is a link to a thread on slack around that problem:
https://meetuphq.slack.com/archives/C2GLWSMAA/p1527075866000363

However there is a more elegant solution for this fix: 
```jsx
import { Nav } from 'meetup-web-components/lib/Nav';
import connectWithMatchMedia from 'mwp-app-render/lib/components/connectWithMatchMedia';

const EnhancedNav = connectWithMatchMedia(Nav);

...
<EnhancedNav ... />
```
This ticket reverts meetup/meetup-web-components#545

