### PR TITLE
Accept Media (MP-1229)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [5.0]
+
+*   **BREAKING CHANGE** `Nav` component now requires media as a prop.
+
 # [3.3]
 
-- `ReduxFormNumberInput` for use with Redux-Form
+*   `ReduxFormNumberInput` for use with Redux-Form

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [5.0]
 
-*   **BREAKING CHANGE** `Nav` component now requires media as a prop.
+*   **BREAKING CHANGE** `Nav` component now requires `media`, from `connectWithMatchMedia`, as a prop.
 
 # [3.3]
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 4.8.$(CI_BUILD_NUMBER)
+VERSION ?= 5.0.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/src/navigation/Nav.jsx
+++ b/src/navigation/Nav.jsx
@@ -4,7 +4,6 @@ import cx from 'classnames';
 
 import swarmLogo from '../../assets/svg/logo--mSwarm--2color.svg';
 import scriptLogo from '../../assets/svg/logo--script.svg';
-import withMatchMedia from '../utils/components/withMatchMedia';
 import Flex from '../layout/Flex';
 import FlexItem from '../layout/FlexItem';
 import Icon from '../media/Icon';
@@ -381,4 +380,4 @@ Nav.propTypes = {
 	navItems: PropTypes.object,
 };
 
-export default withMatchMedia(Nav);
+export default Nav;

--- a/src/navigation/nav.story.jsx
+++ b/src/navigation/nav.story.jsx
@@ -88,23 +88,49 @@ export const navItems = {
 storiesOf('Nav', module)
 	.addDecorator(decorateWithBasics)
 	.add('authenticated', () => (
-		<Nav self={MOCK_MEMBER} navItems={navItems} style={{ width: '100%' }} />
+		<Nav
+			self={MOCK_MEMBER}
+			navItems={navItems}
+			style={{ width: '100%' }}
+			media={{ isAtMediumUp: true, isAtLargeUp: true }}
+		/>
 	))
 	.add('authenticated but members groups has not been loaded', () => {
 		const groups = { ...navItems.groups, list: undefined };
 		const items = { ...navItems, groups };
-		return <Nav self={MOCK_MEMBER} navItems={items} style={{ width: '100%' }} />;
+		return (
+			<Nav
+				self={MOCK_MEMBER}
+				navItems={items}
+				style={{ width: '100%' }}
+				media={{ isAtMediumUp: true, isAtLargeUp: true }}
+			/>
+		);
 	})
 	.add('authenticated but notifications has not been loaded', () => {
 		const notifications = { ...navItems.notifications, list: undefined };
 		const items = { ...navItems, notifications };
-		return <Nav self={MOCK_MEMBER} navItems={items} style={{ width: '100%' }} />;
+		return (
+			<Nav
+				self={MOCK_MEMBER}
+				navItems={items}
+				style={{ width: '100%' }}
+				media={{ isAtMediumUp: true, isAtLargeUp: true }}
+			/>
+		);
 	})
 	.add('authenticated but notifications and groups are empty', () => {
 		const notifications = { ...navItems.notifications, list: [] };
 		const groups = { ...navItems.groups, list: [] };
 		const items = { ...navItems, notifications, groups };
-		return <Nav self={MOCK_MEMBER} navItems={items} style={{ width: '100%' }} />;
+		return (
+			<Nav
+				self={MOCK_MEMBER}
+				navItems={items}
+				style={{ width: '100%' }}
+				media={{ isAtMediumUp: true, isAtLargeUp: true }}
+			/>
+		);
 	})
 	.add('authenticated Pro member', () => (
 		<Nav
@@ -114,8 +140,14 @@ storiesOf('Nav', module)
 			}}
 			navItems={navItems}
 			style={{ width: '100%' }}
+			media={{ isAtMediumUp: true, isAtLargeUp: true }}
 		/>
 	))
 	.add('unauthenticated', () => (
-		<Nav self={{ status: 'prereg' }} navItems={navItems} style={{ width: '100%' }} />
+		<Nav
+			self={{ status: 'prereg' }}
+			navItems={navItems}
+			style={{ width: '100%' }}
+			media={{ isAtMediumUp: true, isAtLargeUp: true }}
+		/>
 	));


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/MP-1229
#### Description
SSR does not support withmatchMedia HOC, so first render of navbar has the wrong size state rendered.
The initial fix was to provide parent media object from connectWithMatchMedia which is supported on the server side, but this was reverted. There is a link to a thread on slack around that problem:
https://meetuphq.slack.com/archives/C2GLWSMAA/p1527075866000363

The pro-web solution for this fix:
```jsx
import { Nav } from 'meetup-web-components/lib/Nav';
import connectWithMatchMedia from 'mwp-app-render/lib/components/connectWithMatchMedia';

const EnhancedNav = connectWithMatchMedia(Nav);

...
<EnhancedNav ... />
```
Accept the media passed by connectWithMatchMedia from pro-web in meetup-web-components.

