### PR TITLE
Resolve tooltip trigger onBlur error

### DIFF
--- a/src/interactive/Tooltip.jsx
+++ b/src/interactive/Tooltip.jsx
@@ -46,6 +46,8 @@ class Tooltip extends React.PureComponent {
 	}
 
 	onBlur(e) {
+		if (!this.contentRef) return;
+
 		setTimeout(() => {
 			if (!this.contentRef.contains(document.activeElement)) {
 				this.closeContent(e);


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-234

#### Description
We were getting `Uncaught TypeError: Cannot read property 'contains' of null` logged when the trigger lost focus because the ref was unmounted and couldn't be checked

#### Screenshots (if applicable)

