### PR TITLE
Correct TabsTab child proptype validation

### DIFF
--- a/src/interactive/Tabs.jsx
+++ b/src/interactive/Tabs.jsx
@@ -74,7 +74,7 @@ Tabs.propTypes = {
 
 		const validChildren = React.Children.map(
 			children,
-			child => child && child.type === TabsTab
+			child => child && child.type.name === 'TabsTab'
 		).every(child => child);
 
 		if (!validChildren) {


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/<XXX-###>

#### Description
Compare name to 'TabsTab' string instead of TabsTab class

#### Screenshots (if applicable)

