### PR TITLE
Sticky modal close area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [4.11]
+
+- **Change** Added the ability to set the close area at the top of a Modal to be sticky using the `stickyCloseArea` prop
+
 # [4.10]
 
 - **Change** Reformatted code with Prettier and Stylelint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [4.11]
 
-- **Change** Added the ability to set the close area at the top of a Modal to be sticky using the `stickyCloseArea` prop
+- **Feature** Added the ability to set the close area at the top of a Modal to be sticky using the `stickyCloseArea` prop
 
 # [4.10]
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 4.10.$(CI_BUILD_NUMBER)
+VERSION ?= 4.11.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/assets/scss/components/_modal.scss
+++ b/assets/scss/components/_modal.scss
@@ -28,7 +28,6 @@ $modal-width: 440px;
 	}
 }
 
-
 .view {
 	@include flexParent("column", false);
 	background: white;

--- a/assets/scss/components/_modal.scss
+++ b/assets/scss/components/_modal.scss
@@ -73,6 +73,18 @@ $modal-width: 440px;
 	z-index: map-get($zindex-map, "popup") + 1;
 }
 
+.modal-closeButtonContainer--sticky {
+	background-color: $C_contentBG;
+	border-bottom: 1px solid $C_border;
+	position: sticky;
+	position: -webkit-sticky;
+	top: 0;
+}
+
+.modal-closeButtonContainer--stickyTransparent {
+	background-color: transparent;
+}
+
 .modal-closeButton {
 	@include color-svg($C_textSecondary);
 }

--- a/assets/scss/components/_modal.scss
+++ b/assets/scss/components/_modal.scss
@@ -75,8 +75,8 @@ $modal-width: 440px;
 .modal-closeButtonContainer--sticky {
 	background-color: $C_contentBG;
 	border-bottom: 1px solid $C_border;
-	position: sticky;
 	position: -webkit-sticky;
+	position: sticky;
 	top: 0;
 }
 

--- a/src/interactive/Modal.jsx
+++ b/src/interactive/Modal.jsx
@@ -10,6 +10,8 @@ import withLoading from '../utils/components/withLoading';
 import { MEDIA_QUERIES } from '../utils/designConstants';
 
 export const MODAL_CLOSE_BUTTON = 'modal-closeButton';
+export const MODAL_CLOSE_AREA_STICKY = 'modal-closeButtonContainer--sticky';
+export const MODAL_CLOSE_AREA_STICKYTRANSP = 'modal-closeButtonContainer--stickyTransparent';
 export const DEFAULT_MARGIN_TOP = '10vh';
 export const MARGIN_TOP_OFFSET = 36;
 
@@ -124,6 +126,7 @@ export class Modal extends React.Component {
 			hideHeroScrim,
 			inverted,
 			closeArea,
+			stickyCloseArea,
 			initialFocus,
 			loadingProps = {}, // eslint-disable-line no-unused-vars
 			isLoading,
@@ -147,6 +150,10 @@ export class Modal extends React.Component {
 
 		const dismissButtonClasses = cx(MODAL_CLOSE_BUTTON, 'button--reset');
 
+		const heroStyles = {
+			backgroundColor: heroBgColor || 'transparent',
+		};
+
 		const overlayShim = (
 			<div className={overlayClasses} onClick={this.onDismiss}>
 				<div className="inverted" />
@@ -154,16 +161,21 @@ export class Modal extends React.Component {
 		);
 
 		const closeElement = closeArea && (
-			<div className="padding--all modal-closeButtonContainer">
+			<div
+				className={cx(
+					{
+						[MODAL_CLOSE_AREA_STICKY]: stickyCloseArea,
+						[MODAL_CLOSE_AREA_STICKYTRANSP]: stickyCloseArea && (Boolean(heroBgColor) || Boolean(heroBgImage)),
+						'border--none': stickyCloseArea && (Boolean(heroBgColor) || Boolean(heroBgImage))
+					},
+					'padding--all modal-closeButtonContainer'
+				)}
+			>
 				<Button onClick={this.onDismiss} className={dismissButtonClasses}>
 					<Icon shape="cross" size="s" />
 				</Button>
 			</div>
 		);
-
-		const heroStyles = {
-			backgroundColor: heroBgColor || 'transparent',
-		};
 
 		return (
 			<div

--- a/src/interactive/Modal.jsx
+++ b/src/interactive/Modal.jsx
@@ -11,7 +11,8 @@ import { MEDIA_QUERIES } from '../utils/designConstants';
 
 export const MODAL_CLOSE_BUTTON = 'modal-closeButton';
 export const MODAL_CLOSE_AREA_STICKY = 'modal-closeButtonContainer--sticky';
-export const MODAL_CLOSE_AREA_STICKYTRANSP = 'modal-closeButtonContainer--stickyTransparent';
+export const MODAL_CLOSE_AREA_STICKYTRANSP =
+	'modal-closeButtonContainer--stickyTransparent';
 export const DEFAULT_MARGIN_TOP = '10vh';
 export const MARGIN_TOP_OFFSET = 36;
 
@@ -165,8 +166,10 @@ export class Modal extends React.Component {
 				className={cx(
 					{
 						[MODAL_CLOSE_AREA_STICKY]: stickyCloseArea,
-						[MODAL_CLOSE_AREA_STICKYTRANSP]: stickyCloseArea && (Boolean(heroBgColor) || Boolean(heroBgImage)),
-						'border--none': stickyCloseArea && (Boolean(heroBgColor) || Boolean(heroBgImage))
+						[MODAL_CLOSE_AREA_STICKYTRANSP]:
+							stickyCloseArea && (Boolean(heroBgColor) || Boolean(heroBgImage)),
+						'border--none':
+							stickyCloseArea && (Boolean(heroBgColor) || Boolean(heroBgImage)),
 					},
 					'padding--all modal-closeButtonContainer'
 				)}

--- a/src/interactive/Modal.jsx
+++ b/src/interactive/Modal.jsx
@@ -236,6 +236,7 @@ Modal.propTypes = {
 	inverted: PropTypes.bool,
 	onDismiss: PropTypes.func.isRequired,
 	closeArea: PropTypes.bool,
+	stickyCloseArea: PropTypes.bool,
 	initialFocus: PropTypes.oneOfType([
 		PropTypes.element,
 		PropTypes.func,

--- a/src/interactive/modal.story.jsx
+++ b/src/interactive/modal.story.jsx
@@ -108,6 +108,21 @@ storiesOf('Modal', module)
 		</div>
 	))
 	.addWithInfo(
+		'stickyCloseArea',
+		'The close area will be sticky at the top of the modal when the content is long enough to scroll',
+		() => (
+			<div style={wrapperStyle}>
+				<Modal stickyCloseArea>
+					{largeContent}
+				</Modal>
+				<div
+					style={iconSpriteStyle}
+					dangerouslySetInnerHTML={{ __html: iconSprite }}
+				/>
+			</div>
+		)
+	)
+	.addWithInfo(
 		'fixed',
 		'This is the basic usage with fixed position content.',
 		() => (
@@ -225,7 +240,7 @@ storiesOf('Modal', module)
 		'Modals with content larger than the screens theyre in will scroll the content',
 		() => (
 			<div style={wrapperStyle}>
-				<Modal closeArea={false} fixed>
+				<Modal fixed>
 					{largeContent}
 				</Modal>
 				<div

--- a/src/interactive/modal.story.jsx
+++ b/src/interactive/modal.story.jsx
@@ -49,7 +49,7 @@ const content = (
 	</Stripe>
 );
 const largeContent = (
-	<Stripe>
+	<Stripe className="border--none">
 		<Section hasSeparator className="border--none">
 			<h2 className="align--center">This is a modal!</h2>
 			<Chunk>Item</Chunk>
@@ -112,7 +112,7 @@ storiesOf('Modal', module)
 		'The close area will be sticky at the top of the modal when the content is long enough to scroll',
 		() => (
 			<div style={wrapperStyle}>
-				<Modal stickyCloseArea>{largeContent}</Modal>
+				<Modal fixed stickyCloseArea>{largeContent}</Modal>
 				<div
 					style={iconSpriteStyle}
 					dangerouslySetInnerHTML={{ __html: iconSprite }}

--- a/src/interactive/modal.story.jsx
+++ b/src/interactive/modal.story.jsx
@@ -112,9 +112,7 @@ storiesOf('Modal', module)
 		'The close area will be sticky at the top of the modal when the content is long enough to scroll',
 		() => (
 			<div style={wrapperStyle}>
-				<Modal stickyCloseArea>
-					{largeContent}
-				</Modal>
+				<Modal stickyCloseArea>{largeContent}</Modal>
 				<div
 					style={iconSpriteStyle}
 					dangerouslySetInnerHTML={{ __html: iconSprite }}
@@ -240,9 +238,7 @@ storiesOf('Modal', module)
 		'Modals with content larger than the screens theyre in will scroll the content',
 		() => (
 			<div style={wrapperStyle}>
-				<Modal fixed>
-					{largeContent}
-				</Modal>
+				<Modal fixed>{largeContent}</Modal>
 				<div
 					style={iconSpriteStyle}
 					dangerouslySetInnerHTML={{ __html: iconSprite }}

--- a/src/interactive/modal.story.jsx
+++ b/src/interactive/modal.story.jsx
@@ -112,7 +112,9 @@ storiesOf('Modal', module)
 		'The close area will be sticky at the top of the modal when the content is long enough to scroll',
 		() => (
 			<div style={wrapperStyle}>
-				<Modal fixed stickyCloseArea>{largeContent}</Modal>
+				<Modal fixed stickyCloseArea>
+					{largeContent}
+				</Modal>
 				<div
 					style={iconSpriteStyle}
 					dangerouslySetInnerHTML={{ __html: iconSprite }}

--- a/src/interactive/modal.test.js
+++ b/src/interactive/modal.test.js
@@ -151,13 +151,19 @@ describe('Modal hero header', () => {
 
 	it('sets the close area to sticky when stickyCloseArea is passed', () => {
 		expect(() =>
-			TestUtils.findRenderedDOMComponentWithClass(modal, MODAL_CLOSE_AREA_STICKY)
+			TestUtils.findRenderedDOMComponentWithClass(
+				modal,
+				MODAL_CLOSE_AREA_STICKY
+			)
 		).not.toThrow();
 	});
 
 	it('sets the sticky close area to be transparent when background image or color are passed', () => {
 		expect(() =>
-			TestUtils.findRenderedDOMComponentWithClass(modal, MODAL_CLOSE_AREA_STICKYTRANSP)
+			TestUtils.findRenderedDOMComponentWithClass(
+				modal,
+				MODAL_CLOSE_AREA_STICKYTRANSP
+			)
 		).not.toThrow();
 	});
 

--- a/src/interactive/modal.test.js
+++ b/src/interactive/modal.test.js
@@ -6,6 +6,8 @@ import Button from '../forms/Button';
 import {
 	Modal,
 	MODAL_CLOSE_BUTTON,
+	MODAL_CLOSE_AREA_STICKY,
+	MODAL_CLOSE_AREA_STICKYTRANSP,
 	DEFAULT_MARGIN_TOP,
 	MARGIN_TOP_OFFSET,
 	getModalPosition,
@@ -108,6 +110,7 @@ describe('Modal hero header', () => {
 		modal = TestUtils.renderIntoDocument(
 			<Modal
 				inverted
+				stickyCloseArea
 				heroBgColor={bgColor}
 				heroBgImage={bgImage}
 				heroContent={heroContentHtml}
@@ -143,6 +146,18 @@ describe('Modal hero header', () => {
 	it('sets the hero Stripe to inverted', () => {
 		expect(() =>
 			TestUtils.findRenderedDOMComponentWithClass(modal, STRIPE_INVERTED_CLASS)
+		).not.toThrow();
+	});
+
+	it('sets the close area to sticky when stickyCloseArea is passed', () => {
+		expect(() =>
+			TestUtils.findRenderedDOMComponentWithClass(modal, MODAL_CLOSE_AREA_STICKY)
+		).not.toThrow();
+	});
+
+	it('sets the sticky close area to be transparent when background image or color are passed', () => {
+		expect(() =>
+			TestUtils.findRenderedDOMComponentWithClass(modal, MODAL_CLOSE_AREA_STICKYTRANSP)
 		).not.toThrow();
 	});
 


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-672

#### Description
Added a prop to `Modal` that allows us to make the close area of a modal stick to the top of the modal

#### Screenshots (if applicable)
![modalstickyheader](https://user-images.githubusercontent.com/2313998/41309939-0d9dcb2e-6e4e-11e8-8243-8ff26ef696a6.gif)

