### PR TITLE
Fix Typeahead border-radius gap

### DIFF
--- a/assets/scss/components/_typeahead.scss
+++ b/assets/scss/components/_typeahead.scss
@@ -11,7 +11,10 @@
 	border: 1px solid $C_textPrimary; // match `input` focus border color
 	border-radius: 0 0 $largeRadius $largeRadius;
 	left: 0;
-	margin-top: -#{$defaultRadius};
+	// $defaultRadius/2 : equal to the whitespace left around a $defaultRadius rounded corner
+	// $space-quarter   : equal to the bottom margin on an input
+	// .5px             : nudge up a little to hide a remaining subpixel of whitespace
+	margin-top: -#{$defaultRadius / 2 + $space-quarter + 0.5px};
 	position: absolute;
 	right: 0;
 	z-index: map-get($zindex-map, "floating-content");


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-673

#### Description
Fixes minor spacing issue with Typeaheads

#### Screenshots (if applicable)
Before:
<img width="239" alt="screen shot 2018-06-13 at 3 19 43 pm" src="https://user-images.githubusercontent.com/2313998/41373343-14832cd8-6f1e-11e8-95d3-2382ee3c2bbe.png">

After:
<img width="238" alt="screen shot 2018-06-13 at 3 19 55 pm" src="https://user-images.githubusercontent.com/2313998/41373346-1861a370-6f1e-11e8-8281-28f8601037c1.png">
