### PR TITLE
Textarea for React 17

### DIFF
--- a/src/forms/Textarea.jsx
+++ b/src/forms/Textarea.jsx
@@ -6,6 +6,14 @@ import CharCounter from './CharCounter';
 import withErrorList from '../utils/components/withErrorList';
 
 /**
+ * Should override value with info from state
+ * @return {Object} the new state for the component
+ */
+export const overrideValue = nextProps => ({
+	value: nextProps.value || '',
+});
+
+/**
  * @module Textarea
  */
 export class Textarea extends React.PureComponent {
@@ -19,6 +27,14 @@ export class Textarea extends React.PureComponent {
 	}
 
 	/**
+	 * @param {Object} nextProps the incoming props
+	 * @return {undefined} side effect only
+	 */
+	static getDerivedStateFromProps(nextProps) {
+		return overrideValue(nextProps);
+	}
+
+	/**
 	 * Turns on autosize if requested
 	 * @return {undefined} side effect only
 	 */
@@ -26,32 +42,6 @@ export class Textarea extends React.PureComponent {
 		if (this.props.autosize) {
 			autosize(this.textarea);
 		}
-	}
-
-	/**
-	 * Should override value with info from state
-	 * @return {[type]} [description]
-	 */
-	overrideValue(nextProps) {
-		this.setState(() => ({
-			value: nextProps.value || '',
-		}));
-	}
-
-	/**
-	 * @param {Object} props the incoming props
-	 * @return {undefined} side effect only
-	 */
-	componentWillMount() {
-		this.overrideValue(this.props);
-	}
-
-	/**
-	 * @param {Object} nextProps the incoming props
-	 * @return {undefined} side effect only
-	 */
-	componentWillReceiveProps(nextProps) {
-		this.overrideValue(nextProps);
 	}
 
 	/**

--- a/src/forms/textarea.test.jsx
+++ b/src/forms/textarea.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import TestUtils from 'react-dom/test-utils';
 import * as autosizePlugin from 'autosize';
-import { Textarea } from './Textarea';
+import { Textarea, overrideValue } from './Textarea';
 
 jest.mock('autosize', () => {
 	return jest.fn();
@@ -56,19 +56,9 @@ describe('Textarea', function() {
 
 	it('should set state to value on `overrideValue`', function() {
 		const newValue = 'someValue';
-		textareaComponent.overrideValue({ value: newValue });
-		expect(textareaComponent.state.value).toEqual(newValue);
-	});
+		const newState = overrideValue({ value: newValue });
 
-	it('should set state to value on `componentwillmount`', function() {
-		textareaComponent.componentWillMount();
-		expect(textareaComponent.state.value).toEqual(VALUE);
-	});
-
-	it('should set state to value on `componentWillReceiveProps`', function() {
-		const newValue = 'hello world';
-		textareaComponent.componentWillReceiveProps({ value: newValue });
-		expect(textareaComponent.state.value).toEqual(newValue);
+		expect(newState.value).toEqual(newValue);
 	});
 
 	it('should call autosize plugin `update` method on `componentDidUpdate`', function() {


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/WC-240

#### Description
Replaced deprecated methods `componentWillReceiveProps` and `componentWillMount` with static `getDerivedPropsFromState` method. Updated tests as needed, but filed [a follow-up ticket](https://meetup.atlassian.net/browse/WC-248) to get better test coverage

#### Screenshots (if applicable)

