### PR TITLE
Temporarily add Bourbon as a dependency

### DIFF
--- a/assets/scss/components/_flex.scss
+++ b/assets/scss/components/_flex.scss
@@ -1,3 +1,5 @@
+@import "~bourbon/app/assets/stylesheets/_bourbon.scss"; // stylelint-disable-line scss/at-import-no-partial-leading-underscore
+
 .flex {
 	@include flexParent("row", false);
 }

--- a/assets/scss/components/_flex.scss
+++ b/assets/scss/components/_flex.scss
@@ -26,7 +26,8 @@
 	}
 }
 
-@include _bpModifier(flex, column, true) { // `true` arg generates "atAll" conditional class
+@include _bpModifier(flex, column, true) {
+	// `true` arg generates "atAll" conditional class
 	@include flexParent("column", false);
 
 	> .flex-item {
@@ -60,7 +61,6 @@
 		}
 	}
 }
-
 
 $flexGrowFactors: 1, 2, 3, 4, 5, 6, 7;
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "autosize": "3.0.21",
+    "bourbon": "4.2.3",
     "downshift": "1.31.12",
     "file-loader": "1.1.11",
     "focus-trap-react": "3.1.2",


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/<XXX-###>

#### Description
Soon we'll be launching a version of `swarm-sasstools` that removes Bourbon. As a result, browser prefixing or usage of mixins imported from Bourbon will not work in an app that has not been upgraded `mwp-cli` to version `8.0` or higher.

Bourbon will be removed as soon as I can clean any traces of it's usage in component styles.

#### Screenshots (if applicable)

