### PR TITLE
Firefox - hide browser-native spinner in input[type=number]

### DIFF
--- a/assets/scss/components/_forms.scss
+++ b/assets/scss/components/_forms.scss
@@ -97,6 +97,11 @@ input.field--reset:active {
 		@include resetFieldStyles();
 	}
 }
+
+[type="number"].field--reset {
+	// hide spinner in Firefox
+	-moz-appearance: textfield;
+}
 /* stylelint-enable */
 
 //
@@ -146,9 +151,11 @@ input.field--reset:active {
 			border-color: transparent;
 			color: $C_textSecondaryInverted;
 
-			&:hover { // stylelint-disable-line selector-max-specificity
+			/* stylelint-disable selector-max-specificity */
+			&:hover {
 				background-color: $C_borderInverted;
 			}
+			/* stylelint-enable */
 		}
 	}
 }
@@ -171,14 +178,16 @@ $C_toggleHighlight: $C_blue;
 		.fauxToggle {
 			border-color: $C_toggleHighlight;
 
-			&.checked { // stylelint-disable-line selector-max-specificity, selector-max-class
+			/* stylelint-disable selector-max-specificity, selector-max-class */
+			&.checked {
 				background-color: darken($C_toggleHighlight, 15%);
 			}
 
-			&.disabled { // stylelint-disable-line selector-max-specificity, selector-max-class
+			&.disabled {
 				background-color: $C_white;
 				border-color: $C_textHint;
 			}
+			/* stylelint-enable */
 		}
 	}
 }
@@ -221,9 +230,11 @@ $C_toggleHighlight: $C_blue;
 	+ .fauxToggle {
 		border-color: $C_toggleHighlight;
 
-		&.checked { // stylelint-disable-line selector-max-specificity, selector-max-class
+		/* stylelint-disable selector-max-specificity, selector-max-class */
+		&.checked {
 			box-shadow: 0 0 4px 1px $C_toggleHighlight;
 		}
+		/* stylelint-enable */
 	}
 }
 

--- a/assets/scss/components/_forms.scss
+++ b/assets/scss/components/_forms.scss
@@ -98,7 +98,10 @@ input.field--reset:active {
 	}
 }
 
-[type="number"].field--reset {
+[type="number"].field--reset,
+[type="number"].field--reset:hover,
+[type="number"].field--reset:focus,
+[type="number"].field--reset:active {
 	// hide spinner in Firefox
 	-moz-appearance: textfield;
 }


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-717

#### Description
See screenshots

#### Screenshots (if applicable)
Before:
<img width="365" alt="screen shot 2018-06-29 at 2 36 40 pm" src="https://user-images.githubusercontent.com/2313998/42108938-fbcf802c-7ba9-11e8-9f30-67a82d431f1d.png">

After:
<img width="350" alt="screen shot 2018-06-29 at 2 37 26 pm" src="https://user-images.githubusercontent.com/2313998/42108946-02b789de-7baa-11e8-8dc7-3179989dea40.png">

