### PR TITLE
fixing calendar component invalid date parse attempt

### DIFF
--- a/src/forms/CalendarComponent.jsx
+++ b/src/forms/CalendarComponent.jsx
@@ -68,7 +68,11 @@ export class CalendarComponent extends React.Component<Props> {
 	) => {
 		const [selectedDate] = selectedDates;
 		const { onChange } = this.props;
-		if (!onChange) {
+		/*
+		 * Seems like Flatpickr can have non-valid dates
+		 * js-joda fails to create intance in that case
+		 */
+		if (!onChange || !selectedDate) {
 			return;
 		}
 		onChange(LocalDate.from(nativeJs(selectedDate)), dateString, flatpickrInstance);

--- a/src/forms/calendarComponent.test.jsx
+++ b/src/forms/calendarComponent.test.jsx
@@ -67,4 +67,17 @@ describe('CalendarComponent', () => {
 			undefined
 		);
 	});
+
+	it('should not call `onChange` if date value is invalid', () => {
+		const spyableChange = jest.fn();
+		const component = mount(
+			<CalendarComponent onChange={spyableChange} {...MOCK_PROPS} />
+		);
+
+		expect(spyableChange).not.toHaveBeenCalled();
+		component
+			.instance()
+			.onFlatPickerChange([]);
+		expect(spyableChange).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/MP-1555

#### Description
Flatpickr might call onChange with non-existent date. Seems like this happens when we provide date constraints (minDate, maxDate) without selecting any date yet.
Like in that case where we have two date fields and they affect each other.
![virtualbox_2018-07-03_12-57-50](https://user-images.githubusercontent.com/513452/42213163-b69d37d2-7ec0-11e8-9e8c-fb07f786e394.png)

This PR fixes this problem. It does not parse if the date has not been selected yet.
