### PR TITLE
card copy isnt wrapping

### DIFF
--- a/assets/scss/components/_card.scss
+++ b/assets/scss/components/_card.scss
@@ -49,6 +49,7 @@ Card-like boxes.
 	min-height: $block-4;
 	padding: var(--responsive-space) var(--responsive-space) 0;
 	position: relative;
+	white-space: initial;
 }
 
 .card--initialHeight {


### PR DESCRIPTION
Fixing card styles so that they wrap, when cards are in hscroll components copy doesn't wrap cause hscroll has a white-space: nowrap, this causes a lot of copy in cards to flow outside of the box