### PR TITLE
Update admin bar - make group an optional param

### DIFF
--- a/assets/scss/components/_adminBar.scss
+++ b/assets/scss/components/_adminBar.scss
@@ -6,7 +6,12 @@
 	z-index: 9999;
 }
 
-.warning {
+.redbar {
 	background-color: var(--c-red);
+	width: 100%;
+}
+
+.greenbar {
+	background-color: var(--c-teal);
 	width: 100%;
 }

--- a/src/interactive/AdminBar.jsx
+++ b/src/interactive/AdminBar.jsx
@@ -151,7 +151,8 @@ export class AdminBar extends React.PureComponent<Props, State> {
 		return (
 			<Flex
 				className={cx('groupAdminLinks', {
-					['warning']: isQL || isProdApi,
+					['redbar']: isQL && isProdApi,
+					['greenbar']: isQL && !isProdApi,
 				})}
 			>
 				{isQL && (

--- a/src/interactive/AdminBar.jsx
+++ b/src/interactive/AdminBar.jsx
@@ -17,7 +17,7 @@ type DropdownProps = {
 };
 
 type Props = {
-	group: Group,
+	group?: Group,
 	event?: EventInfo,
 	isQL: boolean,
 	isAdmin: boolean,
@@ -120,16 +120,15 @@ export class AdminBar extends React.PureComponent<Props, State> {
 		this.setState({ highlightValue: e.target.value });
 	};
 
-	highlightGroup = (host: string) => {
-		fetch(`https://admin.${host}/admin_api/index/highlight/`, {
-			method: 'POST',
-			headers: { 'content-type': 'application/x-www-form-urlencoded' },
-			body: `chapter_id=${this.props.group.id}&value=${this.state.highlightValue}`,
-			credentials: 'include',
-		}).then(() => {
-			this.props.group.highlight = this.state.highlightValue;
-			this.toggleHighlighter();
-		});
+	highlightGroup = (host: string, group: Group) => {
+			fetch(`https://admin.${host}/admin_api/index/highlight/`, {
+				method: 'POST',
+				headers: { 'content-type': 'application/x-www-form-urlencoded' },
+				body: `chapter_id=${group.id}&value=${this.state.highlightValue}`,
+				credentials: 'include',
+			}).then(() => {
+				this.toggleHighlighter();
+			});
 	};
 
 	toggleHighlighter = () => {
@@ -144,7 +143,6 @@ export class AdminBar extends React.PureComponent<Props, State> {
 		}
 		const host: string =
 			nodeEnv === 'production' || isProdApi ? 'meetup.com' : 'dev.meetup.com';
-		const savedHighlightValue = group.highlight === '' ? '' : `(${group.highlight})`;
 		const highlightOptions = ['1', '2', '3', '4', '5', 'lowlight'].map(h => ({
 			label: h,
 			value: h,
@@ -178,6 +176,8 @@ export class AdminBar extends React.PureComponent<Props, State> {
 						<p className="text--display4">You are using production data.</p>
 					</FlexItem>
 				)}
+				{
+					group !== undefined &&
 				<FlexItem shrink>
 					<Tooltip
 						direction="top"
@@ -195,41 +195,45 @@ export class AdminBar extends React.PureComponent<Props, State> {
 							</Button>
 						}
 						content={
-							<DropdownContent host={host} group={group} event={event} />
+							group !== undefined && <DropdownContent host={host} group={group} event={event} />
 						}
 					/>
 				</FlexItem>
-				<FlexItem shrink>
-					<Tooltip
-						direction="top"
-						align="left"
-						withClose
-						noPortal
-						id="highlight-label-btn"
-						isActive={this.state.showHighlighter}
-						trigger={
-							<Button id="highlight-label-btn">
-								Highlight {savedHighlightValue}
-							</Button>
-						}
-						content={
-							<Section>
-								<SelectInput
-									name="highlightValue"
-									onChange={this.onHighlightValueChange}
-									options={highlightOptions}
-									value={group.highlight}
-								/>
-								<a
-									className="button margin--bottom"
-									onClick={this.highlightGroup.bind(host)}
-								>
-									submit
-								</a>
-							</Section>
-						}
-					/>
-				</FlexItem>
+			}
+				{
+					group !== undefined &&
+					<FlexItem shrink>
+						<Tooltip
+							direction="top"
+							align="left"
+							withClose
+							noPortal
+							id="highlight-label-btn"
+							isActive={this.state.showHighlighter}
+							trigger={
+								<Button id="highlight-label-btn">
+									Highlight {`${this.state.highlightValue}`}
+								</Button>
+							}
+							content={
+								<Section>
+									<SelectInput
+										name="highlightValue"
+										onChange={this.onHighlightValueChange}
+										options={highlightOptions}
+										value={this.state.highlightValue}
+									/>
+									<a
+										className="button margin--bottom"
+										onClick={this.highlightGroup.bind(this, host, group)}
+									>
+										submit
+									</a>
+								</Section>
+							}
+						/>
+					</FlexItem>
+				}
 			</Flex>
 		);
 	}

--- a/src/interactive/AdminBar.jsx
+++ b/src/interactive/AdminBar.jsx
@@ -151,7 +151,7 @@ export class AdminBar extends React.PureComponent<Props, State> {
 		return (
 			<Flex
 				className={cx('groupAdminLinks', {
-					['redbar']: isQL && isProdApi,
+					['redbar']: isProdApi,
 					['greenbar']: isQL && !isProdApi,
 				})}
 			>

--- a/src/interactive/AdminBar.jsx
+++ b/src/interactive/AdminBar.jsx
@@ -121,14 +121,14 @@ export class AdminBar extends React.PureComponent<Props, State> {
 	};
 
 	highlightGroup = (host: string, group: Group) => {
-			fetch(`https://admin.${host}/admin_api/index/highlight/`, {
-				method: 'POST',
-				headers: { 'content-type': 'application/x-www-form-urlencoded' },
-				body: `chapter_id=${group.id}&value=${this.state.highlightValue}`,
-				credentials: 'include',
-			}).then(() => {
-				this.toggleHighlighter();
-			});
+		fetch(`https://admin.${host}/admin_api/index/highlight/`, {
+			method: 'POST',
+			headers: { 'content-type': 'application/x-www-form-urlencoded' },
+			body: `chapter_id=${group.id}&value=${this.state.highlightValue}`,
+			credentials: 'include',
+		}).then(() => {
+			this.toggleHighlighter();
+		});
 	};
 
 	toggleHighlighter = () => {
@@ -176,32 +176,36 @@ export class AdminBar extends React.PureComponent<Props, State> {
 						<p className="text--display4">You are using production data.</p>
 					</FlexItem>
 				)}
-				{
-					group !== undefined &&
-				<FlexItem shrink>
-					<Tooltip
-						direction="top"
-						align="left"
-						minWidth="100px"
-						withClose
-						noPortal
-						id="admin-label-btn"
-						trigger={
-							<Button
-								id="admin-label-btn"
-								icon={<Icon shape="cog" size="xs" />}
-							>
-								Admin
-							</Button>
-						}
-						content={
-							group !== undefined && <DropdownContent host={host} group={group} event={event} />
-						}
-					/>
-				</FlexItem>
-			}
-				{
-					group !== undefined &&
+				{group !== undefined && (
+					<FlexItem shrink>
+						<Tooltip
+							direction="top"
+							align="left"
+							minWidth="100px"
+							withClose
+							noPortal
+							id="admin-label-btn"
+							trigger={
+								<Button
+									id="admin-label-btn"
+									icon={<Icon shape="cog" size="xs" />}
+								>
+									Admin
+								</Button>
+							}
+							content={
+								group !== undefined && (
+									<DropdownContent
+										host={host}
+										group={group}
+										event={event}
+									/>
+								)
+							}
+						/>
+					</FlexItem>
+				)}
+				{group !== undefined && (
 					<FlexItem shrink>
 						<Tooltip
 							direction="top"
@@ -225,7 +229,11 @@ export class AdminBar extends React.PureComponent<Props, State> {
 									/>
 									<a
 										className="button margin--bottom"
-										onClick={this.highlightGroup.bind(this, host, group)}
+										onClick={this.highlightGroup.bind(
+											this,
+											host,
+											group
+										)}
 									>
 										submit
 									</a>
@@ -233,7 +241,7 @@ export class AdminBar extends React.PureComponent<Props, State> {
 							}
 						/>
 					</FlexItem>
-				}
+				)}
 			</Flex>
 		);
 	}

--- a/src/interactive/AdminBar.story.jsx
+++ b/src/interactive/AdminBar.story.jsx
@@ -21,4 +21,13 @@ storiesOf('AdminBar', module)
 	))
 	.addWithInfo('isProdApi and isQL', () => (
 		<AdminBar group={MOCK_GROUP} self={{ id: '' }} isAdmin isProdApi isQL />
+	))
+	.addWithInfo('group is the optional param', () => (
+		<AdminBar self={{ id: '' }} isAdmin isProdApi isQL />
+	))
+	.addWithInfo('when QL on dev the bar color is green', () => (
+		<AdminBar self={{ id: '' }} isAdmin isQL />
+	))
+	.addWithInfo('when QL on prod the bar color is red', () => (
+		<AdminBar self={{ id: '' }} isAdmin isProdApi isQL />
 	));

--- a/src/interactive/__snapshots__/AdminBar.test.jsx.snap
+++ b/src/interactive/__snapshots__/AdminBar.test.jsx.snap
@@ -151,7 +151,7 @@ exports[`AdminBar renders correctly 1`] = `
 
 exports[`AdminBar renders correctly when QLd 1`] = `
 <Flex
-  className="groupAdminLinks warning"
+  className="groupAdminLinks greenbar"
 >
   <FlexItem
     className="inverted padding--top-half"
@@ -305,7 +305,7 @@ exports[`AdminBar renders correctly when QLd 1`] = `
 
 exports[`AdminBar renders correctly when isProdApi 1`] = `
 <Flex
-  className="groupAdminLinks warning"
+  className="groupAdminLinks redbar"
 >
   <FlexItem
     className="inverted padding--top-half"

--- a/src/interactive/__snapshots__/AdminBar.test.jsx.snap
+++ b/src/interactive/__snapshots__/AdminBar.test.jsx.snap
@@ -118,7 +118,7 @@ exports[`AdminBar renders correctly 1`] = `
                 },
               ]
             }
-            value={undefined}
+            value="1"
           />
           <a
             className="button margin--bottom"
@@ -140,7 +140,7 @@ exports[`AdminBar renders correctly 1`] = `
           type="button"
         >
           Highlight 
-          (undefined)
+          1
         </Button>
       }
       withClose={true}
@@ -272,7 +272,7 @@ exports[`AdminBar renders correctly when QLd 1`] = `
                 },
               ]
             }
-            value={undefined}
+            value="1"
           />
           <a
             className="button margin--bottom"
@@ -294,7 +294,7 @@ exports[`AdminBar renders correctly when QLd 1`] = `
           type="button"
         >
           Highlight 
-          (undefined)
+          1
         </Button>
       }
       withClose={true}
@@ -417,7 +417,7 @@ exports[`AdminBar renders correctly when isProdApi 1`] = `
                 },
               ]
             }
-            value={undefined}
+            value="1"
           />
           <a
             className="button margin--bottom"
@@ -439,7 +439,7 @@ exports[`AdminBar renders correctly when isProdApi 1`] = `
           type="button"
         >
           Highlight 
-          (undefined)
+          1
         </Button>
       }
       withClose={true}
@@ -553,7 +553,7 @@ exports[`AdminBar renders correctly when no org exists 1`] = `
                 },
               ]
             }
-            value={undefined}
+            value="1"
           />
           <a
             className="button margin--bottom"
@@ -575,7 +575,7 @@ exports[`AdminBar renders correctly when no org exists 1`] = `
           type="button"
         >
           Highlight 
-          (undefined)
+          1
         </Button>
       }
       withClose={true}


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/1689

#### Description
Before (new branch created to match new jira ticket):  https://github.com/meetup/meetup-web-components/pull/588

Group should be an optional param for AdminBar component - pro-web doesn't not need to display the buttons or group related information.

#### Screenshots (if applicable)
AdminBar on pro-web

using prodApi:

![screen shot 2018-07-12 at 3 55 41 pm](https://user-images.githubusercontent.com/2530057/42657395-0d486f26-85f0-11e8-9cdf-f87f7581593a.png)

using QL and prodApi:

![screen shot 2018-07-13 at 10 08 51 am](https://user-images.githubusercontent.com/2530057/42695999-f629ba3a-8684-11e8-914e-6bb34f5cfab2.png)

using QL and !prodAp:
![screen shot 2018-07-13 at 10 08 56 am](https://user-images.githubusercontent.com/2530057/42696009-fd4dc964-8684-11e8-963f-e4285506d218.png)
prodApi:


