### PR TITLE
Remove addWithInfo usage in AdminBar stories

### DIFF
--- a/src/interactive/AdminBar.story.jsx
+++ b/src/interactive/AdminBar.story.jsx
@@ -19,12 +19,12 @@ storiesOf('AdminBar', module)
 	.add('isProdApi and isQL', () => (
 		<AdminBar group={MOCK_GROUP} self={{ id: '' }} isAdmin isProdApi isQL />
 	))
-	.addWithInfo('group is the optional param', () => (
+	.add('group is the optional param', () => (
 		<AdminBar self={{ id: '' }} isAdmin isProdApi isQL />
 	))
-	.addWithInfo('when QL on dev the bar color is green', () => (
+	.add('when QL on dev the bar color is green', () => (
 		<AdminBar self={{ id: '' }} isAdmin isQL />
 	))
-	.addWithInfo('when QL on prod the bar color is red', () => (
+	.add('when QL on prod the bar color is red', () => (
 		<AdminBar self={{ id: '' }} isAdmin isProdApi isQL />
 	));


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/<XXX-###>

#### Description
`addWithInfo` was removed from Storybook in version 4, and is now only available through the [Storybook info addon](https://github.com/storybooks/storybook/tree/master/addons/info)

#### Screenshots (if applicable)

