### PR TITLE
Display warning when using prodApi=true, isAdmin=false, nodeEnv=development

### DIFF
--- a/src/interactive/AdminBar.jsx
+++ b/src/interactive/AdminBar.jsx
@@ -150,10 +150,11 @@ export class AdminBar extends React.PureComponent<Props, State> {
 
 	render() {
 		const { group, event, isQL, isAdmin, self, isProdApi, nodeEnv } = this.props;
-		// when not admin we don't want to show admin bar
-		if (!isAdmin) {
+		const isProdEnv = nodeEnv === 'production';
+		if (!isAdmin && isProdEnv) {
 			return null;
 		}
+
 		const host: string =
 			nodeEnv === 'production' || isProdApi ? 'meetup.com' : 'dev.meetup.com';
 		const highlightOptions = ['1', '2', '3', '4', '5', 'lowlight'].map(h => ({
@@ -168,7 +169,7 @@ export class AdminBar extends React.PureComponent<Props, State> {
 					['greenbar']: isQL && !isProdApi,
 				})}
 			>
-				{isQL && (
+				{isQL && isAdmin && (
 					<FlexItem className="inverted padding--top-half">
 						<p className="text--display3">
 							QL:{' '}
@@ -185,12 +186,12 @@ export class AdminBar extends React.PureComponent<Props, State> {
 						</p>
 					</FlexItem>
 				)}
-				{isProdApi && (
+				{isProdApi && !isProdEnv && (
 					<FlexItem className="inverted padding--top-half">
 						<p className="text--display4">You are using production data.</p>
 					</FlexItem>
 				)}
-				{group !== undefined && (
+				{group !== undefined && isAdmin && (
 					<FlexItem shrink>
 						<Tooltip
 							direction="top"
@@ -219,7 +220,7 @@ export class AdminBar extends React.PureComponent<Props, State> {
 						/>
 					</FlexItem>
 				)}
-				{group !== undefined && (
+				{group !== undefined && isAdmin && (
 					<FlexItem shrink>
 						<Tooltip
 							direction="top"

--- a/src/interactive/AdminBar.jsx
+++ b/src/interactive/AdminBar.jsx
@@ -21,7 +21,7 @@ type Props = {
 	group?: Group,
 
 	/** The event for which to render the admin bar */
-  event?: EventInfo,
+	event?: EventInfo,
 
 	/** Whether the user is QL'ed into somebody else */
 	isQL: boolean,
@@ -169,94 +169,100 @@ export class AdminBar extends React.PureComponent<Props, State> {
 					['greenbar']: isQL && !isProdApi,
 				})}
 			>
-				{isQL && isAdmin && (
-					<FlexItem className="inverted padding--top-half">
-						<p className="text--display3">
-							QL:{' '}
-							<a
-								href={`https://admin.${host}/admin/member.jsp?m=${
-									self.id
-								}`}
-								className="link"
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								{self.name}
-							</a>
-						</p>
-					</FlexItem>
-				)}
-				{isProdApi && !isProdEnv && (
-					<FlexItem className="inverted padding--top-half">
-						<p className="text--display4">You are using production data.</p>
-					</FlexItem>
-				)}
-				{group !== undefined && isAdmin && (
-					<FlexItem shrink>
-						<Tooltip
-							direction="top"
-							align="left"
-							minWidth="100px"
-							withClose
-							noPortal
-							id="admin-label-btn"
-							trigger={
-								<Button
-									id="admin-label-btn"
-									icon={<Icon shape="cog" size="xs" />}
+				{isQL &&
+					isAdmin && (
+						<FlexItem className="inverted padding--top-half">
+							<p className="text--display3">
+								QL:{' '}
+								<a
+									href={`https://admin.${host}/admin/member.jsp?m=${
+										self.id
+									}`}
+									className="link"
+									target="_blank"
+									rel="noopener noreferrer"
 								>
-									Admin
-								</Button>
-							}
-							content={
-								group !== undefined && (
-									<DropdownContent
-										host={host}
-										group={group}
-										event={event}
-									/>
-								)
-							}
-						/>
-					</FlexItem>
-				)}
-				{group !== undefined && isAdmin && (
-					<FlexItem shrink>
-						<Tooltip
-							direction="top"
-							align="left"
-							withClose
-							noPortal
-							id="highlight-label-btn"
-							isActive={this.state.showHighlighter}
-							trigger={
-								<Button id="highlight-label-btn">
-									Highlight {`${this.state.highlightValue}`}
-								</Button>
-							}
-							content={
-								<Section>
-									<SelectInput
-										name="highlightValue"
-										onChange={this.onHighlightValueChange}
-										options={highlightOptions}
-										value={this.state.highlightValue}
-									/>
-									<a
-										className="button margin--bottom"
-										onClick={this.highlightGroup.bind(
-											this,
-											host,
-											group
-										)}
+									{self.name}
+								</a>
+							</p>
+						</FlexItem>
+					)}
+				{isProdApi &&
+					!isProdEnv && (
+						<FlexItem className="inverted padding--top-half">
+							<p className="text--display4">
+								You are using production data.
+							</p>
+						</FlexItem>
+					)}
+				{group !== undefined &&
+					isAdmin && (
+						<FlexItem shrink>
+							<Tooltip
+								direction="top"
+								align="left"
+								minWidth="100px"
+								withClose
+								noPortal
+								id="admin-label-btn"
+								trigger={
+									<Button
+										id="admin-label-btn"
+										icon={<Icon shape="cog" size="xs" />}
 									>
-										submit
-									</a>
-								</Section>
-							}
-						/>
-					</FlexItem>
-				)}
+										Admin
+									</Button>
+								}
+								content={
+									group !== undefined && (
+										<DropdownContent
+											host={host}
+											group={group}
+											event={event}
+										/>
+									)
+								}
+							/>
+						</FlexItem>
+					)}
+				{group !== undefined &&
+					isAdmin && (
+						<FlexItem shrink>
+							<Tooltip
+								direction="top"
+								align="left"
+								withClose
+								noPortal
+								id="highlight-label-btn"
+								isActive={this.state.showHighlighter}
+								trigger={
+									<Button id="highlight-label-btn">
+										Highlight {`${this.state.highlightValue}`}
+									</Button>
+								}
+								content={
+									<Section>
+										<SelectInput
+											name="highlightValue"
+											onChange={this.onHighlightValueChange}
+											options={highlightOptions}
+											value={this.state.highlightValue}
+										/>
+										<a
+											className="button margin--bottom"
+											onClick={this.highlightGroup.bind(
+												this,
+												host,
+												group
+											)}
+										>
+											submit
+										</a>
+									</Section>
+								}
+							/>
+						</FlexItem>
+					)}
 			</Flex>
 		);
 	}

--- a/src/interactive/AdminBar.story.jsx
+++ b/src/interactive/AdminBar.story.jsx
@@ -8,16 +8,28 @@ import AdminBar from './AdminBar';
 storiesOf('AdminBar', module)
 	.addDecorator(decorateWithBasics)
 	.addDecorator(decorateWithInfo)
-	.add('default: isAdmin={false}', () => <AdminBar isAdmin={false} />, {
-		info: { text: 'Component is not rendered if props: isAdmin=false' },
+	.add('default: isAdmin={false} prod environment', () => (<AdminBar
+	nodeEnv='production'/>), {
+		info: { text: 'Component is not rendered if props: isAdmin=false, nodeEnv=production' },
 	})
-	.add('isAdmin', () => <AdminBar group={MOCK_GROUP} isAdmin />)
+	.add('isAdmin and prod environment', () => (<AdminBar
+	nodeEnv='production'
+	group={MOCK_GROUP} isAdmin />))
 	.add('isQL', () => <AdminBar group={MOCK_GROUP} self={{ id: '' }} isAdmin isQL />)
 	.add('isProdApi', () => (
 		<AdminBar group={MOCK_GROUP} self={{ id: '' }} isAdmin isProdApi />
 	))
 	.add('isProdApi and isQL', () => (
 		<AdminBar group={MOCK_GROUP} self={{ id: '' }} isAdmin isProdApi isQL />
+	))
+	.add('isQL and prod environment', () => (
+		<AdminBar group={MOCK_GROUP} self={{ id: '' }} isAdmin isQL />
+	))
+	.add('isProdApi and isAdmin=false on dev env', () => (
+		<AdminBar self={{ id: '' }} isProdApi nodeEnv='development' />
+	))
+	.add('isProdApi and isAdmin=false on prod env', () => (
+		<AdminBar self={{ id: '' }} isProdApi nodeEnv='production' />
 	))
 	.add('group is the optional param', () => (
 		<AdminBar self={{ id: '' }} isAdmin isProdApi isQL />

--- a/src/interactive/AdminBar.story.jsx
+++ b/src/interactive/AdminBar.story.jsx
@@ -8,13 +8,19 @@ import AdminBar from './AdminBar';
 storiesOf('AdminBar', module)
 	.addDecorator(decorateWithBasics)
 	.addDecorator(decorateWithInfo)
-	.add('default: isAdmin={false} prod environment', () => (<AdminBar
-	nodeEnv='production'/>), {
-		info: { text: 'Component is not rendered if props: isAdmin=false, nodeEnv=production' },
-	})
-	.add('isAdmin and prod environment', () => (<AdminBar
-	nodeEnv='production'
-	group={MOCK_GROUP} isAdmin />))
+	.add(
+		'default: isAdmin={false} prod environment',
+		() => <AdminBar nodeEnv="production" />,
+		{
+			info: {
+				text:
+					'Component is not rendered if props: isAdmin=false, nodeEnv=production',
+			},
+		}
+	)
+	.add('isAdmin and prod environment', () => (
+		<AdminBar nodeEnv="production" group={MOCK_GROUP} isAdmin />
+	))
 	.add('isQL', () => <AdminBar group={MOCK_GROUP} self={{ id: '' }} isAdmin isQL />)
 	.add('isProdApi', () => (
 		<AdminBar group={MOCK_GROUP} self={{ id: '' }} isAdmin isProdApi />
@@ -26,10 +32,10 @@ storiesOf('AdminBar', module)
 		<AdminBar group={MOCK_GROUP} self={{ id: '' }} isAdmin isQL />
 	))
 	.add('isProdApi and isAdmin=false on dev env', () => (
-		<AdminBar self={{ id: '' }} isProdApi nodeEnv='development' />
+		<AdminBar self={{ id: '' }} isProdApi nodeEnv="development" />
 	))
 	.add('isProdApi and isAdmin=false on prod env', () => (
-		<AdminBar self={{ id: '' }} isProdApi nodeEnv='production' />
+		<AdminBar self={{ id: '' }} isProdApi nodeEnv="production" />
 	))
 	.add('group is the optional param', () => (
 		<AdminBar self={{ id: '' }} isAdmin isProdApi isQL />

--- a/src/interactive/AdminBar.test.jsx
+++ b/src/interactive/AdminBar.test.jsx
@@ -19,7 +19,7 @@ describe('AdminBar', () => {
 		const MOCK_PROPS = {
 			group: group,
 			isAdmin: false,
-			nodeEnv: 'production'
+			nodeEnv: 'production',
 		};
 		const component = shallow(<AdminBar {...MOCK_PROPS} />);
 		expect(component).toMatchSnapshot();
@@ -28,7 +28,7 @@ describe('AdminBar', () => {
 		const MOCK_PROPS = {
 			isAdmin: false,
 			isProdApi: true,
-			nodeEnv: 'development'
+			nodeEnv: 'development',
 		};
 		const component = shallow(<AdminBar {...MOCK_PROPS} />);
 		expect(component).toMatchSnapshot();

--- a/src/interactive/AdminBar.test.jsx
+++ b/src/interactive/AdminBar.test.jsx
@@ -15,10 +15,20 @@ describe('AdminBar', () => {
 		const component = shallow(<AdminBar {...MOCK_PROPS} />);
 		expect(component).toMatchSnapshot();
 	});
-	it('renders nothing if user is not an admin', () => {
+	it('renders nothing if user is not an admin and nodeEnv is prod', () => {
 		const MOCK_PROPS = {
 			group: group,
 			isAdmin: false,
+			nodeEnv: 'production'
+		};
+		const component = shallow(<AdminBar {...MOCK_PROPS} />);
+		expect(component).toMatchSnapshot();
+	});
+	it('renders warning when nodeEnv is development and using isProdApi', () => {
+		const MOCK_PROPS = {
+			isAdmin: false,
+			isProdApi: true,
+			nodeEnv: 'development'
 		};
 		const component = shallow(<AdminBar {...MOCK_PROPS} />);
 		expect(component).toMatchSnapshot();

--- a/src/interactive/__snapshots__/AdminBar.test.jsx.snap
+++ b/src/interactive/__snapshots__/AdminBar.test.jsx.snap
@@ -588,4 +588,20 @@ exports[`AdminBar renders correctly when no org exists 1`] = `
 </Flex>
 `;
 
-exports[`AdminBar renders nothing if user is not an admin 1`] = `""`;
+exports[`AdminBar renders nothing if user is not an admin and nodeEnv is prod 1`] = `""`;
+
+exports[`AdminBar renders warning when nodeEnv is development and using isProdApi 1`] = `
+<Flex
+  className="groupAdminLinks redbar"
+>
+  <FlexItem
+    className="inverted padding--top-half"
+  >
+    <p
+      className="text--display4"
+    >
+      You are using production data.
+    </p>
+  </FlexItem>
+</Flex>
+`;


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/MP-1717

#### Description
On Pro display warning about using production data if:
prodApi={true}, 
isAdmin={false}, 
nodeEnv={development}

Now we can see the red warning bar even if isAdmin is false.

#### Screenshots (if applicable)

