### PR TITLE
increase width of numberInput

### DIFF
--- a/src/forms/NumberInput.jsx
+++ b/src/forms/NumberInput.jsx
@@ -123,7 +123,7 @@ export class NumberInput extends React.Component {
 		} = this.props;
 
 		const classNames = {
-			field: cx('field--reset', { 'field--error': error }, className, 'span--100'),
+			field: cx('field--reset span--100', { 'field--error': error }, className),
 			fauxInput: cx(FAUX_INPUT_CLASS, {
 				disabled,
 				error,

--- a/src/forms/NumberInput.jsx
+++ b/src/forms/NumberInput.jsx
@@ -123,7 +123,7 @@ export class NumberInput extends React.Component {
 		} = this.props;
 
 		const classNames = {
-			field: cx('field--reset', { 'field--error': error }, className),
+			field: cx('field--reset', { 'field--error': error }, className, 'span--100'),
 			fauxInput: cx(FAUX_INPUT_CLASS, {
 				disabled,
 				error,


### PR DESCRIPTION
#### Description
Make the numberInput field width longer because currently if the max is 10 it will cut off if a user types in 100. The expected behavior is that if a user is able to type in 100 that 100 should not be cut off.

#### Screenshots (if applicable)

<img width="1072" alt="screen shot 2018-07-24 at 3 27 10 pm" src="https://user-images.githubusercontent.com/6998954/43161587-7e39a1f4-8f56-11e8-94d7-324005f137ed.png">
<img width="1081" alt="screen shot 2018-07-24 at 3 27 23 pm" src="https://user-images.githubusercontent.com/6998954/43161588-7e4ae388-8f56-11e8-8adf-7ce10131e8af.png">
