### PR TITLE
Fix "Show Info" button for Modal stories

### DIFF
--- a/src/SignupModal.jsx
+++ b/src/SignupModal.jsx
@@ -25,10 +25,10 @@ export const SIGNUP_MODAL_EMAIL_CLASS = `${SIGNUP_MODAL_CLASS}-email`;
  * @param {Object} props component properties
  * @returns {React.element} SignupModal
  */
-export const SignupModal = ({ onDismiss, signupOptions }) => {
+export const SignupModal = ({ onDismiss, signupOptions, ...other }) => {
 	const { google, facebook, email, login, title, orLabel } = signupOptions;
 	return (
-		<Modal className={SIGNUP_MODAL_CLASS} onDismiss={onDismiss} fixed>
+		<Modal className={SIGNUP_MODAL_CLASS} onDismiss={onDismiss} fixed {...other}>
 			<div className={SIGNUP_MODAL_WRAPPER_CLASS}>
 				<Chunk>
 					<h1 className="text--big">{title}</h1>

--- a/src/interactive/modal.story.jsx
+++ b/src/interactive/modal.story.jsx
@@ -124,11 +124,7 @@ storiesOf('Interactive/Modal', module)
 		'stickyCloseArea',
 		() => (
 			<div style={wrapperStyle}>
-				<ModalComponent
-					focusTrapActive={false}
-					fixed
-					stickyCloseArea
-				>
+				<ModalComponent focusTrapActive={false} fixed stickyCloseArea>
 					{largeContent}
 				</ModalComponent>
 				<div
@@ -230,11 +226,7 @@ storiesOf('Interactive/Modal', module)
 						meow or run outside as soon as door open.
 					</p>
 				</div>
-				<ModalComponent
-					onDismiss={onDismiss}
-					focusTrapActive={false}
-					fixed
-				>
+				<ModalComponent onDismiss={onDismiss} focusTrapActive={false} fixed>
 					<Stripe>
 						<Section hasSeparator className="border--none">
 							<Chunk className="align--center">
@@ -272,7 +264,9 @@ storiesOf('Interactive/Modal', module)
 		'fixed - long content',
 		() => (
 			<div style={wrapperStyle}>
-				<ModalComponent focusTrapActive={false} fixed>{largeContent}</ModalComponent>
+				<ModalComponent focusTrapActive={false} fixed>
+					{largeContent}
+				</ModalComponent>
 				<div
 					style={iconSpriteStyle}
 					dangerouslySetInnerHTML={{ __html: iconSprite }}
@@ -472,7 +466,9 @@ storiesOf('Interactive/Modal', module)
 		'No close area',
 		() => (
 			<div style={wrapperStyle}>
-				<ModalComponent closeArea={false} focusTrapActive={false}>{content}</ModalComponent>
+				<ModalComponent closeArea={false} focusTrapActive={false}>
+					{content}
+				</ModalComponent>
 				<div
 					style={iconSpriteStyle}
 					dangerouslySetInnerHTML={{ __html: iconSprite }}

--- a/src/interactive/modal.story.jsx
+++ b/src/interactive/modal.story.jsx
@@ -124,7 +124,11 @@ storiesOf('Interactive/Modal', module)
 		'stickyCloseArea',
 		() => (
 			<div style={wrapperStyle}>
-				<ModalComponent fixed stickyCloseArea>
+				<ModalComponent
+					focusTrapActive={false}
+					fixed
+					stickyCloseArea
+				>
 					{largeContent}
 				</ModalComponent>
 				<div
@@ -226,7 +230,11 @@ storiesOf('Interactive/Modal', module)
 						meow or run outside as soon as door open.
 					</p>
 				</div>
-				<ModalComponent onDismiss={onDismiss} fixed>
+				<ModalComponent
+					onDismiss={onDismiss}
+					focusTrapActive={false}
+					fixed
+				>
 					<Stripe>
 						<Section hasSeparator className="border--none">
 							<Chunk className="align--center">
@@ -264,7 +272,7 @@ storiesOf('Interactive/Modal', module)
 		'fixed - long content',
 		() => (
 			<div style={wrapperStyle}>
-				<ModalComponent fixed>{largeContent}</ModalComponent>
+				<ModalComponent focusTrapActive={false} fixed>{largeContent}</ModalComponent>
 				<div
 					style={iconSpriteStyle}
 					dangerouslySetInnerHTML={{ __html: iconSprite }}
@@ -295,6 +303,7 @@ storiesOf('Interactive/Modal', module)
 							</Chunk>
 						</Section>
 					}
+					focusTrapActive={false}
 				>
 					<Stripe>
 						<Section hasSeparator className="border--none">
@@ -345,6 +354,7 @@ storiesOf('Interactive/Modal', module)
 							</Chunk>
 						</Section>
 					}
+					focusTrapActive={false}
 				>
 					<Stripe>
 						<Section hasSeparator className="border--none">
@@ -395,6 +405,7 @@ storiesOf('Interactive/Modal', module)
 							</Chunk>
 						</Section>
 					}
+					focusTrapActive={false}
 				>
 					<Stripe>
 						<Section hasSeparator className="border--none">
@@ -440,6 +451,7 @@ storiesOf('Interactive/Modal', module)
 				<ModalComponent
 					onDismiss={onDismiss}
 					initialFocus="#firstFocus"
+					focusTrapActive={false}
 					fullscreen
 				>
 					{content}
@@ -460,7 +472,7 @@ storiesOf('Interactive/Modal', module)
 		'No close area',
 		() => (
 			<div style={wrapperStyle}>
-				<ModalComponent closeArea={false}>{content}</ModalComponent>
+				<ModalComponent closeArea={false} focusTrapActive={false}>{content}</ModalComponent>
 				<div
 					style={iconSpriteStyle}
 					dangerouslySetInnerHTML={{ __html: iconSprite }}
@@ -476,7 +488,12 @@ storiesOf('Interactive/Modal', module)
 	)
 	.add('isLoading', () => (
 		<div style={wrapperStyle}>
-			<Modal isLoading onDismiss={onDismiss} initialFocus="#firstFocus">
+			<Modal
+				isLoading
+				onDismiss={onDismiss}
+				initialFocus="#firstFocus"
+				focusTrapActive={false}
+			>
 				{content}
 			</Modal>
 			<div
@@ -496,6 +513,7 @@ storiesOf('Interactive/Modal', module)
 				}}
 				onDismiss={onDismiss}
 				initialFocus="#firstFocus"
+				focusTrapActive={false}
 			>
 				{content}
 			</Modal>

--- a/src/signupModal.story.jsx
+++ b/src/signupModal.story.jsx
@@ -30,5 +30,9 @@ storiesOf('Uncategorized/SignupModal', module)
 	.addDecorator(decorateWithBasics)
 	.addDecorator(decorateWithInfo)
 	.add('default', () => (
-		<SignupModal signupOptions={signupOptions} onDismiss={() => {}} />
+		<SignupModal
+			signupOptions={signupOptions}
+			onDismiss={() => {}}
+			focusTrapActive={false}
+		/>
 	));


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/<XXX-###>

#### Description
The Modal component uses [focus-trap](https://github.com/davidtheclark/focus-trap-react) to keep focus within open modals. This is a best practice for a11y and keyboard navigation, but it screws up the click event on Storybook's "Show Info" button, so we can disable it for this case

#### Screenshots (if applicable)

