### PR TITLE
reduce card shadow border

### DIFF
--- a/assets/scss/components/_card.scss
+++ b/assets/scss/components/_card.scss
@@ -72,6 +72,7 @@ Card-like boxes.
 
 .card--hasShadow {
 	@extend %shadow;
+	border: 0px;
 }
 
 .card--hasHoverShadow {


### PR DESCRIPTION
Per design's request, removing 1px border from shadow on the `Card` component

Looks like this now:
![image](https://user-images.githubusercontent.com/18507092/43849342-309f28e8-9b03-11e8-9f04-e45058033424.png)


