### PR TITLE
Use highres_link in AvatarMember

### DIFF
--- a/src/media/AvatarMember.jsx
+++ b/src/media/AvatarMember.jsx
@@ -19,7 +19,16 @@ class AvatarMember extends React.PureComponent {
 		const { member, org, fbFriend, className, ...other } = this.props;
 		const { big, large, xxlarge } = other;
 
-		const photoLink = big || large || xxlarge ? 'photo_link' : 'thumb_link';
+		let photoLink = 'thumb_link';
+
+		if (big || large || xxlarge) {
+			photoLink = 'photo_link';
+
+			// try `highres_link` in case `photo_link` is undefined
+			if ((member.photo || {})[photoLink] == undefined) {
+				photoLink = 'highres_link';
+			}
+		}
 		const showNoPhoto = (member.photo || {})[photoLink] == undefined;
 
 		const classNames = cx(

--- a/src/media/AvatarMember.jsx
+++ b/src/media/AvatarMember.jsx
@@ -10,6 +10,20 @@ export const AVATAR_PERSON_FB_CLASS = 'avatar--fbFriend';
 export const AVATAR_PERSON_NOPHOTO_CLASS = 'avatar--noPhoto';
 const AVATAR_ICON_BADGE_CLASS = 'svg--avatarBadge';
 
+export const getPhoto = (photo, size) => {
+	if (!photo) {
+		return undefined;
+	}
+	switch(size) {
+		case 'big':
+		case 'large':
+		case 'xxlarge': // clear handling of these 3 overlapping size handlers
+			return photo.photo_link || photo.highres_link; // use highres_link as a fallback
+		default:
+			return photo.thumb_link;
+	}
+};
+
 /**
  * An avatar for a member - just supply a member
  * @module AvatarMember
@@ -19,17 +33,9 @@ class AvatarMember extends React.PureComponent {
 		const { member, org, fbFriend, className, ...other } = this.props;
 		const { big, large, xxlarge } = other;
 
-		let photoLink = 'thumb_link';
-
-		if (big || large || xxlarge) {
-			photoLink = 'photo_link';
-
-			// try `highres_link` in case `photo_link` is undefined
-			if ((member.photo || {})[photoLink] == undefined) {
-				photoLink = 'highres_link';
-			}
-		}
-		const showNoPhoto = (member.photo || {})[photoLink] == undefined;
+		const photoSize = big || large || xxlarge ? 'big' : 'default';
+		const photoLink = getPhoto(member.photo, photoSize);
+		const showNoPhoto = typeof photoLink !== 'string'; // _any_ non-string value should be considered invalid.
 
 		const classNames = cx(
 			AVATAR_PERSON_CLASS,
@@ -47,7 +53,7 @@ class AvatarMember extends React.PureComponent {
 		};
 
 		if (!showNoPhoto) {
-			allProps.src = member.photo[photoLink];
+			allProps.src = photoLink;
 		}
 
 		return (

--- a/src/media/avatarmember.test.js
+++ b/src/media/avatarmember.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { MOCK_MEMBER } from 'meetup-web-mocks/lib/api';
 import AvatarMember, {
+	getPhoto,
 	AVATAR_PERSON_CLASS,
 	AVATAR_PERSON_NOPHOTO_CLASS,
 } from './AvatarMember';
@@ -23,12 +24,8 @@ describe('AvatarMember', function() {
 		const MOCK_MEMBER_NO_PHOTO = { ...MOCK_MEMBER };
 		MOCK_MEMBER_NO_PHOTO.photo = {};
 
-		const avatarMember = shallow(
-			<AvatarMember member={MOCK_MEMBER_NO_PHOTO} />
-		);
-		expect(avatarMember.find(`.${AVATAR_PERSON_NOPHOTO_CLASS}`).exists()).toBe(
-			true
-		);
+		const avatarMember = shallow(<AvatarMember member={MOCK_MEMBER_NO_PHOTO} />);
+		expect(avatarMember.find(`.${AVATAR_PERSON_NOPHOTO_CLASS}`).exists()).toBe(true);
 	});
 
 	it('should render member photo on large size', () => {
@@ -77,9 +74,7 @@ describe('AvatarMember', function() {
 			photo: { ...MOCK_MEMBER.photo, thumb_link: 'test image' },
 		};
 		const avatarMember = shallow(<AvatarMember member={mockMember} />);
-		expect(avatarMember.find(`.${AVATAR_PERSON_NOPHOTO_CLASS}`).exists()).toBe(
-			false
-		);
+		expect(avatarMember.find(`.${AVATAR_PERSON_NOPHOTO_CLASS}`).exists()).toBe(false);
 		expect(avatarMember.find(Icon).exists()).toBe(false);
 	});
 
@@ -92,6 +87,33 @@ describe('AvatarMember', function() {
 			};
 			const avatarMember = shallow(<AvatarMember {...props} />);
 			expect(avatarMember.find(`.avatar--${variant}`).exists()).toBe(true);
+		});
+	});
+
+	describe('getPhoto', function() {
+		it('returns undefined if member.photo is undefined', function() {
+			const member = { ...MOCK_MEMBER, photo: undefined };
+			expect(getPhoto(member.photo, 'big')).toBe(undefined);
+		});
+
+		it('returns photo_link for member.photo and big size', function() {
+			expect(getPhoto(MOCK_MEMBER.photo, 'big')).toBe(MOCK_MEMBER.photo.photo_link);
+		});
+
+		it('returns highres_link for member.photo and big size in case photo_link is undefined', function() {
+			const member = {
+				...MOCK_MEMBER,
+				photo: {
+					...MOCK_MEMBER.photo,
+					highres_link: 'http://placekitten.com/g/500/500',
+					photo_link: undefined,
+				}
+			};
+			expect(getPhoto(member.photo, 'big')).toBe(member.photo.highres_link);
+		});
+
+		it('returns thumb_link for member.photo and small size', function() {
+			expect(getPhoto(MOCK_MEMBER.photo)).toBe(MOCK_MEMBER.photo.thumb_link);
 		});
 	});
 });

--- a/src/media/avatarmember.test.js
+++ b/src/media/avatarmember.test.js
@@ -41,6 +41,16 @@ describe('AvatarMember', function() {
 		expect(avatarMember.find(Avatar).prop('src')).toBe(mockPhoto);
 	});
 
+	it('should render member highres_link on large size if no photo_link', () => {
+		const mockPhoto = 'photo image';
+		const mockMember = {
+			...MOCK_MEMBER,
+			photo: { highres_link: mockPhoto },
+		};
+		const avatarMember = shallow(<AvatarMember member={mockMember} large />);
+		expect(avatarMember.find(Avatar).prop('src')).toBe(mockPhoto);
+	});
+
 	it('should render thumbnail photo on regular size', () => {
 		const mockPhoto = 'photo image';
 		const mockMember = {


### PR DESCRIPTION
#### Related issues
https://meetup.atlassian.net/browse/MG-2498
mup-web pr: https://github.com/meetup/mup-web/pull/4139

#### Description
From new member_list endpoint we receive only `highres_link` and `thumb_link` for Photo. Use `highres_link` as a fallback for large size in case `photo_link` is not present.

#### Screenshots (if applicable)

