### PR TITLE
Hide previous and next month days in calendar

### DIFF
--- a/assets/scss/components/_calendar.scss
+++ b/assets/scss/components/_calendar.scss
@@ -362,6 +362,11 @@ $calendarWidth: 310px;
 	cursor: default;
 }
 
+.flatpickr-day.prevMonthDay,
+.flatpickr-day.nextMonthDay {
+	visibility: hidden;
+}
+
 .flatpickr-day.disabled,
 .flatpickr-day.disabled:hover {
 	color: rgba(57, 57, 57, 0.1);

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "engine": "node >=6.5.0",
   "scripts": {
     "build": "babel src --out-dir lib --ignore test.js,test.jsx,story.jsx --source-maps",
+    "build:watch": "yarn build --watch",
     "coveralls": "if [ \"${TRAVIS_PULL_REQUEST}\" = \"false\" ] && [ \"${COVERALLS_REPO_TOKEN}\" != \"\" ]; then cat coverage/lcov.info | coveralls; fi",
     "lint": "yarn run lint:base --fix",
     "lint:base": "eslint . --ext .js,.jsx",


### PR DESCRIPTION
### Related issues
Fixes https://meetup.atlassian.net/browse/MG-2397

### Description

Hides days from "previous" and "next" months while viewing any given month,

### Screenshots
![screen shot 2018-08-07 at 11 50 09 am](https://user-images.githubusercontent.com/149517/43792946-1fd95eb8-9a48-11e8-886e-158a67dee412.png)
![screen shot 2018-08-07 at 11 51 01 am](https://user-images.githubusercontent.com/149517/43792951-21ddb790-9a48-11e8-8fe3-483a82bf122d.png)