### PR TITLE
fix 'max' comparison and add tests

### DIFF
--- a/src/forms/FieldsetTime.jsx
+++ b/src/forms/FieldsetTime.jsx
@@ -61,13 +61,13 @@ const getValueComponents = (
  * the most recent valid value that has been entered
  * getValidValue(10, '0123') === 3;
  * getValidValue(10, '01234') === 4;
- * getValidValue(100, '0123467') === 67
- * getValidValue(500, '0123467') === 467
+ * getValidValue(100, '0123456') === 56
+ * getValidValue(500, '0123456') === 456
  */
-const getValidValue = (max: number, value: string): number => {
+export const getValidValue = (max: number, value: string): number => {
 	const maxDigits = max.toString().length;
 	const value2digit = parseInt(value.slice(-maxDigits), 10);
-	return value2digit >= max ? parseInt(value.slice(-(maxDigits - 1)), 10) : value2digit;
+	return value2digit > max ? parseInt(value.slice(-(maxDigits - 1)), 10) : value2digit;
 };
 
 /*

--- a/src/forms/fieldsetTime.test.jsx
+++ b/src/forms/fieldsetTime.test.jsx
@@ -7,9 +7,20 @@ import FieldsetTime, {
 	MINUTES_INPUT_NAME,
 	UP_ARROW,
 	DOWN_ARROW,
+	getValidValue,
 } from './FieldsetTime';
 
-// TODO: could use some inline snapshots here - upgrade Jest to make it happen
+describe('getValidValue', () => {
+	test.each([
+		[10, '0123', 3],
+		[10, '01234', 4],
+		[100, '0123456', 56],
+		[500, '0123456', 456],
+		[100, '100', 100], // exact max is ok
+	])('getValidValue(%i, %i)', (max, value, expected) => {
+		expect(getValidValue(max, value)).toBe(expected);
+	});
+});
 describe('FieldsetTime', () => {
 	const MOCK_PROPS = {
 		name: 'mocktime',


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/MG-2471

#### Description

The text-based time input was topping out at 'max - 1' instead of max.

This is really just a one-character code change, but I've fixed some comment typos and added unit tests for the problematic function

