### PR TITLE
allow manual toggle of tooltip

### DIFF
--- a/src/interactive/Tooltip.jsx
+++ b/src/interactive/Tooltip.jsx
@@ -259,7 +259,16 @@ Tooltip.propTypes = {
 	/** Whether to render the dropdown content directly in the component instead of bulling it out and attaching to the document root */
 	noPortal: PropTypes.bool,
 	/** Required function to close the dropdown when working with a manually toggled tooltip */
-	onClose: PropTypes.func,
+	onClose: (props, propName, componentName) => {
+		if (
+			props.manualToggle === true &&
+			(props[propName] === undefined || typeof props[propName] !== 'function')
+		) {
+			return new Error(
+				'The onClose function is required if manualToggle is passed to this component!'
+			);
+		}
+	},
 };
 
 export default Tooltip;

--- a/src/interactive/Tooltip.jsx
+++ b/src/interactive/Tooltip.jsx
@@ -22,7 +22,47 @@ class Tooltip extends React.PureComponent {
 		};
 	}
 
+	componentDidMount() {
+		if (this.props.manualToggle) {
+			document.addEventListener('click', this.handleClickOutsideContent);
+		}
+	}
+
+	componentWillUnmount() {
+		if (this.props.manualToggle) {
+			document.removeEventListener('click', this.handleClickOutsideContent);
+		}
+	}
+
+	static getDerivedStateFromProps(nextProps, prevState) {
+		if (nextProps.manualToggle && prevState.isActive !== nextProps.isActive) {
+			return { isActive: nextProps.isActive };
+		}
+		return prevState;
+	}
+
+	handleClickOutsideContent = e => {
+		// only close the content if a user click on anything but the trigger or the content
+		if (
+			this.contentRef &&
+			this.triggerRef &&
+			!this.contentRef.contains(e.target) &&
+			!this.triggerRef.contains(e.target)
+		) {
+			this.closeContent(e);
+		}
+	};
+
 	closeContent(e) {
+		if (this.props.manualToggle) {
+			if (this.props.onClick) {
+				this.props.onClick(e);
+				return;
+			}
+			this.props.onClose && this.props.onClose();
+			return;
+		}
+
 		this.setState(() => ({ isActive: false }));
 
 		if (this.props.onBlur) {
@@ -51,7 +91,7 @@ class Tooltip extends React.PureComponent {
 			if (!this.contentRef.contains(document.activeElement)) {
 				this.closeContent(e);
 			}
-		}, 1);
+		}, 0);
 	}
 
 	render() {
@@ -68,20 +108,20 @@ class Tooltip extends React.PureComponent {
 			direction,
 			manualToggle,
 			withClose,
-			onClick, // eslint-disable-line no-unused-vars
 			...other
 		} = this.props;
 
+		const { isActive } = this.state;
+
 		// Do not pass along to children
 		delete other.isActive;
+		delete other.onClick;
 
 		const classNames = {
 			dropdown: cx(className, 'popup', {
 				'popup--noPortal': noPortal,
 			}),
 		};
-
-		const isActive = manualToggle ? this.props.isActive : this.state.isActive;
 
 		const getTrigger = () => {
 			return this.triggerRef;
@@ -94,15 +134,15 @@ class Tooltip extends React.PureComponent {
 		return (
 			<div
 				className={classNames.dropdown}
-				onMouseLeave={this.closeContent}
+				onMouseLeave={manualToggle ? undefined : this.closeContent}
 				{...other}
 			>
 				<div
 					ref={el => (this.triggerRef = el)}
 					className="popup-trigger"
-					onFocus={this.openContent}
-					onBlur={this.onBlur}
-					onMouseEnter={this.openContent}
+					onFocus={manualToggle ? undefined : this.openContent}
+					onBlur={manualToggle ? undefined : this.onBlur}
+					onMouseEnter={manualToggle ? undefined : this.openContent}
 					aria-labelledby={id}
 				>
 					{trigger}
@@ -218,6 +258,8 @@ Tooltip.propTypes = {
 
 	/** Whether to render the dropdown content directly in the component instead of bulling it out and attaching to the document root */
 	noPortal: PropTypes.bool,
+	/** Required function to close the dropdown when working with a manually toggled tooltip */
+	onClose: PropTypes.func,
 };
 
 export default Tooltip;

--- a/src/interactive/tooltip.story.jsx
+++ b/src/interactive/tooltip.story.jsx
@@ -35,6 +35,10 @@ class ManualToggleDropdown extends React.PureComponent {
 		this.setState(() => ({ tooltipOpen: !this.state.tooltipOpen }));
 	}
 
+	closeDropdown = () => {
+		this.setState(() => ({ tooltipOpen: false }));
+	};
+
 	render() {
 		return (
 			<Tooltip
@@ -48,6 +52,8 @@ class ManualToggleDropdown extends React.PureComponent {
 					</Button>
 				}
 				content={dropdownContent}
+				withClose
+				onClose={this.closeDropdown}
 			/>
 		);
 	}


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/MG-2364

#### Description
Accidentally removed the ability to click on the x in the tooltip to close it. This adds it back and allows the ability to close the tooltip by clicking outside of it. 