### PR TITLE
Adds justifyItems to Flex component

### DIFF
--- a/assets/scss/components/_flex.scss
+++ b/assets/scss/components/_flex.scss
@@ -2,7 +2,8 @@
 	@include flexParent("row", false);
 }
 
-.flex-item {
+.flex-item,
+.flex-item--justifyLeft {
 	@include flexChild("grow");
 	padding-left: var(--responsive-space);
 
@@ -119,6 +120,21 @@ $flexGrowFactors: 1, 2, 3, 4, 5, 6, 7;
 	.flex-item {
 		padding-left: 0;
 		padding-right: var(--responsive-space);
+
+		&:last-child {
+			padding-right: 0;
+		}
+	}
+}
+
+.flex--justifyCenter {
+	.flex-item {
+		padding-left: calc(var(--responsive-space) / 2);
+		padding-right: calc(var(--responsive-space) / 2);
+
+		&:first-child {
+			padding-left: 0;
+		}
 
 		&:last-child {
 			padding-right: 0;

--- a/assets/scss/components/_flex.scss
+++ b/assets/scss/components/_flex.scss
@@ -114,3 +114,14 @@ $flexGrowFactors: 1, 2, 3, 4, 5, 6, 7;
 		align-items: $aprop;
 	}
 }
+
+.flex--justifyRight {
+	.flex-item {
+		padding-left: 0;
+		padding-right: var(--responsive-space);
+
+		&:last-child {
+			padding-right: 0;
+		}
+	}
+}

--- a/src/forms/RadioButtonGroup.jsx
+++ b/src/forms/RadioButtonGroup.jsx
@@ -44,7 +44,7 @@ export default class RadioButtonGroup extends PureComponent {
 			name,
 			className,
 			wrap,
-			justifyItemsRight,
+			justifyItems,
 		} = this.props;
 
 		const switchDirectionAttr = switchDirection ? { switchDirection } : '';
@@ -55,7 +55,7 @@ export default class RadioButtonGroup extends PureComponent {
 				{...switchDirectionAttr}
 				className={className}
 				wrap={wrap}
-				justifyItemsRight={justifyItemsRight}
+				justifyItems={justifyItems}
 			>
 				{React.Children.map(children, option => (
 					<FlexItem shrink>

--- a/src/forms/RadioButtonGroup.jsx
+++ b/src/forms/RadioButtonGroup.jsx
@@ -44,6 +44,7 @@ export default class RadioButtonGroup extends PureComponent {
 			name,
 			className,
 			wrap,
+			justifyItemsRight,
 		} = this.props;
 
 		const switchDirectionAttr = switchDirection ? { switchDirection } : '';
@@ -54,6 +55,7 @@ export default class RadioButtonGroup extends PureComponent {
 				{...switchDirectionAttr}
 				className={className}
 				wrap={wrap}
+				justifyItemsRight={justifyItemsRight}
 			>
 				{React.Children.map(children, option => (
 					<FlexItem shrink>

--- a/src/layout/Flex.jsx
+++ b/src/layout/Flex.jsx
@@ -33,6 +33,7 @@ export const FLEX_COLUMN_CLASS = `${FLEX_CLASS}--${DIRECTION_COLUMN}`;
 export const FLEX_WRAP_CLASS = `${FLEX_CLASS}--wrap`;
 export const FLEX_NOGUTTER_CLASS = `${FLEX_CLASS}--noGutters`;
 export const FLEX_ALIGN_CLASS = `${FLEX_CLASS}--align`;
+export const FLEX_JUSTIFY_RIGHT_CLASS = `${FLEX_CLASS}--justifyRight`;
 
 /**
  * Design System Component: Provides `Flex` styled container for ideal use with `FlexItem` content
@@ -56,6 +57,7 @@ export class FlexComponent extends React.Component {
 			className,
 			loadingProps = {}, // eslint-disable-line no-unused-vars
 			isLoading,
+			justifyItemsRight,
 			...other
 		} = this.props;
 
@@ -89,6 +91,7 @@ export class FlexComponent extends React.Component {
 				[`${FLEX_ALIGN_CLASS}${VALID_ALIGNMENTS[align]}`]: align,
 				[FLEX_WRAP_CLASS]: wrap,
 				'component--isLoading': isLoading,
+				[FLEX_JUSTIFY_RIGHT_CLASS]: justifyItemsRight,
 			},
 			className
 		);

--- a/src/layout/Flex.jsx
+++ b/src/layout/Flex.jsx
@@ -24,6 +24,12 @@ export const VALID_SPACE = {
 	flexStart: 'flexStart',
 };
 
+export const VALID_ITEM_JUSTIFY = {
+	left: 'left',
+	right: 'right',
+	center: 'center',
+};
+
 export const DIRECTION_ROW = 'row';
 export const DIRECTION_COLUMN = 'column';
 
@@ -33,7 +39,9 @@ export const FLEX_COLUMN_CLASS = `${FLEX_CLASS}--${DIRECTION_COLUMN}`;
 export const FLEX_WRAP_CLASS = `${FLEX_CLASS}--wrap`;
 export const FLEX_NOGUTTER_CLASS = `${FLEX_CLASS}--noGutters`;
 export const FLEX_ALIGN_CLASS = `${FLEX_CLASS}--align`;
+export const FLEX_JUSTIFY_LEFT_CLASS = `${FLEX_CLASS}--justifyLeft`;
 export const FLEX_JUSTIFY_RIGHT_CLASS = `${FLEX_CLASS}--justifyRight`;
+export const FLEX_JUSTIFY_CENTER_CLASS = `${FLEX_CLASS}--justifyCenter`;
 
 /**
  * Design System Component: Provides `Flex` styled container for ideal use with `FlexItem` content
@@ -57,7 +65,7 @@ export class FlexComponent extends React.Component {
 			className,
 			loadingProps = {}, // eslint-disable-line no-unused-vars
 			isLoading,
-			justifyItemsRight,
+			justifyItems,
 			...other
 		} = this.props;
 
@@ -91,7 +99,9 @@ export class FlexComponent extends React.Component {
 				[`${FLEX_ALIGN_CLASS}${VALID_ALIGNMENTS[align]}`]: align,
 				[FLEX_WRAP_CLASS]: wrap,
 				'component--isLoading': isLoading,
-				[FLEX_JUSTIFY_RIGHT_CLASS]: justifyItemsRight,
+				[FLEX_JUSTIFY_LEFT_CLASS]: justifyItems === VALID_ITEM_JUSTIFY.left,
+				[FLEX_JUSTIFY_RIGHT_CLASS]: justifyItems === VALID_ITEM_JUSTIFY.right,
+				[FLEX_JUSTIFY_CENTER_CLASS]: justifyItems === VALID_ITEM_JUSTIFY.center,
 			},
 			className
 		);

--- a/src/layout/flex.story.jsx
+++ b/src/layout/flex.story.jsx
@@ -495,8 +495,46 @@ storiesOf('Layout/Flex', module)
 			},
 		}
 	)
+	.add('justify items left', () => (
+		<Flex style={(flexParentStyles, { padding: 0 })} justifyItems="left">
+			<FlexItem style={flexItemStyles}>
+				<div style={boxStyles}>Item 1</div>
+			</FlexItem>
+			<FlexItem style={flexItemStyles}>
+				<div style={boxStyles}>Item 2</div>
+			</FlexItem>
+			<FlexItem style={flexItemStyles}>
+				<div style={boxStyles}>Item 3</div>
+			</FlexItem>
+			<FlexItem style={flexItemStyles}>
+				<div style={boxStyles}>Item 4</div>
+			</FlexItem>
+			<FlexItem style={flexItemStyles}>
+				<div style={boxStyles}>Item 5</div>
+			</FlexItem>
+		</Flex>
+	))
 	.add('justify items right', () => (
-		<Flex style={(flexParentStyles, { padding: 0 })} justifyItemsRight>
+		<Flex style={(flexParentStyles, { padding: 0 })} justifyItems="right">
+			<FlexItem style={flexItemStyles}>
+				<div style={boxStyles}>Item 1</div>
+			</FlexItem>
+			<FlexItem style={flexItemStyles}>
+				<div style={boxStyles}>Item 2</div>
+			</FlexItem>
+			<FlexItem style={flexItemStyles}>
+				<div style={boxStyles}>Item 3</div>
+			</FlexItem>
+			<FlexItem style={flexItemStyles}>
+				<div style={boxStyles}>Item 4</div>
+			</FlexItem>
+			<FlexItem style={flexItemStyles}>
+				<div style={boxStyles}>Item 5</div>
+			</FlexItem>
+		</Flex>
+	))
+	.add('justify items center', () => (
+		<Flex style={(flexParentStyles, { padding: 0 })} justifyItems="center">
 			<FlexItem style={flexItemStyles}>
 				<div style={boxStyles}>Item 1</div>
 			</FlexItem>

--- a/src/layout/flex.story.jsx
+++ b/src/layout/flex.story.jsx
@@ -495,6 +495,25 @@ storiesOf('Layout/Flex', module)
 			},
 		}
 	)
+	.add('justify items right', () => (
+		<Flex style={(flexParentStyles, { padding: 0 })} justifyItemsRight>
+			<FlexItem style={flexItemStyles}>
+				<div style={boxStyles}>Item 1</div>
+			</FlexItem>
+			<FlexItem style={flexItemStyles}>
+				<div style={boxStyles}>Item 2</div>
+			</FlexItem>
+			<FlexItem style={flexItemStyles}>
+				<div style={boxStyles}>Item 3</div>
+			</FlexItem>
+			<FlexItem style={flexItemStyles}>
+				<div style={boxStyles}>Item 4</div>
+			</FlexItem>
+			<FlexItem style={flexItemStyles}>
+				<div style={boxStyles}>Item 5</div>
+			</FlexItem>
+		</Flex>
+	))
 	.add('isLoading', () => (
 		<Flex isLoading style={flexParentStyles}>
 			<FlexItem style={flexItemStyles}>

--- a/src/layout/flex.test.jsx
+++ b/src/layout/flex.test.jsx
@@ -11,6 +11,7 @@ import {
 	FLEX_WRAP_CLASS,
 	FLEX_NOGUTTER_CLASS,
 	FLEX_ALIGN_CLASS,
+	FLEX_JUSTIFY_RIGHT_CLASS,
 	VALID_ALIGNMENTS,
 	VALID_BREAKPOINTS,
 	VALID_SPACE,
@@ -154,6 +155,13 @@ describe('Flex', function() {
 					flex.hasClass(`${VALID_BREAKPOINTS[breakpoint]}_flex--columnReverse`)
 				).toBe(true);
 			});
+		});
+	});
+	describe('justifyItemsRight', () => {
+		it(`check that the component has ${FLEX_JUSTIFY_RIGHT_CLASS} class`, function() {
+			const flex = shallow(<FlexComponent justifyItemsRight />);
+			expect(flex.hasClass(FLEX_CLASS)).toBe(true);
+			expect(flex.hasClass(FLEX_JUSTIFY_RIGHT_CLASS)).toBe(true);
 		});
 	});
 });

--- a/src/layout/flex.test.jsx
+++ b/src/layout/flex.test.jsx
@@ -11,7 +11,9 @@ import {
 	FLEX_WRAP_CLASS,
 	FLEX_NOGUTTER_CLASS,
 	FLEX_ALIGN_CLASS,
+	FLEX_JUSTIFY_LEFT_CLASS,
 	FLEX_JUSTIFY_RIGHT_CLASS,
+	FLEX_JUSTIFY_CENTER_CLASS,
 	VALID_ALIGNMENTS,
 	VALID_BREAKPOINTS,
 	VALID_SPACE,
@@ -157,11 +159,25 @@ describe('Flex', function() {
 			});
 		});
 	});
-	describe('justifyItemsRight', () => {
+	describe('justifyItems left', () => {
+		it(`check that the component has ${FLEX_JUSTIFY_LEFT_CLASS} class`, function() {
+			const flex = shallow(<FlexComponent justifyItems="left" />);
+			expect(flex.hasClass(FLEX_CLASS)).toBe(true);
+			expect(flex.hasClass(FLEX_JUSTIFY_LEFT_CLASS)).toBe(true);
+		});
+	});
+	describe('justifyItems right', () => {
 		it(`check that the component has ${FLEX_JUSTIFY_RIGHT_CLASS} class`, function() {
-			const flex = shallow(<FlexComponent justifyItemsRight />);
+			const flex = shallow(<FlexComponent justifyItems="right" />);
 			expect(flex.hasClass(FLEX_CLASS)).toBe(true);
 			expect(flex.hasClass(FLEX_JUSTIFY_RIGHT_CLASS)).toBe(true);
+		});
+	});
+	describe('justifyItems center', () => {
+		it(`check that the component has ${FLEX_JUSTIFY_CENTER_CLASS} class`, function() {
+			const flex = shallow(<FlexComponent justifyItems="center" />);
+			expect(flex.hasClass(FLEX_CLASS)).toBe(true);
+			expect(flex.hasClass(FLEX_JUSTIFY_CENTER_CLASS)).toBe(true);
 		});
 	});
 });


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/MG-2708

#### Description
Adds the option to justify flex item padding to the right instead of to the left. Not convinced about the naming.

#### Screenshots (if applicable)
![screen shot 2018-09-04 at 1 30 09 pm](https://user-images.githubusercontent.com/18121068/45047308-b07d4880-b046-11e8-832e-d1faa69438e5.png)

