### PR TITLE
add photoSrc property for AvatarMember

### DIFF
--- a/src/media/AvatarMember.jsx
+++ b/src/media/AvatarMember.jsx
@@ -10,11 +10,16 @@ export const AVATAR_PERSON_FB_CLASS = 'avatar--fbFriend';
 export const AVATAR_PERSON_NOPHOTO_CLASS = 'avatar--noPhoto';
 const AVATAR_ICON_BADGE_CLASS = 'svg--avatarBadge';
 
-export const getPhoto = (photo, size) => {
+export const getPhoto = (photo, size, photoSrc) => {
+	// custom photo link removes dependency on `size` prop and gives more flexibility for the component
+	// e.g. we could use large avatars with `thumb_link` to improve performance
+	if (photoSrc) {
+		return photoSrc;
+	}
 	if (!photo) {
 		return undefined;
 	}
-	switch(size) {
+	switch (size) {
 		case 'big':
 		case 'large':
 		case 'xxlarge': // clear handling of these 3 overlapping size handlers
@@ -30,11 +35,11 @@ export const getPhoto = (photo, size) => {
  */
 class AvatarMember extends React.PureComponent {
 	render() {
-		const { member, org, fbFriend, className, ...other } = this.props;
+		const { member, org, fbFriend, className, photoSrc, ...other } = this.props;
 		const { big, large, xxlarge } = other;
 
 		const photoSize = big || large || xxlarge ? 'big' : 'default';
-		const photoLink = getPhoto(member.photo, photoSize);
+		const photoLink = getPhoto(member.photo, photoSize, photoSrc);
 		const showNoPhoto = typeof photoLink !== 'string'; // _any_ non-string value should be considered invalid.
 
 		const classNames = cx(
@@ -99,6 +104,9 @@ AvatarMember.propTypes = {
 
 	/** Whether this avatar is for a person the user is friends with on FB */
 	fbFriend: PropTypes.bool,
+
+	/** Custom photo url */
+	photoSrc: PropTypes.string,
 };
 
 export default AvatarMember;

--- a/src/media/avatarmember.test.js
+++ b/src/media/avatarmember.test.js
@@ -68,6 +68,30 @@ describe('AvatarMember', function() {
 		expect(avatarMember.find(Avatar).prop('src')).toBe(mockPhoto);
 	});
 
+	it('should render custom photo on small size', () => {
+		const customPhotoLink = 'custom/photo/link';
+		const avatarMember = shallow(
+			<AvatarMember member={MOCK_MEMBER} small photoSrc={customPhotoLink} />
+		);
+		expect(avatarMember.find(Avatar).prop('src')).toBe(customPhotoLink);
+	});
+
+	it('should render custom photo on default size', () => {
+		const customPhotoLink = 'custom/photo/link';
+		const avatarMember = shallow(
+			<AvatarMember member={MOCK_MEMBER} photoSrc={customPhotoLink} />
+		);
+		expect(avatarMember.find(Avatar).prop('src')).toBe(customPhotoLink);
+	});
+
+	it('should render custom photo on large size', () => {
+		const customPhotoLink = 'custom/photo/link';
+		const avatarMember = shallow(
+			<AvatarMember member={MOCK_MEMBER} large photoSrc={customPhotoLink} />
+		);
+		expect(avatarMember.find(Avatar).prop('src')).toBe(customPhotoLink);
+	});
+
 	it('should *not* render the noPhoto variant only when a photo is present', function() {
 		const mockMember = {
 			...MOCK_MEMBER,
@@ -107,13 +131,20 @@ describe('AvatarMember', function() {
 					...MOCK_MEMBER.photo,
 					highres_link: 'http://placekitten.com/g/500/500',
 					photo_link: undefined,
-				}
+				},
 			};
 			expect(getPhoto(member.photo, 'big')).toBe(member.photo.highres_link);
 		});
 
 		it('returns thumb_link for member.photo and small size', function() {
 			expect(getPhoto(MOCK_MEMBER.photo)).toBe(MOCK_MEMBER.photo.thumb_link);
+		});
+
+		it('returns custom photo if passed', function() {
+			const customPhotoLink = 'custom/photo/link';
+			expect(getPhoto(MOCK_MEMBER.photo, 'small', customPhotoLink)).toBe(
+				customPhotoLink
+			);
 		});
 	});
 });


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/MG-2779

#### Description
It seems like we're using the highres image to display a thumbnail next to the member. This is causing some performance issues. We want to use a smaller image.

Custom photo link removes dependency on `size` prop and gives more flexibility for the component
e.g. we could use large avatars with `thumb_link` to improve performance

#### Screenshots (if applicable)

