### PR TITLE
Allow screen readers to read alt text on the Avatar component

### DIFF
--- a/src/media/Avatar.jsx
+++ b/src/media/Avatar.jsx
@@ -46,6 +46,7 @@ class Avatar extends React.PureComponent {
 
 		const aria = {
 			role: 'img',
+			'aria-label': alt,
 		};
 
 		const computedProps = {
@@ -82,6 +83,10 @@ class Avatar extends React.PureComponent {
 		);
 	}
 }
+
+Avatar.defaultProps = {
+	alt: 'Avatar',
+};
 
 Avatar.propTypes = {
 	/** Render Avatar at a smaller size */

--- a/src/media/avatar.story.jsx
+++ b/src/media/avatar.story.jsx
@@ -8,7 +8,7 @@ const MOCK_IMAGE_SRC = 'http://placekitten.com/g/400/400';
 storiesOf('Media/Avatar', module)
 	.addDecorator(decorateWithBasics)
 	.addDecorator(decorateWithInfo)
-	.add('default', () => <Avatar src={MOCK_IMAGE_SRC} />, {
+	.add('default', () => <Avatar src={MOCK_IMAGE_SRC} alt="kitten" />, {
 		info: { text: 'This is the basic usage with the component.' },
 	})
 	.add('small', () => <Avatar src={MOCK_IMAGE_SRC} small />)
@@ -24,6 +24,7 @@ storiesOf('Media/Avatar', module)
 					return action('go to http://google.com')(e);
 				}}
 				src={MOCK_IMAGE_SRC}
+				alt="kitten"
 			/>
 		),
 		{ info: { text: 'To link within the app, supply a `to` prop instead of `href`' } }

--- a/src/navigation/__snapshots__/Nav.test.jsx.snap
+++ b/src/navigation/__snapshots__/Nav.test.jsx.snap
@@ -954,6 +954,7 @@ exports[`Nav should match the snapshot for authenticated pro admins 1`] = `
         >
           <FlexItem>
             <Avatar
+              alt="Avatar"
               className="display--block atMedium_display--none margin--left circular"
               small={true}
               src="https://placeimg.com/640/480/any"

--- a/src/navigation/components/notifications/__snapshots__/Notifications.test.jsx.snap
+++ b/src/navigation/components/notifications/__snapshots__/Notifications.test.jsx.snap
@@ -11,6 +11,7 @@ exports[`Notification component should match snapshot 1`] = `
       shrink={true}
     >
       <Avatar
+        alt="Avatar"
         className="notification-image"
         src="http://photos4.meetupstatic.com/photos/event/5/d/4/a/600_434003882.jpeg"
       />


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/sds-676

#### Description
This pr adds `aria-label` to `<Avatar />` and sets the value to the `alt` prop. I added a default prop to `<Avatar />` instead of requiring one because I didn't want to introduce a breaking change and am unsure if any teams builds fail on lint errors.

