### PR TITLE
NumberInput to always show numerical keypad on ios

### DIFF
--- a/src/forms/NumberInput.jsx
+++ b/src/forms/NumberInput.jsx
@@ -182,6 +182,7 @@ export class NumberInput extends React.PureComponent<Props, State> {
 						<FlexItem>
 							<input
 								type="number"
+								pattern="[0-9]*"
 								id={id}
 								name={name}
 								max={max}

--- a/src/forms/__snapshots__/numberInput.test.jsx.snap
+++ b/src/forms/__snapshots__/numberInput.test.jsx.snap
@@ -12,6 +12,7 @@ Object {
   "onChange": [Function],
   "onFocus": [Function],
   "onKeyDown": [Function],
+  "pattern": "[0-9]*",
   "required": true,
   "step": 1,
   "type": "number",
@@ -45,6 +46,7 @@ exports[`NumberInput basic exists 1`] = `
           onChange={[Function]}
           onFocus={[Function]}
           onKeyDown={[Function]}
+          pattern="[0-9]*"
           required={true}
           step={1}
           type="number"
@@ -106,6 +108,7 @@ Object {
   "onChange": [Function],
   "onFocus": [Function],
   "onKeyDown": [Function],
+  "pattern": "[0-9]*",
   "required": true,
   "step": 1,
   "type": "number",
@@ -123,6 +126,7 @@ exports[`NumberInput basic should specify attributes that are passed in 1`] = `
   onChange={[Function]}
   onFocus={[Function]}
   onKeyDown={[Function]}
+  pattern="[0-9]*"
   placeholder="Guests"
   step={1}
   type="number"


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/sds-754

#### Description
Adding `pattern=[0-9]*` to `<NumberInput />` prompts ios to show the numerical keyboard rather than the qwerty keyboard

#### Screenshots (if applicable)
With `pattern`
![ios-numerical](https://user-images.githubusercontent.com/1270494/45982527-1433d980-c027-11e8-83f9-4ce6023ca1e9.jpg)
Without `pattern`
![ios-qwerty](https://user-images.githubusercontent.com/1270494/45982528-1433d980-c027-11e8-8665-747caa5b4627.jpg)
