### PR TITLE
cleaning up closeOnBodyClick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [6.0]
 
+-   **BREAKING CHANGE** `closeOnBodyClick` is being deprecated from `Dropdown` component. Continue using
+    `manualToggle` and `isActive` props instead.
+
+# [6.0]
+
 -   **BREAKING CHANGE** `NumberInput`'s `onChange` callback will now receive a
     `number | null` argument, not a `SyntheticInputEvent` (or the previous fake event).
     Consumers should update their `onChange` handlers to expect _only_ the number

--- a/src/interactive/Dropdown.jsx
+++ b/src/interactive/Dropdown.jsx
@@ -50,9 +50,6 @@ type Props = {
 	/** Props to pass to the `Downshift` component */
 	downshiftProps?: Object,
 
-	/** Whether the dropdown should close when a click on the body is registered */
-	closeOnBodyClick?: boolean,
-
 	/** Optional custom function to execute on dropdown click */
 	onClick?: (e: SyntheticMouseEvent<*>) => void,
 };
@@ -70,7 +67,6 @@ class Dropdown extends React.PureComponent<Props, State> {
 		direction: 'bottom',
 		minWidth: '0px',
 		noPortal: false,
-		closeOnBodyClick: false,
 	};
 
 	closeContent = (e: SyntheticKeyboardEvent<*> | SyntheticMouseEvent<*>) => {
@@ -107,11 +103,6 @@ class Dropdown extends React.PureComponent<Props, State> {
 	};
 
 	onBodyClick = (e: SyntheticMouseEvent<*>) => {
-		if (this.props.closeOnBodyClick) {
-			this.closeContent(e);
-			return;
-		}
-
 		if (!this.contentRef || !this.triggerRef) {
 			return;
 		}
@@ -171,7 +162,6 @@ class Dropdown extends React.PureComponent<Props, State> {
 		// Do not pass along to children
 		delete other.manualToggle;
 		delete other.isActive;
-		delete other.closeOnBodyClick;
 
 		const classNames = {
 			dropdown: cx(className, 'popup', {

--- a/src/interactive/dropdown.story.jsx
+++ b/src/interactive/dropdown.story.jsx
@@ -187,29 +187,6 @@ storiesOf('Interactive/Dropdown', module)
 		),
 		{ info: { text: 'Use the `menuItems` prop to render a menu' } }
 	)
-	.add(
-		'With menu items and closeOnBodyClick',
-		() => (
-			<Dropdown
-				closeOnBodyClick
-				align="center"
-				minWidth="160px"
-				maxWidth="250px"
-				trigger={<Button small>Open</Button>}
-				onSelect={(selectedItem, stateAndHelpers) => selectedItem.props.onClick()}
-				menuItems={[
-					<div onClick={action('item one click')}>
-						Item one has text that is really long and should wrap once we
-						reach max width
-					</div>,
-					<div onClick={action('item two click')}>Item two</div>,
-					<div onClick={action('item three click')}>Item three</div>,
-				]}
-				noPortal // to test text-wrapping
-			/>
-		),
-		{ info: { text: 'Use the `menuItems` prop to render a menu' } }
-	)
 	.add('with custom toggle functionality', () => (
 		<Flex justify="flexEnd">
 			<FlexItem shrink>

--- a/src/interactive/dropdown.test.jsx
+++ b/src/interactive/dropdown.test.jsx
@@ -134,27 +134,6 @@ describe('Dropdown', () => {
 		});
 	});
 
-	describe('dropdown with menuItems and closeOnBodyClick', () => {
-		const menuItemDropdown = (
-			<Dropdown
-				closeOnBodyClick
-				align="center"
-				trigger={dropdownTrigger}
-				menuItems={[<div>one</div>, <div>two</div>, <div>three</div>]}
-			/>
-		);
-		const menuItemDropdownWrapper = mount(menuItemDropdown);
-		const trigger = menuItemDropdownWrapper.find('.popup-trigger');
-
-		it('closes the dropdown on menu item click', () => {
-			// open menu
-			trigger.simulate('click');
-			// click on some item menu
-			menuItemDropdownWrapper.find(Downshift).simulate('click');
-			expect(menuItemDropdownWrapper.state('isActive').toBeFalsy);
-		});
-	});
-
 	describe('manually toggle dropdown', () => {
 		let closedComponent, trigger;
 


### PR DESCRIPTION
#### Description
- After testing the new prop and talking to @hsbacot  it became apparent that there's no easy way to close the Dropdown after an action has been taken on the menu item contained within. 
- There's now to guarantee that the menu item action (owned by parent and passed through `menuItems`) will fire before the Dropdown closes. As of right now, `manualToggle`, alongside `isActive` is our best bet. 
- This PR removes all `closeOnBodyClick` functionality since it's basically useless (at least the previous PR flowed the file and fixed some bugs). 

#### Screenshots (if applicable)

