### PR TITLE
deprecating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [6.1]
+
+-   **BREAKING CHANGE** `closeOnBodyClick` prop for `Dropdown` component is deprecated.
+    Continue using `manualToggle` in conjunction with `isActive` to manage open/close state of
+    dropdown.
+
 # [6.0]
 
 -   **BREAKING CHANGE** `NumberInput`'s `onChange` callback will now receive a

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_BUILD_NUMBER ?= $(USER)-snapshot
-VERSION ?= 6.0.$(CI_BUILD_NUMBER)
+VERSION ?= 6.1.$(CI_BUILD_NUMBER)
 
 version:
 	@echo $(VERSION)

--- a/src/interactive/Dropdown.jsx
+++ b/src/interactive/Dropdown.jsx
@@ -50,9 +50,6 @@ type Props = {
 	/** Props to pass to the `Downshift` component */
 	downshiftProps?: Object,
 
-	/** Whether the dropdown should close when a click on the body is registered */
-	closeOnBodyClick?: boolean,
-
 	/** Optional custom function to execute on dropdown click */
 	onClick?: (e: SyntheticMouseEvent<*>) => void,
 };
@@ -70,7 +67,6 @@ class Dropdown extends React.PureComponent<Props, State> {
 		direction: 'bottom',
 		minWidth: '0px',
 		noPortal: false,
-		closeOnBodyClick: false,
 	};
 
 	closeContent = (e: SyntheticKeyboardEvent<*> | SyntheticMouseEvent<*>) => {
@@ -107,11 +103,6 @@ class Dropdown extends React.PureComponent<Props, State> {
 	};
 
 	onBodyClick = (e: SyntheticMouseEvent<*>) => {
-		if (this.props.closeOnBodyClick) {
-			this.closeContent(e);
-			return;
-		}
-
 		if (!this.contentRef || !this.triggerRef) {
 			return;
 		}
@@ -171,7 +162,6 @@ class Dropdown extends React.PureComponent<Props, State> {
 		// Do not pass along to children
 		delete other.manualToggle;
 		delete other.isActive;
-		delete other.closeOnBodyClick;
 
 		const classNames = {
 			dropdown: cx(className, 'popup', {

--- a/src/interactive/dropdown.story.jsx
+++ b/src/interactive/dropdown.story.jsx
@@ -187,29 +187,6 @@ storiesOf('Interactive/Dropdown', module)
 		),
 		{ info: { text: 'Use the `menuItems` prop to render a menu' } }
 	)
-	.add(
-		'With menu items and closeOnBodyClick',
-		() => (
-			<Dropdown
-				closeOnBodyClick
-				align="center"
-				minWidth="160px"
-				maxWidth="250px"
-				trigger={<Button small>Open</Button>}
-				onSelect={(selectedItem, stateAndHelpers) => selectedItem.props.onClick()}
-				menuItems={[
-					<div onClick={action('item one click')}>
-						Item one has text that is really long and should wrap once we
-						reach max width
-					</div>,
-					<div onClick={action('item two click')}>Item two</div>,
-					<div onClick={action('item three click')}>Item three</div>,
-				]}
-				noPortal // to test text-wrapping
-			/>
-		),
-		{ info: { text: 'Use the `menuItems` prop to render a menu' } }
-	)
 	.add('with custom toggle functionality', () => (
 		<Flex justify="flexEnd">
 			<FlexItem shrink>

--- a/src/interactive/dropdown.test.jsx
+++ b/src/interactive/dropdown.test.jsx
@@ -134,27 +134,6 @@ describe('Dropdown', () => {
 		});
 	});
 
-	describe('dropdown with menuItems and closeOnBodyClick', () => {
-		const menuItemDropdown = (
-			<Dropdown
-				closeOnBodyClick
-				align="center"
-				trigger={dropdownTrigger}
-				menuItems={[<div>one</div>, <div>two</div>, <div>three</div>]}
-			/>
-		);
-		const menuItemDropdownWrapper = mount(menuItemDropdown);
-		const trigger = menuItemDropdownWrapper.find('.popup-trigger');
-
-		it('closes the dropdown on menu item click', () => {
-			// open menu
-			trigger.simulate('click');
-			// click on some item menu
-			menuItemDropdownWrapper.find(Downshift).simulate('click');
-			expect(menuItemDropdownWrapper.state('isActive').toBeFalsy);
-		});
-	});
-
 	describe('manually toggle dropdown', () => {
 		let closedComponent, trigger;
 


### PR DESCRIPTION
#### Related issues
Revert of https://github.com/meetup/meetup-web-components/pull/642

#### Description
- Sadly after many different iterations and with the help of @browne0 and @hsbacot, we've determined that 
there was no easy way to add a prop that would allow us to close the Dropdown after item menu click _and_ be simpler to use than `manualToggle` in conjunction with `isActive`. 
- Some iterations did indeed work, but added only to the complexity and overhead that we were trying to avoid in the first place. 
- As it stands right now, `manualToggle` seems to be the best way to close the Dropdown after menu item click. This might be worth revisiting in the future. 

