### PR TITLE
adding webkit overflow scroll so that ios scrolls modal content

### DIFF
--- a/assets/scss/components/_modal.scss
+++ b/assets/scss/components/_modal.scss
@@ -58,6 +58,8 @@ $modal-width: 440px;
 }
 
 .view--modal {
+	-webkit-overflow-scrolling: touch;
+
 	.stripe-heroContent {
 		min-height: 0;
 		text-align: inherit;


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/sds-740

#### Description
This allows scrolling on containers that aren't the body on ios
More info here: https://github.com/tachyons-css/tachyons/issues/566

