### PR TITLE
linting only src directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:watch": "yarn build --watch",
     "coveralls": "if [ \"${TRAVIS_PULL_REQUEST}\" = \"false\" ] && [ \"${COVERALLS_REPO_TOKEN}\" != \"\" ]; then cat coverage/lcov.info | coveralls; fi",
     "lint": "yarn run lint:base --fix",
-    "lint:base": "eslint . --ext .js,.jsx",
+    "lint:base": "eslint src/ --ext .js,.jsx",
     "lint:airbnb": "eslint --ext .js,.jsx -c .eslintrc.airbnb.js",
     "lint:prettier": "prettier -l {src,src/**,src/**/**,assets/,assets/**}/*.{js,jsx,scss}",
     "modules:clean": "rm -rf node_modules",


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-726

#### Description
Configured `lint` command to only run eslint on the `src` directory allowing it to ignore the linting errors on the compiled code in `lib/`.

