### PR TITLE
MP-2084: Added new radio-group behavior

### DIFF
--- a/src/forms/RadioButtonGroup.jsx
+++ b/src/forms/RadioButtonGroup.jsx
@@ -45,6 +45,7 @@ export default class RadioButtonGroup extends PureComponent {
 			className,
 			wrap,
 			justifyItems,
+			isActive,
 		} = this.props;
 
 		const switchDirectionAttr = switchDirection ? { switchDirection } : '';
@@ -63,7 +64,9 @@ export default class RadioButtonGroup extends PureComponent {
 							onChange: this.handleChange,
 							...option.props,
 							name,
-							checked: option.props.value === this.state.selectedValue,
+							checked: isActive
+								? option.props.value === this.state.selectedValue
+								: false,
 						})}
 					</FlexItem>
 				))}
@@ -89,8 +92,12 @@ RadioButtonGroup.propTypes = {
 
 	/** Callback that happens when the input changes */
 	onChange: PropTypes.func,
+
+	/** defines whether buttons enabled or disabled */
+	isActive: PropTypes.boolean,
 };
 
 RadioButtonGroup.defaultProps = {
 	direction: 'row',
+	isActive: true,
 };

--- a/src/forms/radioButtonGroup.test.jsx
+++ b/src/forms/radioButtonGroup.test.jsx
@@ -23,6 +23,11 @@ describe('RadioButtonGroup', () => {
 		expect(getWrapper()).toMatchSnapshot();
 	});
 
+	it('should not have indicator when `isActive` is set to false', () => {
+		const wrapper = getWrapper({ isActive: false });
+		expect(wrapper.find('div.radio-indicator').length).toEqual(0);
+	});
+
 	it('should apply switchDirection, direction, and wrap props', () => {
 		expect(
 			getWrapper({ switchDirection: 'medium', direction: 'column', wrap: true })

--- a/src/forms/redux-form/RadioButtonGroup.jsx
+++ b/src/forms/redux-form/RadioButtonGroup.jsx
@@ -2,8 +2,9 @@ import { mapProps } from 'recompose';
 
 import RadioButtonGroup from '../RadioButtonGroup';
 
-export const propMapper = ({ input, meta, ...other }) => ({
+export const propMapper = ({ input, meta, isActive, ...other }) => ({
 	selectedValue: input.value,
+	isActive,
 	...input,
 	...other,
 });

--- a/src/forms/redux-form/RadioButtonGroup.test.jsx
+++ b/src/forms/redux-form/RadioButtonGroup.test.jsx
@@ -13,9 +13,11 @@ describe('redux-form RadioButtonGroup', () => {
 			const meta = {
 				error: 'error',
 			};
+			const isActive = true;
 			expect(
 				propMapper({
 					input,
+					isActive,
 					meta,
 					otherProp: 'otherProp',
 				})

--- a/src/forms/redux-form/__snapshots__/RadioButtonGroup.test.jsx.snap
+++ b/src/forms/redux-form/__snapshots__/RadioButtonGroup.test.jsx.snap
@@ -2,6 +2,7 @@
 
 exports[`redux-form RadioButtonGroup propMapper should map the props as expected 1`] = `
 Object {
+  "isActive": true,
   "name": "test-name",
   "onBlur": "onBlur",
   "onChange": "onChange",


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/MP-2084

#### Description
Added new radio-group behavior depending on isActive prop. By passing this attribute you can set radio buttons to disabled state to prevent rendering radio-buttons with default values.

#### Screenshots (if applicable)
### isActive is set to false
![image](https://user-images.githubusercontent.com/36071846/47294577-3284f900-d616-11e8-9e91-fd24c58bfc87.png)

### When no isActive specified
![image](https://user-images.githubusercontent.com/36071846/47294603-44ff3280-d616-11e8-8172-97535b232966.png)
