### PR TITLE
Sds 761 info toggle refactor

### DIFF
--- a/src/interactive/InfoToggle.jsx
+++ b/src/interactive/InfoToggle.jsx
@@ -1,17 +1,22 @@
+// @flow
 import PropTypes from 'prop-types';
-import React from 'react';
+import * as React from 'react';
 
 import Button from '../forms/Button';
 import Tooltip from './Tooltip';
 
-export const InfoTooltipTrigger = props => (
-	<Button
-		reset
-		onClick={e => {
-			e.preventDefault();
-			props.onClick(e);
-		}}
-	>
+type Props = React.ElementConfig<'div'> & {
+	className?: string,
+	/** The content that's rendered inside the tooltip's content bubble */
+	tooltipContent: React.Node,
+	/** The label rendered next to the Tooltip's trigger */
+	label?: string,
+	/** The unique identifier for the Tooltip */
+	tooltipId: string,
+};
+
+export const InfoTooltipTrigger = () => (
+	<Button reset>
 		<span className="infoToggle-trigger align--center" role="img">
 			?
 		</span>
@@ -20,22 +25,25 @@ export const InfoTooltipTrigger = props => (
 
 const InfoToggle = ({
 	className,
-	label,
-	tooltipId,
-	tooltipProps,
+	children,
 	tooltipContent,
-	onClick,
+	label,
+	tooltip,
+	tooltipProps,
+	tooltipId,
 	...other
-}) => {
+}: Props) => {
+	const tooltipOptions = {
+		id: tooltipId,
+		...tooltipProps,
+	};
+
 	return (
 		<div className={className} {...other}>
 			<span className="infoToggle-label">{label}</span>
-			<Tooltip
-				id={tooltipId}
-				trigger={<InfoTooltipTrigger onClick={onClick} />}
-				content={tooltipContent}
-				{...tooltipProps}
-			/>
+			<Tooltip trigger={<InfoTooltipTrigger />} {...tooltipOptions}>
+				{tooltipContent || children}
+			</Tooltip>
 		</div>
 	);
 };

--- a/src/interactive/InfoToggle.jsx
+++ b/src/interactive/InfoToggle.jsx
@@ -41,7 +41,7 @@ const InfoToggle = ({
 		<div className={className} {...other}>
 			<span className="infoToggle-label">{label}</span>
 			<Tooltip trigger={<InfoTooltipTrigger />} {...tooltipOptions}>
-				{tooltipContent || children}
+				{children || tooltipContent}
 			</Tooltip>
 		</div>
 	);

--- a/src/interactive/InfoToggle.jsx
+++ b/src/interactive/InfoToggle.jsx
@@ -1,5 +1,4 @@
 // @flow
-import PropTypes from 'prop-types';
 import * as React from 'react';
 
 import Button from '../forms/Button';
@@ -52,20 +51,6 @@ InfoToggle.defaultProps = {
 	tooltipProps: {
 		align: 'right',
 	},
-};
-
-InfoToggle.propTypes = {
-	/** The content that's rendered inside the tooltip's content bubble */
-	tooltipContent: PropTypes.element,
-
-	/** The label rendered next to the Tooltip's trigger */
-	label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-
-	/** The unique identifier for the Tooltip */
-	tooltipId: PropTypes.string.isRequired,
-
-	/** Props to pass to the Tooltip component */
-	tooltipProps: PropTypes.object,
 };
 
 export default InfoToggle;

--- a/src/interactive/Tooltip.jsx
+++ b/src/interactive/Tooltip.jsx
@@ -61,7 +61,7 @@ class Tooltip extends React.PureComponent {
 	}
 
 	handleClick = () => {
-		this.setState(prevState => ({ isActive: !prevState.isActive }));
+		this.setState(state => ({ isActive: !state.isActive }));
 	};
 
 	onBlur(e) {
@@ -184,7 +184,7 @@ class Tooltip extends React.PureComponent {
 											reset
 										/>
 									)}
-									{content || children}
+									{children || content}
 								</div>
 							</div>
 						)}
@@ -208,10 +208,7 @@ Tooltip.propTypes = {
 	/** The element that opens the tooltip when hovered or focused */
 	trigger: PropTypes.element.isRequired,
 
-	/** The content that's rendered inside the tooltip */
-	children: PropTypes.element,
-
-	/** The content that's rendered inside the tooltip, to be deprecated in favor of children */
+	/** The content that's rendered inside the tooltip, deprecated */
 	content: PropTypes.element,
 
 	/** The horizontal alignment of the tooltip content bubble to the dropdown trigger (defaults to right) */

--- a/src/interactive/Tooltip.jsx
+++ b/src/interactive/Tooltip.jsx
@@ -60,6 +60,10 @@ class Tooltip extends React.PureComponent {
 		}
 	}
 
+	handleClick = () => {
+		this.setState(prevState => ({ isActive: !prevState.isActive }));
+	};
+
 	onBlur(e) {
 		if (!this.contentRef) return;
 
@@ -74,6 +78,7 @@ class Tooltip extends React.PureComponent {
 		const {
 			className,
 			trigger,
+			children,
 			content,
 			align,
 			offset,
@@ -119,6 +124,7 @@ class Tooltip extends React.PureComponent {
 					onFocus={manualToggle ? undefined : this.openContent}
 					onBlur={manualToggle ? undefined : this.onBlur}
 					onMouseEnter={manualToggle ? undefined : this.openContent}
+					onClick={this.handleClick}
 					aria-labelledby={id}
 				>
 					{trigger}
@@ -178,7 +184,7 @@ class Tooltip extends React.PureComponent {
 											reset
 										/>
 									)}
-									{content}
+									{content || children}
 								</div>
 							</div>
 						)}
@@ -203,6 +209,9 @@ Tooltip.propTypes = {
 	trigger: PropTypes.element.isRequired,
 
 	/** The content that's rendered inside the tooltip */
+	children: PropTypes.element,
+
+	/** The content that's rendered inside the tooltip, to be deprecated in favor of children */
 	content: PropTypes.element,
 
 	/** The horizontal alignment of the tooltip content bubble to the dropdown trigger (defaults to right) */

--- a/src/interactive/__snapshots__/tooltip.test.jsx.snap
+++ b/src/interactive/__snapshots__/tooltip.test.jsx.snap
@@ -32,6 +32,42 @@ exports[`Tooltip aligned tooltip matches snapshot 1`] = `
 />
 `;
 
+exports[`Tooltip should toggle the content when the trigger is clicked 1`] = `
+<div
+  className="popup"
+  onMouseLeave={[Function]}
+>
+  <div
+    className="popup-trigger"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onMouseEnter={[Function]}
+  />
+</div>
+`;
+
+exports[`Tooltip should toggle the content when the trigger is clicked 2`] = `
+<div
+  className="popup"
+  onMouseLeave={[Function]}
+>
+  <div
+    className="popup-trigger"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onMouseEnter={[Function]}
+  />
+  <WithMatchMedia(FloatingPosition)
+    direction="bottom"
+    getContent={[Function]}
+    getTrigger={[Function]}
+    noPortal={false}
+  />
+</div>
+`;
+
 exports[`Tooltip tooltip with a close button should render correctly 1`] = `
 <Tooltip
   align="right"
@@ -72,6 +108,7 @@ exports[`Tooltip tooltip with a close button should render correctly 1`] = `
       aria-labelledby="testDropdown"
       className="popup-trigger"
       onBlur={[Function]}
+      onClick={[Function]}
       onFocus={[Function]}
       onMouseEnter={[Function]}
     >

--- a/src/interactive/infoToggle.story.jsx
+++ b/src/interactive/infoToggle.story.jsx
@@ -24,15 +24,7 @@ class ManualInfoToggle extends React.PureComponent {
 			<InfoToggle
 				label={text('label', 'Info toggle label')}
 				tooltipId={text('tooltipId', 'info-tooltip')}
-				tooltipContent={
-					<div className="runningText padding--all">
-						<p>
-							This is a tooltip is being passed props that adjust the
-							alignment of the popup bubble to point to the trigger.
-						</p>
-					</div>
-				}
-				onClick={this.toggleTooltip}
+				onClick={() => console.log('toggle clicked')}
 				tooltipProps={{
 					align: select('align', ['left', 'right', 'center'], 'left'),
 					withClose: boolean('withClose', true),
@@ -40,7 +32,14 @@ class ManualInfoToggle extends React.PureComponent {
 					isActive: this.state.tooltipOpen,
 					onClose: this.closeTooltip,
 				}}
-			/>
+			>
+				<div className="runningText padding--all">
+					<p>
+						This is a tooltip is being passed props that adjust the alignment
+						of the popup bubble to point to the trigger.
+					</p>
+				</div>
+			</InfoToggle>
 		);
 	}
 }

--- a/src/interactive/infoToggle.test.jsx
+++ b/src/interactive/infoToggle.test.jsx
@@ -47,18 +47,4 @@ describe('InfoToggle', () => {
 		const tooltip = toggle.find(Tooltip);
 		expect(tooltip.prop('trigger')).toEqual(trigger);
 	});
-	it('should add an onClick prop to the trigger if provided', () => {
-		const onClick = jest.fn();
-		const trigger = <InfoTooltipTrigger onClick={onClick} />;
-		const toggle = renderComponent({
-			trigger,
-			onClick,
-		});
-		const tooltip = toggle.find(Tooltip);
-		const renderedTooltip = shallow(tooltip.prop('trigger'));
-		const mockEvent = { preventDefault: jest.fn() };
-		renderedTooltip.prop('onClick')(mockEvent);
-		expect(onClick).toHaveBeenCalled();
-		expect(mockEvent.preventDefault).toHaveBeenCalled();
-	});
 });

--- a/src/interactive/tooltip.story.jsx
+++ b/src/interactive/tooltip.story.jsx
@@ -83,8 +83,9 @@ storiesOf('Interactive/Tooltip', module)
 					align={align()}
 					id={text('tooltipId', 'testTooltip')}
 					trigger={<Button small>Open</Button>}
-					content={dropdownContent}
-				/>
+				>
+					{dropdownContent}
+				</Tooltip>
 			</div>
 		),
 		{ info: { text: 'Aligned right by default' } }

--- a/src/interactive/tooltip.test.jsx
+++ b/src/interactive/tooltip.test.jsx
@@ -57,6 +57,16 @@ describe('Tooltip', () => {
 		expect(onMouseLeave).toHaveBeenCalled();
 	});
 
+	it('should toggle the content when the trigger is clicked', () => {
+		const component = shallow(<Tooltip />);
+		const trigger = component.find('.popup-trigger').first();
+		expect(component).toMatchSnapshot();
+		expect(component.state().isActive).toBe(false);
+		trigger.simulate('click');
+		expect(component).toMatchSnapshot();
+		expect(component.state().isActive).toBe(true);
+	});
+
 	it('should call onFocus and onBlur functions if passed as props', () => {
 		const onFocus = jest.fn();
 		const onBlur = jest.fn();


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-761
#### Description
Refactor `<InfoToggle />` to use `children` as component props, restructure the tooltip props taken into `<InfoToggle />` and moved the state of tooltips being opened when the trigger is clicked into the tooltip component.

