### PR TITLE
add info on connectWithMatchMedia to docs

### DIFF
--- a/src/utils/components/withMatchMedia.story.jsx
+++ b/src/utils/components/withMatchMedia.story.jsx
@@ -29,6 +29,13 @@ class TestComponent extends React.Component {
 							the breakpoint props it provides to conditionally render
 							elements based on viewport size.
 						</p>
+						<p>
+							Note: Consider using{' '}
+							<code className="text--red">connectWithMatchMedia</code> from{' '}
+							<code>mwp-app-render</code> instead, which uses the user agent
+							string to detect the device and smartly set a default media on
+							initial render, before we detect the media from the viewport.
+						</p>
 						<p className="text--bold">
 							Resize your browser to see it in action.
 						</p>


### PR DESCRIPTION
Would like to raise awareness of connectWithMatchMedia, which is superior to withMatchMedia because it sets a default media based on device (detected from user agent) before we can detect the viewport size
![image](https://user-images.githubusercontent.com/5428933/48652651-8c3ad200-e9ce-11e8-9f87-93aa3da28307.png)



