### PR TITLE
Shrink largest avatar size from --responsiveMedia-xxl to --space-6

### DIFF
--- a/assets/scss/components/_avatar.scss
+++ b/assets/scss/components/_avatar.scss
@@ -97,8 +97,8 @@ $avatarBg: $C_coolGrayLight;
 }
 
 .avatar--xxlarge {
-	height: var(--responsiveMedia-xxl);
-	width: var(--responsiveMedia-xxl);
+	height: var(--space-6);
+	width: var(--space-6);
 }
 
 //


### PR DESCRIPTION
#### Related issues
https://meetup.atlassian.net/browse/MG-3930

#### Description
This shrinks avatars from 150px at the largest media query to 120px there, and maintains 120px at the smallest.