### PR TITLE
Updating input borders and icons to be darker for more contrast

### DIFF
--- a/assets/scss/components/_forms.scss
+++ b/assets/scss/components/_forms.scss
@@ -13,6 +13,10 @@
 	padding: $space;
 	position: absolute;
 	top: 0;
+
+	.svg-icon {
+		fill: $C_textPrimary;
+	}
 }
 
 input:focus + .icon--field {

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "swarm-animation": "0.0.95",
     "swarm-constants": "2.2.122",
     "swarm-icons": "3.8.349",
-    "swarm-sasstools": "5.0.419",
+    "swarm-sasstools": "5.0.428",
     "uri-js": "3.0.2",
     "webpack": "4.14.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10371,9 +10371,9 @@ swarm-icons@3.8.349:
   version "3.8.349"
   resolved "https://registry.yarnpkg.com/swarm-icons/-/swarm-icons-3.8.349.tgz#af520f40843d3186b7eac66b174b6df2fcc21594"
 
-swarm-sasstools@5.0.419:
-  version "5.0.419"
-  resolved "https://registry.yarnpkg.com/swarm-sasstools/-/swarm-sasstools-5.0.419.tgz#efc5d9ecef211ece68b181fcb70511dd3f246d05"
+swarm-sasstools@5.0.428:
+  version "5.0.428"
+  resolved "https://registry.yarnpkg.com/swarm-sasstools/-/swarm-sasstools-5.0.428.tgz#848a348574da729198e2297256ca2e72e078a80f"
   dependencies:
     sass-rem "^1.2.4"
 


### PR DESCRIPTION
Updating swarm-sasstools version and making input icons darker to have better contrast

#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-796

#### Description


#### Screenshots (if applicable)

