### PR TITLE
SDS-874 Migrated Select to use new Swarm UI components

### DIFF
--- a/src/forms/Select.jsx
+++ b/src/forms/Select.jsx
@@ -34,7 +34,9 @@ type Props = React.ElementConfig<HTMLSelectElement> & {
 export const SelectInput = (props: Props) => {
 	const { id, label, name, error, helperText, required, ...other } = props;
 
-	const requiredText = typeof required === 'string' ? required : '*';
+	const requiredProps = required
+		? { requiredText: typeof required === 'string' ? required : '*' }
+		: {};
 
 	return (
 		<SwarmSelect
@@ -43,8 +45,7 @@ export const SelectInput = (props: Props) => {
 			name={name}
 			error={error}
 			helperText={helperText}
-			required={required}
-			requiredText={requiredText}
+			{...requiredProps}
 			{...other}
 		/>
 	);

--- a/src/forms/Select.jsx
+++ b/src/forms/Select.jsx
@@ -1,16 +1,16 @@
 // @flow
 import * as React from 'react';
-import cx from 'classnames';
 
-import Icon from '../media/Icon';
+import { default as SwarmSelect } from '@meetup/swarm-components/lib/Select';
+
 import withErrorList from '../utils/components/withErrorList';
 
 type Props = React.ElementConfig<HTMLSelectElement> & {
-	/** Additional class name/s to add to the `<select/>` element  */
-	className?: string,
+	/** Optional `id` attribute for the input, and associates it with the `<label />` */
+	id?: string,
 
 	/** The `name` attribute for the input, and associates it with the `<label />` */
-	name: string, // required - will be used as 'id' as well
+	name: string, // required - will be used as 'id' as well if `id` attribute is not provied
 
 	/** Required - this component is stateless. A callback that happens when the input changes */
 	onChange: (e: SyntheticInputEvent<*>) => void,
@@ -20,12 +20,6 @@ type Props = React.ElementConfig<HTMLSelectElement> & {
 
 	/** An additional piece of helpful info rendered with the field */
 	helperText?: string,
-
-	/** The class name/s to add to the `<label />` element */
-	labelClassName?: string,
-
-	/** The class name/s to add to the div element wrapping select input + icon */
-	selectClassName?: string,
 
 	/** What we render into the input's `<label />` */
 	label?: string,
@@ -38,57 +32,21 @@ type Props = React.ElementConfig<HTMLSelectElement> & {
  * MWC custom <select> component
  */
 export const SelectInput = (props: Props) => {
-	const {
-		className,
-		id,
-		labelClassName,
-		label,
-		name,
-		error,
-		helperText,
-		required,
-		selectClassName,
-		...other
-	} = props;
+	const { id, label, name, error, helperText, required, ...other } = props;
 
-	const classNames = {
-		label: cx(
-			'label--field',
-			{ 'label--required': required, 'flush--bottom': helperText },
-			labelClassName
-		),
-		field: cx(
-			'select--reset span--100 padding--selectArrow',
-			{ 'field--error': error },
-			className
-		),
-		helperText: cx('helperTextContainer', { required }),
-	};
 	const requiredText = typeof required === 'string' ? required : '*';
 
 	return (
-		<div className="inputContainer">
-			{label && (
-				<label
-					className={classNames.label}
-					htmlFor={name}
-					data-requiredtext={requiredText}
-				>
-					{label}
-				</label>
-			)}
-			{helperText && <div className={classNames.helperText}>{helperText}</div>}
-			<div className={`selectWrapper ${selectClassName || ''}`}>
-				<select
-					name={name}
-					id={id || name}
-					required={Boolean(required)}
-					className={classNames.field}
-					{...other}
-				/>
-				<Icon className="select-customArrow" shape="chevron-down" size="xs" />
-			</div>
-		</div>
+		<SwarmSelect
+			id={id || name}
+			label={label}
+			name={name}
+			error={error}
+			helperText={helperText}
+			required={required}
+			requiredText={requiredText}
+			{...other}
+		/>
 	);
 };
 


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-874

#### Description
Updated `Select` component in `meetup-web-components` to use new [`Select`](https://github.com/meetup/swarm-ui/blob/master/packages/swarm-components/src/Select.jsx) component from `swarm-components`.

DoD:
- removed `className`, `labelClassName`, `selectClassName` props
- added flow type and documented optional `id` attribute (was used before)
- updated `required` (`boolean` or `string`) prop handling to match new `requiredText` (`string`) API
- checked Storybook examples to make sure they still function properly
  - made some fancy screenshots and used `perceptualdiff` package to compare them (after I caught a bug with `required` prop and fixed it), including one for reference here

#### Screenshots
Before:
![Select_required_after](https://user-images.githubusercontent.com/38076/54374185-fc8ff200-4654-11e9-97a6-126e09a0bd29.png)

After:
![Select_required_before](https://user-images.githubusercontent.com/38076/54374193-031e6980-4655-11e9-8c12-dda5378977da.png)

Diff:
![Select_required_diff](https://user-images.githubusercontent.com/38076/54374209-087bb400-4655-11e9-9222-1f602587a05c.png)


