### PR TITLE
Basic TextInput migrated, still need to replicate a few props.

### DIFF
--- a/src/forms/TextInput.jsx
+++ b/src/forms/TextInput.jsx
@@ -1,17 +1,15 @@
 // @flow
 import PropTypes from 'prop-types';
 import React from 'react';
-import cx from 'classnames';
-import Icon from '../media/Icon';
-import { MEDIA_SIZES } from '../utils/designConstants';
-import CharCounter from './CharCounter';
+
+import { TextInput as SwarmTextInput } from '@meetup/swarm-components/lib/TextInput';
+
 import withErrorList from '../utils/components/withErrorList';
 
 export const FIELD_WITH_ICON_CLASS = 'field--withIcon';
 
 type Props = {
 	children?: React$Node,
-	className?: string,
 	disabled?: boolean,
 	error?: string | React$Node,
 	helperText?: string | React$Node,
@@ -20,7 +18,6 @@ type Props = {
 	id?: string,
 	isSearch?: boolean,
 	label?: string | React$Node,
-	labelClassName?: string,
 	maxLength?: number,
 	name: string,
 	onChange: string => void,
@@ -38,18 +35,13 @@ type Props = {
  */
 export const TextInput = (props: Props): React$Element<*> => {
 	const {
-		className,
-		children,
 		disabled,
 		error,
 		helperText,
-		iconShape,
 		id,
 		isSearch,
-		maxLength,
 		name,
 		label,
-		labelClassName,
 		onChange,
 		pattern,
 		placeholder,
@@ -60,40 +52,6 @@ export const TextInput = (props: Props): React$Element<*> => {
 		value,
 		...other
 	} = props;
-
-	const classNames = {
-		field: cx(
-			'span--100',
-			{
-				'field--error': error,
-				[FIELD_WITH_ICON_CLASS]: iconShape,
-			},
-			className
-		),
-		label: cx(
-			'label--field',
-			{
-				'label--disabled': disabled,
-				'label--required': required,
-				'flush--bottom': helperText,
-			},
-			labelClassName
-		),
-		helperText: cx('helperTextContainer', { required, disabled }),
-		icon: 'icon--field',
-	};
-
-	const iconProps = {
-		shape: iconShape,
-		size: props.iconSize || 'xs',
-		className: classNames.icon,
-		'aria-hidden': true,
-	};
-
-	const paddingSize = parseInt(MEDIA_SIZES[iconProps.size], 10) + 24; // #TODO :SDS: replace '32' with something like "$space * 1.5" from `swarm-constants`
-	const inputStyles = iconShape && {
-		paddingLeft: `${paddingSize}px`,
-	};
 
 	const handleOnChange = e => {
 		if (onChange) {
@@ -123,42 +81,32 @@ export const TextInput = (props: Props): React$Element<*> => {
 	}
 
 	return (
-		<div className="inputContainer">
+		<div>
 			{label && (
-				<label
-					className={classNames.label}
-					htmlFor={id}
-					data-requiredtext={required && requiredText}
-				>
+				<label htmlFor={id || name}>
 					{label}
+					{required ? <span> {requiredText}</span> : ''}
 				</label>
 			)}
-			{helperText && <div className={classNames.helperText}>{helperText}</div>}
-			<div style={{ position: 'relative' }}>
-				<input
-					type={isSearch ? 'search' : 'text'}
+
+			{helperText && <p data-swarm-select-helper-text="1">{helperText}</p>}
+
+			<div data-swarm-select-wrapper="1">
+				<SwarmTextInput
+					isSearch={isSearch}
 					name={name}
+					error={error}
 					required={required}
 					placeholder={placeholder}
-					className={classNames.field}
 					onChange={handleOnChange}
 					onInvalid={handleInvalid}
 					pattern={pattern}
 					disabled={disabled}
 					id={id}
-					style={inputStyles}
 					{...optionalInputProps}
 					{...other}
 				/>
-				{iconShape && <Icon {...iconProps} />}
 			</div>
-			{maxLength && (
-				<CharCounter
-					maxLength={parseInt(maxLength, 10)}
-					valueLength={parseInt(value.length, 10)}
-				/>
-			)}
-			{children}
 		</div>
 	);
 };

--- a/src/forms/TextInput.jsx
+++ b/src/forms/TextInput.jsx
@@ -85,7 +85,7 @@ export const TextInput = (props: Props): React$Element<*> => {
 			{label && (
 				<label htmlFor={id || name}>
 					{label}
-					{required ? <span> {requiredText}</span> : ''}
+					{required && <> {requiredText}</>}
 				</label>
 			)}
 

--- a/src/forms/TextInput.jsx
+++ b/src/forms/TextInput.jsx
@@ -85,7 +85,7 @@ export const TextInput = (props: Props): React$Element<*> => {
 			{label && (
 				<label htmlFor={id || name}>
 					{label}
-					{required && <> {requiredText}</>}
+					{required && <span> {requiredText}</span>}
 				</label>
 			)}
 

--- a/src/forms/textInput.story.jsx
+++ b/src/forms/textInput.story.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TextInput } from './TextInput';
+import TextInput from './TextInput';
 import Button from './Button';
 import { storiesOf } from '@storybook/react';
 import { decorateWithBasics, decorateWithInfo } from '../utils/decorators';


### PR DESCRIPTION
#### Related issues
Fixes https://meetup.atlassian.net/browse/SDS-875

#### Description
Updated `TextInput` component in `meetup-web-components` to use new `TextInput` component from `swarm-components`.

DoD:
* removed className, labelClassName, selectClassName props
* added flow type and documented optional id attribute (was used before)
* updated required (boolean or string) prop handling to match new requiredText (string) API
* checked Storybook examples to make sure they still function properly
  * [x] type "tel"
  * [x] default
  * [x] with value
  * [x] disabled
  * [x] error state
  * [x] error state as element _(actually works, storybook imported wrong component)_
  * [x] with helper text
  * [x] required
  * [x] search


Outstanding use-cases:
  * [ ] with icon
    * How do we support these elements? Do we have a helper for this?
  * [ ] with char counter if you provide maxLength
    * Do we even need this, need final decision
  * [ ] has a pattern for min length
    * `pattern` prop is passed through as before but it doesn't seem to affect anything (now or before, is this a bug or we are not testing it properly
  * `withErrorList` seems to be styled differently now (just bulleted list instead of colorized), is this the new styling

#### Screenshots (if applicable)
![2019-03-15_11-39-16](https://user-images.githubusercontent.com/38076/54445650-928e5000-471b-11e9-824a-dce38edd8a7b.png)
