### PR TITLE
SDS-909 fix tests for TogglePill

### DIFF
--- a/src/forms/__snapshots__/togglePill.test.jsx.snap
+++ b/src/forms/__snapshots__/togglePill.test.jsx.snap
@@ -4,7 +4,6 @@ exports[`TogglePill renders a component with expected attributes 1`] = `
 <TogglePill
   id="hikingCategory"
   isActive={false}
-  labelClassName="someClass"
   name="meetupCategories"
   onChange={[MockFunction]}
   value="hiking"
@@ -12,7 +11,6 @@ exports[`TogglePill renders a component with expected attributes 1`] = `
   <TogglePill
     checked={false}
     id="hikingCategory"
-    labelClassName="someClass"
     name="meetupCategories"
     onChange={[MockFunction]}
     value="hiking"
@@ -22,7 +20,6 @@ exports[`TogglePill renders a component with expected attributes 1`] = `
       checked={false}
       data-swarm-toggle-pill="unchecked"
       id="hikingCategory"
-      labelClassName="someClass"
       name="meetupCategories"
       onChange={[MockFunction]}
       role="checkbox"

--- a/src/forms/redux-form/TogglePill.jsx
+++ b/src/forms/redux-form/TogglePill.jsx
@@ -21,13 +21,7 @@ const ReduxFormTogglePill = props => {
 		...other
 	} = props;
 
-	return (
-		<TogglePill
-			{...input}
-			isActive={input.value === true && !other.useRadio}
-			{...other}
-		/>
-	);
+	return <TogglePill {...input} isActive={input.value === true} {...other} />;
 };
 
 ReduxFormTogglePill.displayName = 'ReduxFormTogglePill';

--- a/src/forms/redux-form/__snapshots__/togglePill.test.jsx.snap
+++ b/src/forms/redux-form/__snapshots__/togglePill.test.jsx.snap
@@ -2,9 +2,12 @@
 
 exports[`redux-form TogglePill renders a TogglePill component with expected attributes from mock data 1`] = `
 <TogglePill
+  id="parenting"
   isActive={false}
   label="Parenting"
   name="parenting"
   value={false}
-/>
+>
+  Parenting!
+</TogglePill>
 `;

--- a/src/forms/redux-form/togglePill.test.jsx
+++ b/src/forms/redux-form/togglePill.test.jsx
@@ -1,14 +1,17 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 import ReduxFormTogglePill from './TogglePill';
+import TogglePill from '../TogglePill';
 
 describe('redux-form TogglePill', function() {
 	// props given in the structure that
 	// redux form would
 	const togglePillProps = {
 		input: {
+			id: 'parenting',
 			label: 'Parenting',
 			name: 'parenting',
+			children: 'Parenting!',
 			value: false, // as a checkbox, redux form will pass true / false for values
 		},
 	};
@@ -20,12 +23,12 @@ describe('redux-form TogglePill', function() {
 
 	it('renders a TogglePill with isActive prop as false when value is false', () => {
 		const component = mount(<ReduxFormTogglePill {...togglePillProps} />);
-		expect(component.find('TogglePill').prop('isActive')).toBe(false);
+		expect(component.find(TogglePill).prop('isActive')).toBe(false);
 	});
 
 	it('renders a TogglePill with isActive prop as true when value is true', () => {
 		togglePillProps.input.value = true;
 		const component = mount(<ReduxFormTogglePill {...togglePillProps} />);
-		expect(component.find('TogglePill').prop('isActive')).toBe(true);
+		expect(component.find(TogglePill).prop('isActive')).toBe(true);
 	});
 });

--- a/src/forms/togglePill.test.jsx
+++ b/src/forms/togglePill.test.jsx
@@ -1,27 +1,19 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import TogglePill, { TOGGLE_PILL_CLASS } from './TogglePill';
-import Icon from '../media/Icon';
+import TogglePill from './TogglePill';
 
 describe('TogglePill', () => {
 	const id = 'hikingCategory',
 		name = 'meetupCategories',
 		label = 'Hiking!',
-		value = 'hiking',
-		labelClass = 'someClass';
+		value = 'hiking';
 
 	let togglePillComponent;
 	const onChangeMock = jest.fn();
 
 	beforeEach(() => {
 		togglePillComponent = mount(
-			<TogglePill
-				onChange={onChangeMock}
-				id={id}
-				name={name}
-				labelClassName={labelClass}
-				value={value}
-			>
+			<TogglePill onChange={onChangeMock} id={id} name={name} value={value}>
 				{label}
 			</TogglePill>
 		);
@@ -35,63 +27,9 @@ describe('TogglePill', () => {
 		expect(togglePillComponent).toMatchSnapshot();
 	});
 
-	it('has appropriate toggle pill class', () => {
-		expect(togglePillComponent.find(TOGGLE_PILL_CLASS)).not.toBeNull();
-	});
-
 	it('executes onChange when clicked', () => {
-		const toggleInput = togglePillComponent.find('input');
-
 		expect(onChangeMock).not.toHaveBeenCalled();
-		toggleInput.simulate('change');
+		togglePillComponent.simulate('change');
 		expect(onChangeMock).toHaveBeenCalled();
-	});
-
-	describe('TogglePill with topic icon', () => {
-		const id = 'parentingTopic',
-			name = 'topics',
-			label = 'Moms and Dads',
-			value = 'parenting';
-
-		beforeEach(() => {
-			togglePillComponent = mount(
-				<TogglePill topic id={id} name={name} value={value}>
-					{label}
-				</TogglePill>
-			);
-		});
-
-		afterEach(() => {
-			togglePillComponent = null;
-		});
-
-		it('creates an Icon component', function() {
-			expect(togglePillComponent.find(Icon).length).toBeGreaterThan(0);
-		});
-	});
-
-	describe('TogglePill with radio input', () => {
-		const id = 'parentingTopic',
-			name = 'topics',
-			label = 'Moms and Dads',
-			value = 'parenting';
-
-		beforeEach(() => {
-			togglePillComponent = mount(
-				<TogglePill useRadio id={id} name={name} value={value}>
-					{label}
-				</TogglePill>
-			);
-		});
-
-		afterEach(() => {
-			togglePillComponent = null;
-		});
-
-		it('creates a Toggle Pill with a radio input', function() {
-			expect(
-				togglePillComponent.find('input[type="radio"]').length
-			).toBeGreaterThan(0);
-		});
 	});
 });


### PR DESCRIPTION
#### Related issues
JIRA https://meetup.atlassian.net/browse/SDS-909

#### Description
Fixes the tests for TogglePill MWC.

**Outstanding question:**
Even though I made tests pass for `redux-forms/TogglePill`, it does throw a few warnings and is effectively broken, at least because it sets `boolean` for `value` prop on MWC `TogglePill` which expects a `string`. It isn't used in `mup-web` or `pro-web` (based on my cursory look) so I suggest we just get rid of `redux-form` version of `TogglePill`.