### PR TITLE
165923751: fixing close button styles of modal component

### DIFF
--- a/src/interactive/Modal.jsx
+++ b/src/interactive/Modal.jsx
@@ -189,7 +189,7 @@ export class ModalComponent extends React.Component {
 					'padding--all modal-closeButtonContainer'
 				)}
 			>
-				<Button onClick={this.onDismiss} className={dismissButtonClasses}>
+				<Button onClick={this.onDismiss} reset className={dismissButtonClasses}>
 					<Icon shape="cross" size="s" />
 				</Button>
 			</div>


### PR DESCRIPTION
**Task: ** https://www.pivotaltracker.com/n/projects/2346583/stories/165923751

**Description**

The close button on modals should be a reset button.

Currently the button is a default button so the default styles are applied. The reset prop needs to be applied to strip the styles from the button.

Places this occurs:
+ Update Checklist