### PR TITLE
add click tracking to sign up modal

### DIFF
--- a/src/SignupModal.jsx
+++ b/src/SignupModal.jsx
@@ -21,37 +21,21 @@ export const SIGNUP_MODAL_FACEBOOK_CLASS = `${SIGNUP_MODAL_CLASS}-facebook`;
 export const SIGNUP_MODAL_GOOGLE_CLASS = `${SIGNUP_MODAL_CLASS}-google`;
 export const SIGNUP_MODAL_EMAIL_CLASS = `${SIGNUP_MODAL_CLASS}-email`;
 
+
 /**
  * @param {Object} props component properties
  * @returns {React.element} SignupModal
  */
 export const SignupModal = ({ onDismiss, signupOptions, ...other }) => {
-	const facebookOnClick = () => {
+
+	const gaTracking = type => () => {
 		window.dataLayer = window.dataLayer || [];
 		window.dataLayer.push({
 			event: 'registrationStart',
 			form: {
-				type: 'facebookAuthButton',
+				type
 			},
 		});
-	};
-	const emailOnClick = () => {
-			window.dataLayer = window.dataLayer || [];
-			window.dataLayer.push({
-				event: 'registrationStart',
-				form: {
-					type: 'email',
-				},
-			});
-	};
-	const googleOnClick = () => {
-			window.dataLayer = window.dataLayer || [];
-			window.dataLayer.push({
-				event: 'registrationStart',
-				form: {
-					type: 'googleAuthButton',
-				},
-			});
 	};
 
 	const { google, facebook, email, login, title, orLabel } = signupOptions;
@@ -79,7 +63,7 @@ export const SignupModal = ({ onDismiss, signupOptions, ...other }) => {
 							SIGNUP_MODAL_FACEBOOK_CLASS,
 							'button button--fullWidth button--hasHoverShadow padding--halfLeft text--bold text--white'
 						)}
-						onClick={facebookOnClick}
+						onClick={gaTracking('facebookAuthButton')}
 					>
 						<Flex>
 							<FlexItem shrink className="inverted">
@@ -100,7 +84,7 @@ export const SignupModal = ({ onDismiss, signupOptions, ...other }) => {
 							SIGNUP_MODAL_GOOGLE_CLASS,
 							'button button--bordered button--fullWidth padding--halfLeft text--bold'
 						)}
-						onClick={googleOnClick}
+						onClick={gaTracking('googleAuthButton')}
 					>
 						<Flex>
 							<FlexItem shrink>
@@ -125,7 +109,7 @@ export const SignupModal = ({ onDismiss, signupOptions, ...other }) => {
 							SIGNUP_MODAL_EMAIL_CLASS,
 							'button button--bordered button--fullWidth padding--halfLeft text--bold'
 						)}
-						onClick={emailOnClick}
+						onClick={gaTracking('email')}
 					>
 						<Flex>
 							<FlexItem shrink>

--- a/src/SignupModal.jsx
+++ b/src/SignupModal.jsx
@@ -26,6 +26,34 @@ export const SIGNUP_MODAL_EMAIL_CLASS = `${SIGNUP_MODAL_CLASS}-email`;
  * @returns {React.element} SignupModal
  */
 export const SignupModal = ({ onDismiss, signupOptions, ...other }) => {
+	const facebookOnClick = () => {
+		window.dataLayer = window.dataLayer || [];
+		window.dataLayer.push({
+			event: 'registrationStart',
+			form: {
+				type: 'facebookAuthButton',
+			},
+		});
+	};
+	const emailOnClick = () => {
+			window.dataLayer = window.dataLayer || [];
+			window.dataLayer.push({
+				event: 'registrationStart',
+				form: {
+					type: 'email',
+				},
+			});
+	};
+	const googleOnClick = () => {
+			window.dataLayer = window.dataLayer || [];
+			window.dataLayer.push({
+				event: 'registrationStart',
+				form: {
+					type: 'googleAuthButton',
+				},
+			});
+	};
+
 	const { google, facebook, email, login, title, orLabel } = signupOptions;
 	return (
 		<Modal className={SIGNUP_MODAL_CLASS} onDismiss={onDismiss} fixed {...other}>
@@ -51,6 +79,7 @@ export const SignupModal = ({ onDismiss, signupOptions, ...other }) => {
 							SIGNUP_MODAL_FACEBOOK_CLASS,
 							'button button--fullWidth button--hasHoverShadow padding--halfLeft text--bold text--white'
 						)}
+						onClick={facebookOnClick}
 					>
 						<Flex>
 							<FlexItem shrink className="inverted">
@@ -71,6 +100,7 @@ export const SignupModal = ({ onDismiss, signupOptions, ...other }) => {
 							SIGNUP_MODAL_GOOGLE_CLASS,
 							'button button--bordered button--fullWidth padding--halfLeft text--bold'
 						)}
+						onClick={googleOnClick}
 					>
 						<Flex>
 							<FlexItem shrink>
@@ -95,6 +125,7 @@ export const SignupModal = ({ onDismiss, signupOptions, ...other }) => {
 							SIGNUP_MODAL_EMAIL_CLASS,
 							'button button--bordered button--fullWidth padding--halfLeft text--bold'
 						)}
+						onClick={emailOnClick}
 					>
 						<Flex>
 							<FlexItem shrink>

--- a/src/SignupModal.jsx
+++ b/src/SignupModal.jsx
@@ -21,23 +21,18 @@ export const SIGNUP_MODAL_FACEBOOK_CLASS = `${SIGNUP_MODAL_CLASS}-facebook`;
 export const SIGNUP_MODAL_GOOGLE_CLASS = `${SIGNUP_MODAL_CLASS}-google`;
 export const SIGNUP_MODAL_EMAIL_CLASS = `${SIGNUP_MODAL_CLASS}-email`;
 
-
 /**
  * @param {Object} props component properties
  * @returns {React.element} SignupModal
  */
-export const SignupModal = ({ onDismiss, signupOptions, ...other }) => {
-
-	const gaTracking = type => () => {
-		window.dataLayer = window.dataLayer || [];
-		window.dataLayer.push({
-			event: 'registrationStart',
-			form: {
-				type
-			},
-		});
-	};
-
+export const SignupModal = ({
+	onDismiss,
+	signupOptions,
+	googleOnClick,
+	facebookOnClick,
+	emailOnClick,
+	...other
+}) => {
 	const { google, facebook, email, login, title, orLabel } = signupOptions;
 	return (
 		<Modal className={SIGNUP_MODAL_CLASS} onDismiss={onDismiss} fixed {...other}>
@@ -63,7 +58,7 @@ export const SignupModal = ({ onDismiss, signupOptions, ...other }) => {
 							SIGNUP_MODAL_FACEBOOK_CLASS,
 							'button button--fullWidth button--hasHoverShadow padding--halfLeft text--bold text--white'
 						)}
-						onClick={gaTracking('facebookAuthButton')}
+						onClick={facebookOnClick}
 					>
 						<Flex>
 							<FlexItem shrink className="inverted">
@@ -84,7 +79,7 @@ export const SignupModal = ({ onDismiss, signupOptions, ...other }) => {
 							SIGNUP_MODAL_GOOGLE_CLASS,
 							'button button--bordered button--fullWidth padding--halfLeft text--bold'
 						)}
-						onClick={gaTracking('googleAuthButton')}
+						onClick={googleOnClick}
 					>
 						<Flex>
 							<FlexItem shrink>
@@ -109,7 +104,7 @@ export const SignupModal = ({ onDismiss, signupOptions, ...other }) => {
 							SIGNUP_MODAL_EMAIL_CLASS,
 							'button button--bordered button--fullWidth padding--halfLeft text--bold'
 						)}
-						onClick={gaTracking('email')}
+						onClick={emailOnClick}
 					>
 						<Flex>
 							<FlexItem shrink>

--- a/src/__snapshots__/SignupModal.test.jsx.snap
+++ b/src/__snapshots__/SignupModal.test.jsx.snap
@@ -35,6 +35,7 @@ exports[`SignupModal should match the snapshot 1`] = `
       <a
         className="meetup-signupModal-facebook button button--fullWidth button--hasHoverShadow padding--halfLeft text--bold text--white"
         href="facebook.com"
+        onClick={[Function]}
       >
         <Flex>
           <FlexItem
@@ -59,6 +60,7 @@ exports[`SignupModal should match the snapshot 1`] = `
       <a
         className="meetup-signupModal-google button button--bordered button--fullWidth padding--halfLeft text--bold"
         href="google.com"
+        onClick={[Function]}
       >
         <Flex>
           <FlexItem
@@ -86,6 +88,7 @@ exports[`SignupModal should match the snapshot 1`] = `
       <a
         className="meetup-signupModal-email button button--bordered button--fullWidth padding--halfLeft text--bold"
         href="meetup.com/email"
+        onClick={[Function]}
       >
         <Flex>
           <FlexItem


### PR DESCRIPTION
#### Related issues
Fixes https://www.pivotaltracker.com/story/show/166418085
#### Description

**Why**
There are numerous ways to navigate to the Member Registration page (secure.meetup.com/register) and these ways have different variations that product, marketing & analysts need to be able to understand.

**As a** GA user
**I want** to see when a member's registration flow starts from the "Sign Up" button in the header or footer on the new guest homepage experience (meetup.com)
**So I can** visualize the flow a user experienced when registering or where they may have fallen off

**What is the desired behavior?**
Acceptance Criteria
Scenario:
Given a guest on (meetup.com [new experience])
When the guest clicks sign up in header or footer)
Then a JS event needs to push data into the dataLayer (see criteria in "More info" below and Steve A. & Malik have code examples) and when a user clicks on one of these buttons (Continue with FB/Google or Sign Up with Email) an event with the appropriate data should be visible in GTM via preview mode
