### PR TITLE
Display Experiences link to logged-out users in NYC

### DIFF
--- a/src/navigation/Nav.jsx
+++ b/src/navigation/Nav.jsx
@@ -204,8 +204,18 @@ export class Nav extends React.Component {
 			className: `${CLASS_UNAUTH_ITEM} navItemLink--createMeetup`,
 		};
 
+		const experiencesLink = experiences &&
+			experiences.link && {
+				shrink: true,
+				linkTo: experiences.link,
+				label: experiences.label,
+				linkClassName: 'navItemLink--experiences',
+				icon: <div className="pill">NEW</div>,
+			};
+
 		let unauthItems = [
 			media.isAtMediumUp && createMeetupLink,
+			media.isAtMediumUp && experiencesLink,
 			{
 				shrink: true,
 				linkTo: login.link,
@@ -256,17 +266,7 @@ export class Nav extends React.Component {
 				),
 			},
 			media.isAtMediumUp && !self.is_pro_admin && createMeetupLink,
-			// If you want to use pill elsewhere, consider making a Pill
-			// component that takes a color prop.
-			media.isAtLargeUp &&
-				experiences &&
-				experiences.link && {
-					shrink: true,
-					linkTo: experiences.link,
-					label: experiences.label,
-					linkClassName: 'navItemLink--experiences',
-					icon: <div className="pill">NEW</div>,
-				},
+			media.isAtMediumUp && experiencesLink,
 			{
 				shrink: true,
 				linkTo: explore.link,

--- a/src/navigation/__snapshots__/Nav.test.jsx.snap
+++ b/src/navigation/__snapshots__/Nav.test.jsx.snap
@@ -189,6 +189,20 @@ exports[`Nav should match the snapshot for authenticated medium screens 1`] = `
       shrink={true}
     />
     <NavItem
+      icon={
+        <div
+          className="pill"
+        >
+          NEW
+        </div>
+      }
+      key="1"
+      label="Experiences"
+      linkClassName="navItemLink--experiences"
+      linkTo="meetup.com/experiences"
+      shrink={true}
+    />
+    <NavItem
       className="navItem--authenticated"
       icon={
         <Icon
@@ -197,7 +211,7 @@ exports[`Nav should match the snapshot for authenticated medium screens 1`] = `
           size="s"
         />
       }
-      key="1"
+      key="2"
       label="Explore"
       linkTo="meetup.com/find/events"
       shrink={true}
@@ -211,7 +225,7 @@ exports[`Nav should match the snapshot for authenticated medium screens 1`] = `
           size="s"
         />
       }
-      key="2"
+      key="3"
       label="Groups"
       linkTo="meetup.com/groups"
       shrink={true}
@@ -226,7 +240,7 @@ exports[`Nav should match the snapshot for authenticated medium screens 1`] = `
           size="s"
         />
       }
-      key="3"
+      key="4"
       label="Messages"
       linkTo="meetup.com/messages"
       shrink={true}
@@ -808,7 +822,7 @@ exports[`Nav should match the snapshot for authenticated medium screens 1`] = `
           size="s"
         />
       }
-      key="4"
+      key="5"
       label="Notifications"
       linkTo=""
       onClickAction={[Function]}
@@ -910,7 +924,7 @@ exports[`Nav should match the snapshot for authenticated medium screens 1`] = `
           </FlexItem>
         </Flex>
       }
-      key="5"
+      key="6"
       label="Profile"
       labelClassName="navItem-label display--block atMedium_display--none"
       linkTo=""
@@ -1121,6 +1135,20 @@ exports[`Nav should match the snapshot for groups loading state 1`] = `
       shrink={true}
     />
     <NavItem
+      icon={
+        <div
+          className="pill"
+        >
+          NEW
+        </div>
+      }
+      key="1"
+      label="Experiences"
+      linkClassName="navItemLink--experiences"
+      linkTo="meetup.com/experiences"
+      shrink={true}
+    />
+    <NavItem
       className="navItem--authenticated"
       icon={
         <Icon
@@ -1129,7 +1157,7 @@ exports[`Nav should match the snapshot for groups loading state 1`] = `
           size="s"
         />
       }
-      key="1"
+      key="2"
       label="Explore"
       linkTo="meetup.com/find/events"
       shrink={true}
@@ -1143,7 +1171,7 @@ exports[`Nav should match the snapshot for groups loading state 1`] = `
           size="s"
         />
       }
-      key="2"
+      key="3"
       label="Groups"
       linkTo="meetup.com/groups"
       shrink={true}
@@ -1158,7 +1186,7 @@ exports[`Nav should match the snapshot for groups loading state 1`] = `
           size="s"
         />
       }
-      key="3"
+      key="4"
       label="Messages"
       linkTo="meetup.com/messages"
       shrink={true}
@@ -1740,7 +1768,7 @@ exports[`Nav should match the snapshot for groups loading state 1`] = `
           size="s"
         />
       }
-      key="4"
+      key="5"
       label="Notifications"
       linkTo=""
       onClickAction={[Function]}
@@ -1842,7 +1870,7 @@ exports[`Nav should match the snapshot for groups loading state 1`] = `
           </FlexItem>
         </Flex>
       }
-      key="5"
+      key="6"
       label="Profile"
       labelClassName="navItem-label display--block atMedium_display--none"
       linkTo=""
@@ -1907,6 +1935,20 @@ exports[`Nav should match the snapshot for notifications loading state 1`] = `
       shrink={true}
     />
     <NavItem
+      icon={
+        <div
+          className="pill"
+        >
+          NEW
+        </div>
+      }
+      key="1"
+      label="Experiences"
+      linkClassName="navItemLink--experiences"
+      linkTo="meetup.com/experiences"
+      shrink={true}
+    />
+    <NavItem
       className="navItem--authenticated"
       icon={
         <Icon
@@ -1915,7 +1957,7 @@ exports[`Nav should match the snapshot for notifications loading state 1`] = `
           size="s"
         />
       }
-      key="1"
+      key="2"
       label="Explore"
       linkTo="meetup.com/find/events"
       shrink={true}
@@ -1929,7 +1971,7 @@ exports[`Nav should match the snapshot for notifications loading state 1`] = `
           size="s"
         />
       }
-      key="2"
+      key="3"
       label="Groups"
       linkTo="meetup.com/groups"
       shrink={true}
@@ -1944,7 +1986,7 @@ exports[`Nav should match the snapshot for notifications loading state 1`] = `
           size="s"
         />
       }
-      key="3"
+      key="4"
       label="Messages"
       linkTo="meetup.com/messages"
       shrink={true}
@@ -2526,7 +2568,7 @@ exports[`Nav should match the snapshot for notifications loading state 1`] = `
           size="s"
         />
       }
-      key="4"
+      key="5"
       label="Notifications"
       linkTo=""
       onClickAction={[Function]}
@@ -2628,7 +2670,7 @@ exports[`Nav should match the snapshot for notifications loading state 1`] = `
           </FlexItem>
         </Flex>
       }
-      key="5"
+      key="6"
       label="Profile"
       labelClassName="navItem-label display--block atMedium_display--none"
       linkTo=""
@@ -2872,15 +2914,22 @@ exports[`Nav should match the snapshot for unauthenticated medium screens 2`] = 
       shrink={true}
     />
     <NavItem
-      className="navItem--unauthenticated navItem--login"
       key="1"
+      label="Experiences"
+      linkClassName="navItemLink--experiences"
+      linkTo="meetup.com/experiences"
+      shrink={true}
+    />
+    <NavItem
+      className="navItem--unauthenticated navItem--login"
+      key="2"
       label="Login"
       linkTo="meetup.com/login"
       shrink={true}
     />
     <NavItem
       className="navItem--unauthenticated"
-      key="2"
+      key="3"
       label="Sign up"
       onAction={[Function]}
       shrink={true}
@@ -3001,6 +3050,20 @@ exports[`Nav should match the snapshot for unread notifications 1`] = `
       shrink={true}
     />
     <NavItem
+      icon={
+        <div
+          className="pill"
+        >
+          NEW
+        </div>
+      }
+      key="1"
+      label="Experiences"
+      linkClassName="navItemLink--experiences"
+      linkTo="meetup.com/experiences"
+      shrink={true}
+    />
+    <NavItem
       className="navItem--authenticated"
       icon={
         <Icon
@@ -3009,7 +3072,7 @@ exports[`Nav should match the snapshot for unread notifications 1`] = `
           size="s"
         />
       }
-      key="1"
+      key="2"
       label="Explore"
       linkTo="meetup.com/find/events"
       shrink={true}
@@ -3023,7 +3086,7 @@ exports[`Nav should match the snapshot for unread notifications 1`] = `
           size="s"
         />
       }
-      key="2"
+      key="3"
       label="Groups"
       linkTo="meetup.com/groups"
       shrink={true}
@@ -3038,7 +3101,7 @@ exports[`Nav should match the snapshot for unread notifications 1`] = `
           size="s"
         />
       }
-      key="3"
+      key="4"
       label="Messages"
       linkTo="meetup.com/messages"
       shrink={true}
@@ -3620,7 +3683,7 @@ exports[`Nav should match the snapshot for unread notifications 1`] = `
           size="s"
         />
       }
-      key="4"
+      key="5"
       label="Notifications"
       linkTo=""
       onClickAction={[Function]}
@@ -3722,7 +3785,7 @@ exports[`Nav should match the snapshot for unread notifications 1`] = `
           </FlexItem>
         </Flex>
       }
-      key="5"
+      key="6"
       label="Profile"
       labelClassName="navItem-label display--block atMedium_display--none"
       linkTo=""

--- a/src/navigation/nav.story.jsx
+++ b/src/navigation/nav.story.jsx
@@ -61,6 +61,7 @@ export const navItemsFactory = () => {
 			},
 		},
 		explore: { link: 'meetup.com/find/events', label: 'Explore' },
+		experiences: { link: 'meetup.com/experiences', label: 'Experiences' },
 		groups: {
 			link: 'meetup.com/groups',
 			label: 'Groups',


### PR DESCRIPTION
#### Related issues
https://www.pivotaltracker.com/story/show/167588973

#### Description
For several months we've been showing logged-in users a link to Meetup Experiences. This is the first of several PRs that will expose it to logged-out users.  

#### Screenshots (if applicable)
Mup-web isn't passing `experiences` if you're logged out...yet. So there's nothing to screenshot here.
