### PR TITLE
Add icon on unauth nav items

### DIFF
--- a/src/navigation/Nav.jsx
+++ b/src/navigation/Nav.jsx
@@ -360,6 +360,7 @@ export class Nav extends React.Component {
 					shrink={item.shrink}
 					linkTo={item.linkTo}
 					label={item.label}
+					icon={item.icon}
 					className={item.className}
 					linkClassName={item.linkClassName}
 					onAction={item.onAction}

--- a/src/navigation/__snapshots__/Nav.test.jsx.snap
+++ b/src/navigation/__snapshots__/Nav.test.jsx.snap
@@ -2914,6 +2914,13 @@ exports[`Nav should match the snapshot for unauthenticated medium screens 2`] = 
       shrink={true}
     />
     <NavItem
+      icon={
+        <div
+          className="pill"
+        >
+          NEW
+        </div>
+      }
       key="1"
       label="Experiences"
       linkClassName="navItemLink--experiences"


### PR DESCRIPTION
#### Related issues
https://www.pivotaltracker.com/story/show/167588973

#### Description
Allow unauth items to have icons, too. I have tested this locally to ensure nothing blows up with the unauth links that *don't* have icons. 

#### Screenshots (if applicable)
![Screen Shot 2019-08-20 at 1 21 12 PM](https://user-images.githubusercontent.com/2222416/63369188-6a032580-c34d-11e9-84f4-4268b5af32bc.png)
