### PR TITLE
typeahead to use textinput from swarm

### DIFF
--- a/src/forms/Typeahead.jsx
+++ b/src/forms/Typeahead.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import Downshift from 'downshift';
 import cx from 'classnames';
 
-import TextInput from './TextInput';
+import { TextInput } from '@meetup/swarm-components';
 
 export const TA_DROPDOWN_CLASSNAME = 'typeahead-dropdown';
 export const TA_ITEM_CLASSNAME = 'typeahead-item';
@@ -104,7 +104,6 @@ class Typeahead extends React.PureComponent {
 						<TextInput
 							{...getInputProps({
 								...inputProps,
-								className: 'typeahead-input',
 								onFocus: openOnFocus && openMenu,
 							})}
 						/>

--- a/src/utils/components/DeprecationWarning.jsx
+++ b/src/utils/components/DeprecationWarning.jsx
@@ -27,7 +27,7 @@ function DeprecationWarning(WrappedComponent) {
 				console.warn(
 					`The ${
 						WrappedComponent.name
-					} component has been deprecated and will be removed from meetup-web-components on October 3, 2019. Please upgrade to the latest from https://github.com/meetup/swarm-ui`
+					} component has been deprecated and will be removed from meetup-web-components on October 21, 2019. Please upgrade to the latest from https://github.com/meetup/swarm-ui`
 				);
 				hasBeenWarned[WrappedComponent.name] = true;
 			}


### PR DESCRIPTION
Updates typeahead to use `TextInput` from `@meetup/swarm-components`
