### PR TITLE
Feature/ch19500/add registration form form toggles but grey them out with cta to go pro event scheduler

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2998,6 +2998,37 @@ $('#fadeInLink').on('click', function(e) {
 .indicator--animateActive {
   transform: rotate(180deg); }
 
+.accordionPanel-locked {
+  margin-right: auto; }
+
+.accordionPanel-locked-container {
+  background: #dcebee;
+  border-radius: 8px;
+  margin-top: 4px;
+  padding: 0; }
+
+.accordionPanel-locked-label {
+  color: #008294;
+  font-size: 14px;
+  line-height: 1.4;
+  padding-left: 6px; }
+
+.accordionPanel-locked-badge {
+  align-items: center;
+  display: flex;
+  margin-top: -2px;
+  padding: 4px 8px; }
+
+@media only screen and (min-width: 640px) {
+  .accordionPanel-locked {
+    flex-direction: row;
+    flex-wrap: nowrap; }
+  .accordionPanel-locked-container {
+    margin-left: 16px;
+    margin-top: -4px; }
+  .accordionPanel-locked-badge {
+    margin-top: 0; } }
+
 .avatar--person,
 .avatar {
   background-color: #e4e9ed;

--- a/assets/scss/components/_accordion.scss
+++ b/assets/scss/components/_accordion.scss
@@ -81,8 +81,10 @@
 }
 
 @include atMediaUp(medium) {
-	flex-direction: row;
-	flex-wrap: nowrap;
+	.accordionPanel-locked {
+		flex-direction: row;
+		flex-wrap: nowrap;
+	}
 
 	.accordionPanel-locked-container {
 		margin-left: 16px;

--- a/assets/scss/components/_accordion.scss
+++ b/assets/scss/components/_accordion.scss
@@ -57,3 +57,35 @@
 .indicator--animateActive {
 	transform: rotate(180deg);
 }
+
+.accordionPanel-locked {
+	margin-right: auto;
+}
+
+.accordionPanel-locked-container {
+	background: #dcebee;
+	border-radius: 8px;
+	margin-top: 4px;
+	padding: 0;
+}
+
+.accordionPanel-locked-label {
+	color: #008294;
+	font-size: 14px;
+	line-height: 1.4;
+	padding-left: 6px;
+}
+
+.accordionPanel-locked-badge {
+	padding: 4px 8px;
+}
+
+@include atMediaUp(medium) {
+	flex-direction: row;
+	flex-wrap: nowrap;
+
+	.accordionPanel-locked-container {
+		margin-left: 16px;
+		margin-top: -4px;
+	}
+}

--- a/assets/scss/components/_accordion.scss
+++ b/assets/scss/components/_accordion.scss
@@ -77,6 +77,9 @@
 }
 
 .accordionPanel-locked-badge {
+	align-items: center;
+	display: flex;
+	margin-top: -2px;
 	padding: 4px 8px;
 }
 
@@ -89,5 +92,9 @@
 	.accordionPanel-locked-container {
 		margin-left: 16px;
 		margin-top: -4px;
+	}
+
+	.accordionPanel-locked-badge {
+		margin-top: 0;
 	}
 }

--- a/src/interactive/AccordionPanel.jsx
+++ b/src/interactive/AccordionPanel.jsx
@@ -22,6 +22,7 @@ class AccordionPanel extends React.Component {
 		this.onKeyUp = this.onKeyUp.bind(this);
 		this.onToggleClick = this.onToggleClick.bind(this);
 		this.onTransitionEnd = this.onTransitionEnd.bind(this);
+		this.handleLockedLabelClick = this.handleLockedLabelClick.bind(this);
 
 		this.state = {
 			height: props.isOpen ? 'auto' : '0px',
@@ -63,7 +64,9 @@ class AccordionPanel extends React.Component {
 			panelIndex,
 			disableAndOpen,
 			isDisabledPanelOpen,
+			isLocked,
 		} = this.props;
+		if (isLocked) return;
 		if (disableAndOpen) {
 			setClickedPanel &&
 				setClickedPanel(e, {
@@ -148,6 +151,12 @@ class AccordionPanel extends React.Component {
 		}
 	}
 
+	handleLockedLabelClick(e) {
+		e.preventDefault();
+
+		this.props.onLockedLabelClick(e);
+	}
+
 	render() {
 		const {
 			panelContent,
@@ -166,6 +175,9 @@ class AccordionPanel extends React.Component {
 			onToggleClick, // eslint-disable-line no-unused-vars
 			disableAndOpen,
 			isDisabledPanelOpen, // eslint-disable-line no-unused-vars
+			isLocked,
+			lockedLabel,
+			onLockedLabelClick, // eslint-disable-line no-unused-vars
 			...other
 		} = this.props;
 
@@ -210,9 +222,34 @@ class AccordionPanel extends React.Component {
 						className={classNames.accordionPanel}
 						rowReverse={indicatorAlign === 'left' && 'all'}
 						tabIndex={-1}
+						align="center"
 						{...other}
 					>
-						<FlexItem id={`label-${panelId}`}>{label}</FlexItem>
+						{isLocked ? (
+							<Flex
+								wrap
+								direction="column"
+								className="accordionPanel-locked"
+							>
+								<FlexItem id={`label-${panelId}`} shrink>
+									{label}
+								</FlexItem>
+								<FlexItem
+									shrink
+									onClick={this.handleLockedLabelClick}
+									className="accordionPanel-locked-container"
+								>
+									<div className="accordionPanel-locked-badge">
+										<Icon shape="lock" size="xs" color="#008294" />
+										<span className="accordionPanel-locked-label">
+											{lockedLabel}
+										</span>
+									</div>
+								</FlexItem>
+							</Flex>
+						) : (
+							<FlexItem id={`label-${panelId}`}>{label}</FlexItem>
+						)}
 
 						<FlexItem
 							className="accordionPanel-icon"
@@ -312,6 +349,15 @@ AccordionPanel.propTypes = {
 
 	/** Prevent ToggleSwitch active but show content after click  */
 	disableAndOpen: PropTypes.bool,
+
+	/** Whether the panel is locked due to some conditional requirements */
+	isLocked: PropTypes.bool,
+
+	/** Label of CTA badge for unlocking the panel */
+	lockedLabel: PropTypes.string,
+
+	/** A callback that happens after the locked label has been clicked  */
+	onLockedLabelClick: PropTypes.func,
 };
 
 export default AccordionPanel;

--- a/src/interactive/__snapshots__/accordionPanel.test.jsx.snap
+++ b/src/interactive/__snapshots__/accordionPanel.test.jsx.snap
@@ -1,5 +1,296 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AccordionPanel Locked panel with toggle switch renders locked toggle panel 1`] = `
+<AccordionPanel
+  indicatorAlign="left"
+  indicatorIcon="chevron-down"
+  indicatorIconSize="xs"
+  indicatorSwitch={true}
+  isLocked={true}
+  isOpen={false}
+  label="First Section"
+  lockedLabel="Unlock me!"
+  onClickCallback={[MockFunction]}
+  onLockedLabelClick={[MockFunction]}
+  panelContent={
+    <div
+      className="runningText"
+    >
+      <p>
+        Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.
+      </p>
+    </div>
+  }
+>
+  <div>
+    <div
+      aria-controls="panel-firstsection"
+      aria-expanded={false}
+      aria-selected={false}
+      className="accordionPanel-label display--block span--100"
+      onClick={[Function]}
+      onKeyUp={[Function]}
+      role="tab"
+      tabIndex={0}
+    >
+      <Flex
+        align="center"
+        className="padding--bottom padding--top accordionPanel"
+        rowReverse="all"
+        tabIndex={-1}
+      >
+        <FlexComponent
+          align="center"
+          className="padding--bottom padding--top accordionPanel"
+          direction="row"
+          rowReverse="all"
+          tabIndex={-1}
+        >
+          <div
+            className="flex flex--row atAll_flex--rowReverse flex--alignCenter padding--bottom padding--top accordionPanel"
+            tabIndex={-1}
+          >
+            <Flex
+              className="accordionPanel-locked"
+              direction="column"
+              wrap={true}
+            >
+              <FlexComponent
+                className="accordionPanel-locked"
+                direction="column"
+                wrap={true}
+              >
+                <div
+                  className="flex flex--column flex--wrap accordionPanel-locked"
+                >
+                  <FlexItem
+                    id="label-firstsection"
+                    shrink={true}
+                  >
+                    <FlexItemComponent
+                      id="label-firstsection"
+                      shrink={true}
+                    >
+                      <div
+                        className="flex-item flex-item--shrink"
+                        id="label-firstsection"
+                      >
+                        First Section
+                      </div>
+                    </FlexItemComponent>
+                  </FlexItem>
+                  <FlexItem
+                    className="accordionPanel-locked-container"
+                    onClick={[Function]}
+                    shrink={true}
+                  >
+                    <FlexItemComponent
+                      className="accordionPanel-locked-container"
+                      onClick={[Function]}
+                      shrink={true}
+                    >
+                      <div
+                        className="flex-item flex-item--shrink accordionPanel-locked-container"
+                        onClick={[Function]}
+                      >
+                        <div
+                          className="accordionPanel-locked-badge"
+                        >
+                          <Icon
+                            color="#008294"
+                            shape="lock"
+                            size="xs"
+                          >
+                            <span>
+                              <Icon
+                                color="#008294"
+                                shape="lock"
+                                size="xs"
+                              >
+                                <svg
+                                  className="svg svg--lock svg-icon valign--middle"
+                                  height="20"
+                                  preserveAspectRatio="xMinYMin meet"
+                                  role="img"
+                                  style={
+                                    Object {
+                                      "fill": "#008294",
+                                    }
+                                  }
+                                  viewBox="0 0 20 20"
+                                  width="20"
+                                >
+                                  <use
+                                    xlinkHref="#icon-lock--small"
+                                  />
+                                </svg>
+                              </Icon>
+                            </span>
+                          </Icon>
+                          <span
+                            className="accordionPanel-locked-label"
+                          >
+                            Unlock me!
+                          </span>
+                        </div>
+                      </div>
+                    </FlexItemComponent>
+                  </FlexItem>
+                </div>
+              </FlexComponent>
+            </Flex>
+            <FlexItem
+              className="accordionPanel-icon"
+              onClick={[Function]}
+              shrink={true}
+            >
+              <FlexItemComponent
+                className="accordionPanel-icon"
+                onClick={[Function]}
+                shrink={true}
+              >
+                <div
+                  className="flex-item flex-item--shrink accordionPanel-icon"
+                  onClick={[Function]}
+                >
+                  <ToggleSwitch
+                    disabled={false}
+                    id="switch-firstsection"
+                    isActive={false}
+                    labelledBy="label-firstsection"
+                    name="firstsection"
+                    onClick={[Function]}
+                    tabIndex="-1"
+                  >
+                    <ToggleSwitch
+                      disabled={false}
+                      id="switch-firstsection"
+                      isActive={false}
+                      labelledBy="label-firstsection"
+                      name="firstsection"
+                      onClick={[Function]}
+                      tabIndex="-1"
+                    >
+                      <div>
+                        <Toggle
+                          aria-labelledby="label-firstsection"
+                          checked={false}
+                          disabled={false}
+                          id="switch-firstsection"
+                          name="firstsection"
+                          onClick={[Function]}
+                          tabIndex="-1"
+                        >
+                          <button
+                            aria-checked={false}
+                            aria-labelledby="label-firstsection"
+                            aria-readonly={false}
+                            checked={false}
+                            data-swarm-toggle="unchecked"
+                            disabled={false}
+                            id="switch-firstsection"
+                            name="firstsection"
+                            onClick={[Function]}
+                            role="checkbox"
+                            tabIndex="-1"
+                            type="button"
+                          >
+                            <span
+                              data-swarm-toggle-switch-disc={true}
+                            >
+                              <Icon
+                                color="var(--color-gray-4)"
+                                shape="cross"
+                                size="xs"
+                              >
+                                <svg
+                                  className="svg svg--cross svg-icon valign--middle"
+                                  height="20"
+                                  preserveAspectRatio="xMinYMin meet"
+                                  role="img"
+                                  style={
+                                    Object {
+                                      "fill": "var(--color-gray-4)",
+                                    }
+                                  }
+                                  viewBox="0 0 20 20"
+                                  width="20"
+                                >
+                                  <use
+                                    xlinkHref="#icon-cross--small"
+                                  />
+                                </svg>
+                              </Icon>
+                            </span>
+                          </button>
+                        </Toggle>
+                      </div>
+                    </ToggleSwitch>
+                  </ToggleSwitch>
+                </div>
+              </FlexItemComponent>
+            </FlexItem>
+          </div>
+        </FlexComponent>
+      </Flex>
+    </div>
+    <Chunk
+      aria-hidden={true}
+      aria-labelledby="label-firstsection"
+      className="accordionPanel-animator accordionPanel-animator--collapse"
+      id="panel-firstsection"
+      onTransitionEnd={[Function]}
+      role="tabpanel"
+      style={
+        Object {
+          "height": "0px",
+        }
+      }
+    >
+      <ChunkComponent
+        aria-hidden={true}
+        aria-labelledby="label-firstsection"
+        className="accordionPanel-animator accordionPanel-animator--collapse"
+        id="panel-firstsection"
+        onTransitionEnd={[Function]}
+        role="tabpanel"
+        style={
+          Object {
+            "height": "0px",
+          }
+        }
+      >
+        <div
+          aria-hidden={true}
+          aria-labelledby="label-firstsection"
+          className="chunk accordionPanel-animator accordionPanel-animator--collapse"
+          id="panel-firstsection"
+          onTransitionEnd={[Function]}
+          role="tabpanel"
+          style={
+            Object {
+              "height": "0px",
+            }
+          }
+        >
+          <div
+            className="accordionPanel-content"
+          >
+            <div
+              className="runningText"
+            >
+              <p>
+                Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source.
+              </p>
+            </div>
+          </div>
+        </div>
+      </ChunkComponent>
+    </Chunk>
+  </div>
+</AccordionPanel>
+`;
+
 exports[`AccordionPanel Panel basic behavior exists and renders with mock props 1`] = `
 <div>
   <div
@@ -13,6 +304,7 @@ exports[`AccordionPanel Panel basic behavior exists and renders with mock props 
     tabIndex={0}
   >
     <Flex
+      align="center"
       className="padding--bottom padding--top accordionPanel"
       rowReverse={false}
       tabIndex={-1}
@@ -76,6 +368,7 @@ exports[`AccordionPanel Panel with custom icon exists and renders a custom icon 
     tabIndex={0}
   >
     <Flex
+      align="center"
       className="padding--bottom padding--top accordionPanel"
       rowReverse="all"
       tabIndex={-1}
@@ -155,18 +448,20 @@ exports[`AccordionPanel Panel with right aligned icon exists and renders icon le
       tabIndex={0}
     >
       <Flex
+        align="center"
         className="padding--bottom padding--top accordionPanel"
         rowReverse="all"
         tabIndex={-1}
       >
         <FlexComponent
+          align="center"
           className="padding--bottom padding--top accordionPanel"
           direction="row"
           rowReverse="all"
           tabIndex={-1}
         >
           <div
-            className="flex flex--row atAll_flex--rowReverse padding--bottom padding--top accordionPanel"
+            className="flex flex--row atAll_flex--rowReverse flex--alignCenter padding--bottom padding--top accordionPanel"
             tabIndex={-1}
           >
             <FlexItem
@@ -319,18 +614,20 @@ exports[`AccordionPanel Panel with toggle switch exists and renders a toggle swi
       tabIndex={0}
     >
       <Flex
+        align="center"
         className="padding--bottom padding--top accordionPanel"
         rowReverse="all"
         tabIndex={-1}
       >
         <FlexComponent
+          align="center"
           className="padding--bottom padding--top accordionPanel"
           direction="row"
           rowReverse="all"
           tabIndex={-1}
         >
           <div
-            className="flex flex--row atAll_flex--rowReverse padding--bottom padding--top accordionPanel"
+            className="flex flex--row atAll_flex--rowReverse flex--alignCenter padding--bottom padding--top accordionPanel"
             tabIndex={-1}
           >
             <FlexItem

--- a/src/interactive/__snapshots__/accordionPanelGroup.test.jsx.snap
+++ b/src/interactive/__snapshots__/accordionPanelGroup.test.jsx.snap
@@ -116,18 +116,20 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable gives panels a
             tabIndex={0}
           >
             <Flex
+              align="center"
               className="padding--bottom padding--top accordionPanel accordionPanel--active"
               rowReverse={false}
               tabIndex={-1}
             >
               <FlexComponent
+                align="center"
                 className="padding--bottom padding--top accordionPanel accordionPanel--active"
                 direction="row"
                 rowReverse={false}
                 tabIndex={-1}
               >
                 <div
-                  className="flex flex--row padding--bottom padding--top accordionPanel accordionPanel--active"
+                  className="flex flex--row flex--alignCenter padding--bottom padding--top accordionPanel accordionPanel--active"
                   tabIndex={-1}
                 >
                   <FlexItem
@@ -300,18 +302,20 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable gives panels a
             tabIndex={0}
           >
             <Flex
+              align="center"
               className="padding--bottom padding--top accordionPanel"
               rowReverse={false}
               tabIndex={-1}
             >
               <FlexComponent
+                align="center"
                 className="padding--bottom padding--top accordionPanel"
                 direction="row"
                 rowReverse={false}
                 tabIndex={-1}
               >
                 <div
-                  className="flex flex--row padding--bottom padding--top accordionPanel"
+                  className="flex flex--row flex--alignCenter padding--bottom padding--top accordionPanel"
                   tabIndex={-1}
                 >
                   <FlexItem
@@ -484,18 +488,20 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable gives panels a
             tabIndex={0}
           >
             <Flex
+              align="center"
               className="padding--bottom padding--top accordionPanel"
               rowReverse={false}
               tabIndex={-1}
             >
               <FlexComponent
+                align="center"
                 className="padding--bottom padding--top accordionPanel"
                 direction="row"
                 rowReverse={false}
                 tabIndex={-1}
               >
                 <div
-                  className="flex flex--row padding--bottom padding--top accordionPanel"
+                  className="flex flex--row flex--alignCenter padding--bottom padding--top accordionPanel"
                   tabIndex={-1}
                 >
                   <FlexItem
@@ -737,18 +743,20 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable renders panels
             tabIndex={0}
           >
             <Flex
+              align="center"
               className="padding--bottom padding--top accordionPanel accordionPanel--active"
               rowReverse={false}
               tabIndex={-1}
             >
               <FlexComponent
+                align="center"
                 className="padding--bottom padding--top accordionPanel accordionPanel--active"
                 direction="row"
                 rowReverse={false}
                 tabIndex={-1}
               >
                 <div
-                  className="flex flex--row padding--bottom padding--top accordionPanel accordionPanel--active"
+                  className="flex flex--row flex--alignCenter padding--bottom padding--top accordionPanel accordionPanel--active"
                   tabIndex={-1}
                 >
                   <FlexItem
@@ -921,18 +929,20 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable renders panels
             tabIndex={0}
           >
             <Flex
+              align="center"
               className="padding--bottom padding--top accordionPanel"
               rowReverse={false}
               tabIndex={-1}
             >
               <FlexComponent
+                align="center"
                 className="padding--bottom padding--top accordionPanel"
                 direction="row"
                 rowReverse={false}
                 tabIndex={-1}
               >
                 <div
-                  className="flex flex--row padding--bottom padding--top accordionPanel"
+                  className="flex flex--row flex--alignCenter padding--bottom padding--top accordionPanel"
                   tabIndex={-1}
                 >
                   <FlexItem
@@ -1105,18 +1115,20 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable renders panels
             tabIndex={0}
           >
             <Flex
+              align="center"
               className="padding--bottom padding--top accordionPanel"
               rowReverse={false}
               tabIndex={-1}
             >
               <FlexComponent
+                align="center"
                 className="padding--bottom padding--top accordionPanel"
                 direction="row"
                 rowReverse={false}
                 tabIndex={-1}
               >
                 <div
-                  className="flex flex--row padding--bottom padding--top accordionPanel"
+                  className="flex flex--row flex--alignCenter padding--bottom padding--top accordionPanel"
                   tabIndex={-1}
                 >
                   <FlexItem

--- a/src/interactive/accordion.story.jsx
+++ b/src/interactive/accordion.story.jsx
@@ -41,6 +41,18 @@ const panelThreeProps = {
 	label: 'Third in default group',
 };
 
+const lockedPanelProps = {
+	panelContent: (
+		<div className="runningText">
+			<p>{textContent2}</p>
+		</div>
+	),
+	label: 'Locked panel',
+	isLocked: true,
+	lockedLabel: 'Unlock me!',
+	onLockedLabelClick: callbackAction('Locked label click'),
+};
+
 const defaultPanels = [
 	<AccordionPanel {...panelOneProps} />,
 	<AccordionPanel {...panelTwoProps} />,
@@ -132,6 +144,20 @@ storiesOf('Interactive/Accordion', module)
 		() => (
 			<div className="span--100 padding--all">
 				<AccordionPanelGroup indicatorSwitch accordionPanels={defaultPanels} />
+			</div>
+		),
+		{ info: { text: 'Show the indicator as a switch' } }
+	)
+	.add(
+		'ToggleSwitch indicator with locked panel',
+		() => (
+			<div className="span--100 padding--all">
+				<AccordionPanelGroup
+					indicatorSwitch
+					accordionPanels={defaultPanels
+						.slice(0, 2)
+						.concat(<AccordionPanel {...lockedPanelProps} />)}
+				/>
 			</div>
 		),
 		{ info: { text: 'Show the indicator as a switch' } }

--- a/src/interactive/accordionPanel.test.jsx
+++ b/src/interactive/accordionPanel.test.jsx
@@ -251,4 +251,52 @@ describe('AccordionPanel', function() {
 			expect(switchNode.props().disabled).toBe(true);
 		});
 	});
+
+	describe('Locked panel with toggle switch', () => {
+		let panelToggleSwitchLocked;
+		const onLockedLabelClickMock = jest.fn();
+		const onClickCallbackMock = jest.fn();
+
+		beforeEach(() => {
+			panelToggleSwitchLocked = mount(
+				<AccordionPanel
+					indicatorSwitch
+					label="First Section"
+					indicatorAlign="left"
+					panelContent={
+						<div className="runningText">
+							<p>{textContent1}</p>
+						</div>
+					}
+					isLocked
+					lockedLabel="Unlock me!"
+					onLockedLabelClick={onLockedLabelClickMock}
+					onClickCallback={onClickCallbackMock}
+				/>
+			);
+		});
+
+		afterEach(() => {
+			panelToggleSwitchLocked = null;
+			onLockedLabelClickMock.mockClear();
+		});
+
+		it('renders locked toggle panel', () => {
+			expect(panelToggleSwitchLocked).toMatchSnapshot();
+		});
+
+		it('should call onLockedLabelClick callback when user clicks on locked label', () => {
+			const lockedLabel = panelToggleSwitchLocked.find(
+				'.accordionPanel-locked-label'
+			);
+			lockedLabel.simulate('click');
+			expect(onLockedLabelClickMock).toHaveBeenCalledTimes(1);
+		});
+
+		it('shouln`t call onClickCallback when user clicks and panel is locked', () => {
+			const switchNode = panelToggleSwitchLocked.find(ToggleSwitch);
+			switchNode.find('button').simulate('click');
+			expect(onClickCallback).toHaveBeenCalledTimes(0);
+		});
+	});
 });


### PR DESCRIPTION
#### Related issues
This PR relates to https://app.clubhouse.io/meetup/story/19500/add-registration-form-form-toggles-but-grey-them-out-with-cta-to-go-pro-event-scheduler

#### Description
This PR updates AccordionPanel with locked state and locked label.

#### Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/16779509/131336696-e6abf1ba-ec6c-4820-ac49-4e95736c3ad3.png)
![image](https://user-images.githubusercontent.com/16779509/131336718-8047f0e3-6c00-4025-bb1e-ef89bec92317.png)
