### PR TITLE
[CH-21562] Upgrade locked badge with optional 'preventDefault' flag prop

### DIFF
--- a/src/forms/LockedBadge.jsx
+++ b/src/forms/LockedBadge.jsx
@@ -34,7 +34,9 @@ export class LockedBadge extends React.PureComponent {
 	}
 
 	handleClick(e) {
-		e.preventDefault();
+		if (this.props.preventDefault) {
+			e.preventDefault();
+		}
 
 		this.props.onClick(e);
 	}
@@ -82,6 +84,13 @@ LockedBadge.propTypes = {
 
 	/** A callback that happens after the locked label has been clicked  */
 	onClick: PropTypes.func.isRequired,
+
+	/** Optional flag for using 'event.preventDefault' method  */
+	preventDefault: PropTypes.bool,
+};
+
+LockedBadge.defaultProps = {
+	preventDefault: true,
 };
 
 export default DeprecationWarning(LockedBadge);

--- a/src/forms/__snapshots__/LockedBadge.test.jsx.snap
+++ b/src/forms/__snapshots__/LockedBadge.test.jsx.snap
@@ -4,6 +4,7 @@ exports[`LockedBadge renders locked badge with default styles 1`] = `
 <LockedBadge
   label="Default label"
   onClick={[MockFunction]}
+  preventDefault={true}
 />
 `;
 
@@ -11,6 +12,7 @@ exports[`LockedBadge renders locked badge with neutral styles 1`] = `
 <LockedBadge
   label="Default label"
   onClick={[MockFunction]}
+  preventDefault={true}
   variant="neutral"
 />
 `;

--- a/src/interactive/__snapshots__/accordionPanel.test.jsx.snap
+++ b/src/interactive/__snapshots__/accordionPanel.test.jsx.snap
@@ -88,6 +88,7 @@ exports[`AccordionPanel Locked panel with toggle switch renders locked toggle pa
                     <LockedBadge
                       label="Unlock me!"
                       onClick={[MockFunction]}
+                      preventDefault={true}
                     >
                       <Flex>
                         <FlexComponent


### PR DESCRIPTION
#### Related issues
https://app.clubhouse.io/meetup/story/21562/under-manager-group-more-add-api-greyed-our-with-an-upgrade-option

#### Description
Need to add optional 'preventDefault' flag prop to use link href in parent elements.

#### Screenshots (if applicable)
