### PR TITLE
feat: [sc-64939] [AWS mods] - Removal of the entire Members tab from the Pro Dashboard

### DIFF
--- a/src/navigation/components/dashboard/DashboardDropdown.jsx
+++ b/src/navigation/components/dashboard/DashboardDropdown.jsx
@@ -20,13 +20,14 @@ export const DashboardDropdownComponent = ({ mobileTabs, dismissAction }) => {
 		profile,
 		logout,
 		analytics,
-		members,
 		groups,
 		events,
 		templates,
 		publicProfile,
 		contact,
 	} = mobileTabs;
+	const { members } = mobileTabs || {};
+
 	return (
 		<Modal onDismiss={dismissAction}>
 			<Flex justify="spaceBetween" className="align--left padding--all">
@@ -35,9 +36,11 @@ export const DashboardDropdownComponent = ({ mobileTabs, dismissAction }) => {
 						<li className="list-item padding--bottom">
 							<a href={analytics.link}>{analytics.label}</a>
 						</li>
-						<li className="list-item padding--bottom">
-							<a href={members.link}>{members.label}</a>
-						</li>
+						{Boolean(members) && (
+							<li className="list-item padding--bottom">
+								<a href={members.link}>{members.label}</a>
+							</li>
+						)}
 						<li className="list-item padding--bottom">
 							<a href={groups.link}>{groups.label}</a>
 						</li>

--- a/src/navigation/components/dashboard/DashboardDropdown.test.jsx
+++ b/src/navigation/components/dashboard/DashboardDropdown.test.jsx
@@ -54,4 +54,11 @@ describe('Profile Dropdown', () => {
 		const wrapper = shallow(<DashboardDropdown {...MOCK_PROPS} />);
 		expect(wrapper).toMatchSnapshot();
 	});
+	it('should match snapshot without members tab', () => {
+		const mobileTabs = { ...MOCK_PROPS.mobileTabs };
+		delete mobileTabs.members;
+		const updatedProps = { ...MOCK_PROPS, mobileTabs };
+		const wrapper = shallow(<DashboardDropdown {...updatedProps} />);
+		expect(wrapper).toMatchSnapshot();
+	});
 });

--- a/src/navigation/components/dashboard/__snapshots__/DashboardDropdown.test.jsx.snap
+++ b/src/navigation/components/dashboard/__snapshots__/DashboardDropdown.test.jsx.snap
@@ -110,3 +110,105 @@ exports[`Profile Dropdown should match snapshot 1`] = `
   </Flex>
 </Modal>
 `;
+
+exports[`Profile Dropdown should match snapshot without members tab 1`] = `
+<Modal
+  onDismiss={[MockFunction]}
+>
+  <Flex
+    className="align--left padding--all"
+    justify="spaceBetween"
+  >
+    <FlexItem
+      className="text--secondary margin--left"
+      growFactor={1}
+    >
+      <ul
+        className="list"
+      >
+        <li
+          className="list-item padding--bottom"
+        >
+          <a
+            href="meetup.com"
+          >
+            Analytics
+          </a>
+        </li>
+        <li
+          className="list-item padding--bottom"
+        >
+          <a
+            href="meetup.com"
+          >
+            Groups
+          </a>
+        </li>
+        <li
+          className="list-item padding--bottom"
+        >
+          <a
+            href="meetup.com"
+          >
+            Events
+          </a>
+        </li>
+        <li
+          className="list-item padding--bottom"
+        >
+          <a
+            href="meetup.com"
+          >
+            Templates
+          </a>
+        </li>
+        <li
+          className="list-item padding--bottom"
+        >
+          <a
+            href="meetup.com"
+          >
+            Public Profile
+          </a>
+        </li>
+        <li
+          className="list-item"
+        >
+          <a
+            href="meetup.com"
+          >
+            Your profile
+          </a>
+        </li>
+        <li
+          className="padding--top"
+        >
+          <a
+            href="meetup.com"
+          >
+            Contact
+          </a>
+        </li>
+        <li
+          className="padding--top"
+        >
+          <a
+            href="meetup.com"
+          >
+            Help
+          </a>
+        </li>
+        <li
+          className="padding--top"
+        >
+          <a
+            href="meetup.com"
+          >
+            Logout
+          </a>
+        </li>
+      </ul>
+    </FlexItem>
+  </Flex>
+</Modal>
+`;


### PR DESCRIPTION
Story details: https://app.shortcut.com/meetup/story/64939

Make members in pro dashboard optional.