### PR TITLE
Feature/sc 66152/fe desktop update core nav bar

### DIFF
--- a/src/__snapshots__/footer.test.jsx.snap
+++ b/src/__snapshots__/footer.test.jsx.snap
@@ -207,7 +207,7 @@ exports[`Footer exists 1`] = `
           items={
             Array [
               <span>
-                © 2023 Meetup LLC
+                © 2022 Meetup LLC
               </span>,
             ]
           }

--- a/src/__snapshots__/footer.test.jsx.snap
+++ b/src/__snapshots__/footer.test.jsx.snap
@@ -207,7 +207,7 @@ exports[`Footer exists 1`] = `
           items={
             Array [
               <span>
-                © 2022 Meetup LLC
+                © 2023 Meetup LLC
               </span>,
             ]
           }

--- a/src/navigation/Nav.jsx
+++ b/src/navigation/Nav.jsx
@@ -158,7 +158,7 @@ export class Nav extends React.Component {
 			onSearchCallback,
 			isNewNavActive,
 			isNewNavsOrder,
-			isProInNavFFEnabled,
+			isProInNavFFEnabled = false,
 			...other
 		} = this.props;
 
@@ -197,6 +197,7 @@ export class Nav extends React.Component {
 		const isNewNavActiveDesktop = isNewNavActive && media.isAtMediumUp;
 		const isProAdminEasyCreateGroup =
 			Boolean(self.is_pro_admin) && media.isAtMediumUp;
+		const isProInNavDesktop = isProInNavFFEnabled && media.isAtMediumUp;
 
 		const profileAvatarSize =
 			isNewNavActiveDesktop || isProAdminEasyCreateGroup
@@ -302,7 +303,7 @@ export class Nav extends React.Component {
 		};
 
 		const getMessagesLabel = () => {
-			if (isProInNavFFEnabled) {
+			if (isProInNavDesktop) {
 				return messages.label;
 			}
 
@@ -312,7 +313,7 @@ export class Nav extends React.Component {
 		};
 
 		const getNotificataionsLabel = () => {
-			if (isProInNavFFEnabled) {
+			if (isProInNavDesktop) {
 				return notifications.label;
 			}
 
@@ -412,14 +413,20 @@ export class Nav extends React.Component {
 				shrink: true,
 				linkTo: messages.link,
 				label: getMessagesLabel(),
-				labelClassName: cx(isProAdminEasyCreateGroup && 'navItem-label-pro'),
+				labelClassName: cx(
+					(isProAdminEasyCreateGroup || isProInNavDesktop) &&
+						'navItem-label-pro'
+				),
 				className: `navItem--messages ${CLASS_AUTH_ITEM}`,
-				linkClassName: cx(isProAdminEasyCreateGroup && 'navItemLink-pro'),
+				linkClassName: cx(
+					(isProAdminEasyCreateGroup || isProInNavDesktop) && 'navItemLink-pro'
+				),
 				counterBadgeClassName: cx(
 					isNewNavActiveDesktop &&
 						!isProAdminEasyCreateGroup &&
 						'navItem--counterBadge',
-					isProAdminEasyCreateGroup && 'navItem--counterBadgeProMessages'
+					(isProAdminEasyCreateGroup || isProInNavDesktop) &&
+						'navItem--counterBadgeProMessages'
 				),
 				icon: getMessagesIcon(),
 				hasUpdates: messages.unreadMessages > 0,
@@ -433,14 +440,20 @@ export class Nav extends React.Component {
 						? ''
 						: notifications.link,
 				label: getNotificataionsLabel(),
-				labelClassName: cx(isProAdminEasyCreateGroup && 'navItem-label-pro'),
+				labelClassName: cx(
+					(isProAdminEasyCreateGroup || isProInNavDesktop) &&
+						'navItem-label-pro'
+				),
 				className: cx('navItem--notifications', CLASS_AUTH_ITEM),
-				linkClassName: cx(isProAdminEasyCreateGroup && 'navItemLink-pro'),
+				linkClassName: cx(
+					(isProAdminEasyCreateGroup || isProInNavDesktop) && 'navItemLink-pro'
+				),
 				counterBadgeClassName: cx(
 					isNewNavActiveDesktop &&
 						!isProAdminEasyCreateGroup &&
 						'navItem--counterBadge',
-					isProAdminEasyCreateGroup && 'navItem--counterBadgeProNotifications'
+					(isProAdminEasyCreateGroup || isProInNavDesktop) &&
+						'navItem--counterBadgeProNotifications'
 				),
 				icon: getNotificationsIcon(),
 				onClickAction:

--- a/src/navigation/Nav.jsx
+++ b/src/navigation/Nav.jsx
@@ -158,6 +158,7 @@ export class Nav extends React.Component {
 			onSearchCallback,
 			isNewNavActive,
 			isNewNavsOrder,
+			isProInNavFFEnabled,
 			...other
 		} = this.props;
 
@@ -300,6 +301,26 @@ export class Nav extends React.Component {
 			);
 		};
 
+		const getMessagesLabel = () => {
+			if (isProInNavFFEnabled) {
+				return messages.label;
+			}
+
+			return isNewNavActiveDesktop && !isProAdminEasyCreateGroup
+				? ''
+				: messages.label;
+		};
+
+		const getNotificataionsLabel = () => {
+			if (isProInNavFFEnabled) {
+				return notifications.label;
+			}
+
+			return isNewNavActiveDesktop && !isProAdminEasyCreateGroup
+				? ''
+				: notifications.label;
+		};
+
 		const proDashboardIcon = isProAdminEasyCreateGroup ? (
 			<img className="proIcon" src={PRO_DASHBOARD_ICON} />
 		) : (
@@ -390,10 +411,7 @@ export class Nav extends React.Component {
 			{
 				shrink: true,
 				linkTo: messages.link,
-				label:
-					isNewNavActiveDesktop && !isProAdminEasyCreateGroup
-						? ''
-						: messages.label,
+				label: getMessagesLabel(),
 				labelClassName: cx(isProAdminEasyCreateGroup && 'navItem-label-pro'),
 				className: `navItem--messages ${CLASS_AUTH_ITEM}`,
 				linkClassName: cx(isProAdminEasyCreateGroup && 'navItemLink-pro'),
@@ -414,10 +432,7 @@ export class Nav extends React.Component {
 					media.isAtMediumUp && !isNewNavActive && !isProAdminEasyCreateGroup
 						? ''
 						: notifications.link,
-				label:
-					isNewNavActiveDesktop && !isProAdminEasyCreateGroup
-						? ''
-						: notifications.label,
+				label: getNotificataionsLabel(),
 				labelClassName: cx(isProAdminEasyCreateGroup && 'navItem-label-pro'),
 				className: cx('navItem--notifications', CLASS_AUTH_ITEM),
 				linkClassName: cx(isProAdminEasyCreateGroup && 'navItemLink-pro'),
@@ -681,6 +696,9 @@ Nav.propTypes = {
 
 	/** Flag to indicate that new Nav should be shown (same as in build-meetup/homepage) */
 	isNewNavActive: PropTypes.bool,
+
+	// Flag to indicate if updated Core nav is shown and for adding Pro to the Core Nav
+	isProInNavFFEnabled: PropTypes.bool,
 };
 
 export default Nav;


### PR DESCRIPTION
[Shortcut](https://app.shortcut.com/meetup/story/66152/fe-desktop-update-core-nav-bar)

#### Screenshot 

new `mup-web`
<img width="653" alt="Screenshot 2023-01-12 at 9 49 36 PM" src="https://user-images.githubusercontent.com/49497414/212234125-29ec9c21-5e91-4beb-a51a-c06061e18af2.png">

to match `pro-web`
<img width="595" alt="Screenshot 2023-01-12 at 9 49 45 PM" src="https://user-images.githubusercontent.com/49497414/212234157-e264a97f-3d3f-4b63-a8f7-ecf0195e423b.png">

