### PR TITLE
feat: [sc-73275] [Pro Dashboard] - custom controls - ARIA toggle fields must have an accessible name

### DIFF
--- a/src/forms/Checkbox.jsx
+++ b/src/forms/Checkbox.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Checkbox as SwarmCheckbox } from '@meetup/swarm-components';
+import Icon from '@meetup/swarm-components/lib/Icon';
 import DeprecationWarning from '../utils/components/DeprecationWarning';
 
 /**
@@ -48,12 +48,10 @@ export class Checkbox extends React.PureComponent {
 	render() {
 		// use the "eslint-disable-line" because we don't want
 		// the `checked` and `controlled` props passed in `other`
-		// to the `SwarmCheckbox` component
 		const {
 			checked, // eslint-disable-line no-unused-vars
 			controlled, // eslint-disable-line no-unused-vars
 			onChange, // eslint-disable-line no-unused-vars
-			labelClassName, // eslint-disable-line no-unused-vars
 			id,
 			label,
 			disabled,
@@ -66,16 +64,36 @@ export class Checkbox extends React.PureComponent {
 		const stateChecked = this.getChecked();
 
 		return (
-			<SwarmCheckbox
-				checked={stateChecked}
-				label={label}
-				id={elId}
-				disabled={disabled}
-				onChange={this.onChange}
-				name={name}
-				value={value}
+			<label
+				data-swarm-checkbox={disabled ? 'disabled' : 'default'}
+				htmlFor={elId}
 				{...other}
-			/>
+			>
+				<span
+					data-swarm-checkbox-field={stateChecked ? 'checked' : 'unchecked'}
+					role="checkbox"
+					aria-checked={stateChecked}
+					aria-label="checkbox"
+				>
+					{stateChecked && (
+						<Icon
+							shape="check"
+							color={disabled ? 'var(--color-gray-6)' : '#ffffff'}
+						/>
+					)}
+				</span>
+				<input
+					type="checkbox"
+					id={elId}
+					checked={stateChecked}
+					disabled={disabled}
+					onChange={this.onChange}
+					readOnly={!this.onChange || disabled}
+					name={name}
+					value={`${value}`}
+				/>
+				<span>{label}</span>
+			</label>
 		);
 	}
 }

--- a/src/forms/__snapshots__/checkbox.test.jsx.snap
+++ b/src/forms/__snapshots__/checkbox.test.jsx.snap
@@ -1,23 +1,56 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Checkbox basic renders checked checkbox 1`] = `
-<Checkbox
-  checked={true}
-  id="hello"
-  label="Hello!"
-  name="greeting"
-  onChange={[Function]}
-  value="hello"
-/>
+<label
+  data-swarm-checkbox="default"
+  htmlFor="hello"
+>
+  <span
+    aria-checked={true}
+    aria-label="checkbox"
+    data-swarm-checkbox-field="checked"
+    role="checkbox"
+  >
+    <Icon
+      color="#ffffff"
+      shape="check"
+    />
+  </span>
+  <input
+    checked={true}
+    id="hello"
+    name="greeting"
+    onChange={[Function]}
+    type="checkbox"
+    value="hello"
+  />
+  <span>
+    Hello!
+  </span>
+</label>
 `;
 
 exports[`Checkbox basic renders unchecked checkbox 1`] = `
-<Checkbox
-  checked={false}
-  id="hello"
-  label="Hello!"
-  name="greeting"
-  onChange={[Function]}
-  value="hello"
-/>
+<label
+  data-swarm-checkbox="default"
+  htmlFor="hello"
+>
+  <span
+    aria-checked={false}
+    aria-label="checkbox"
+    data-swarm-checkbox-field="unchecked"
+    role="checkbox"
+  />
+  <input
+    checked={false}
+    id="hello"
+    name="greeting"
+    onChange={[Function]}
+    type="checkbox"
+    value="hello"
+  />
+  <span>
+    Hello!
+  </span>
+</label>
 `;


### PR DESCRIPTION
Story details: https://app.shortcut.com/meetup/story/73275
 
Moving checkbox from swarm-ui, because [swarm-ui](https://github.com/meetup/swarm-ui) is not deployable and planned to be deprecated.
Added aria-label for accessibility.