### PR TITLE
Event Create custom controls Elements must [sc-73276]

### DIFF
--- a/src/interactive/Tooltip.jsx
+++ b/src/interactive/Tooltip.jsx
@@ -119,7 +119,8 @@ class Tooltip extends React.PureComponent {
 					onFocus={manualToggle ? undefined : this.openContent}
 					onBlur={manualToggle ? undefined : this.onBlur}
 					onMouseEnter={manualToggle ? undefined : this.openContent}
-					aria-labelledby={id}
+					aria-labelledby={isActive ? id : undefined}
+					role={isActive ? 'button' : undefined}
 				>
 					{trigger}
 				</div>

--- a/src/interactive/__snapshots__/tooltip.test.jsx.snap
+++ b/src/interactive/__snapshots__/tooltip.test.jsx.snap
@@ -70,6 +70,7 @@ exports[`Tooltip tooltip with a close button should render correctly 1`] = `
       onBlur={[Function]}
       onFocus={[Function]}
       onMouseEnter={[Function]}
+      role="button"
     >
       <Button
         small={true}


### PR DESCRIPTION
#### Related issues
Fixes PIVOTAL-xxx

#### Description

#### Screenshots (if applicable)

`aria-labelledby` should be added only when element with id exist
role `button` was added only for active status when component have `aria-labelledby` to avoid mistakes

