### PR TITLE
Web Alt text Event Create page [sc-72006]

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -7339,25 +7339,50 @@ Breakpoints        | Property       | Variants
 .tw-flex-grow {
   flex-grow: 1; }
 
+@-webkit-keyframes tw-spin {
+  to {
+    transform: rotate(360deg); } }
+
 @keyframes tw-spin {
   to {
     transform: rotate(360deg); } }
+
+@-webkit-keyframes tw-ping {
+  75%, 100% {
+    transform: scale(2);
+    opacity: 0; } }
 
 @keyframes tw-ping {
   75%, 100% {
     transform: scale(2);
     opacity: 0; } }
 
+@-webkit-keyframes tw-pulse {
+  50% {
+    opacity: .5; } }
+
 @keyframes tw-pulse {
   50% {
     opacity: .5; } }
 
-@keyframes tw-bounce {
+@-webkit-keyframes tw-bounce {
   0%, 100% {
     transform: translateY(-25%);
+    -webkit-animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
     animation-timing-function: cubic-bezier(0.8, 0, 1, 1); }
   50% {
     transform: none;
+    -webkit-animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+    animation-timing-function: cubic-bezier(0, 0, 0.2, 1); } }
+
+@keyframes tw-bounce {
+  0%, 100% {
+    transform: translateY(-25%);
+    -webkit-animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+    animation-timing-function: cubic-bezier(0.8, 0, 1, 1); }
+  50% {
+    transform: none;
+    -webkit-animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
     animation-timing-function: cubic-bezier(0, 0, 0.2, 1); } }
 
 .tw-flex-row {

--- a/assets/css/tailwind.min.css
+++ b/assets/css/tailwind.min.css
@@ -26,9 +26,22 @@
   flex-grow: 1
 }
 
+@-webkit-keyframes tw-spin {
+  to {
+    transform: rotate(360deg)
+  }
+}
+
 @keyframes tw-spin {
   to {
     transform: rotate(360deg)
+  }
+}
+
+@-webkit-keyframes tw-ping {
+  75%, 100% {
+    transform: scale(2);
+    opacity: 0
   }
 }
 
@@ -39,21 +52,43 @@
   }
 }
 
+@-webkit-keyframes tw-pulse {
+  50% {
+    opacity: .5
+  }
+}
+
 @keyframes tw-pulse {
   50% {
     opacity: .5
   }
 }
 
-@keyframes tw-bounce {
+@-webkit-keyframes tw-bounce {
   0%, 100% {
     transform: translateY(-25%);
-    animation-timing-function: cubic-bezier(0.8,0,1,1)
+    -webkit-animation-timing-function: cubic-bezier(0.8,0,1,1);
+            animation-timing-function: cubic-bezier(0.8,0,1,1)
   }
 
   50% {
     transform: none;
-    animation-timing-function: cubic-bezier(0,0,0.2,1)
+    -webkit-animation-timing-function: cubic-bezier(0,0,0.2,1);
+            animation-timing-function: cubic-bezier(0,0,0.2,1)
+  }
+}
+
+@keyframes tw-bounce {
+  0%, 100% {
+    transform: translateY(-25%);
+    -webkit-animation-timing-function: cubic-bezier(0.8,0,1,1);
+            animation-timing-function: cubic-bezier(0.8,0,1,1)
+  }
+
+  50% {
+    transform: none;
+    -webkit-animation-timing-function: cubic-bezier(0,0,0.2,1);
+            animation-timing-function: cubic-bezier(0,0,0.2,1)
   }
 }
 

--- a/src/interactive/__snapshots__/accordionPanel.test.jsx.snap
+++ b/src/interactive/__snapshots__/accordionPanel.test.jsx.snap
@@ -138,6 +138,7 @@ exports[`AccordionPanel Locked panel with toggle switch renders locked toggle pa
                                       >
                                         <Icon
                                           color="#00798A"
+                                          role="presentation"
                                           shape="lock"
                                           size="xs"
                                         >
@@ -145,7 +146,7 @@ exports[`AccordionPanel Locked panel with toggle switch renders locked toggle pa
                                             className="svg svg--lock svg-icon valign--middle"
                                             height="20"
                                             preserveAspectRatio="xMinYMin meet"
-                                            role="img"
+                                            role="presentation"
                                             style={
                                               Object {
                                                 "fill": "#00798A",
@@ -539,6 +540,7 @@ exports[`AccordionPanel Panel with right aligned icon exists and renders icon le
                       className="indicator"
                     >
                       <Icon
+                        role="presentation"
                         shape="chevron-down"
                         size="xs"
                       >
@@ -546,7 +548,7 @@ exports[`AccordionPanel Panel with right aligned icon exists and renders icon le
                           className="svg svg--chevron-down svg-icon valign--middle"
                           height="20"
                           preserveAspectRatio="xMinYMin meet"
-                          role="img"
+                          role="presentation"
                           style={Object {}}
                           viewBox="0 0 20 20"
                           width="20"

--- a/src/interactive/__snapshots__/accordionPanelGroup.test.jsx.snap
+++ b/src/interactive/__snapshots__/accordionPanelGroup.test.jsx.snap
@@ -168,6 +168,7 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable gives panels a
                             className="indicator indicator--animateActive"
                           >
                             <Icon
+                              role="presentation"
                               shape="chevron-down"
                               size="xs"
                             >
@@ -175,7 +176,7 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable gives panels a
                                 className="svg svg--chevron-down svg-icon valign--middle"
                                 height="20"
                                 preserveAspectRatio="xMinYMin meet"
-                                role="img"
+                                role="presentation"
                                 style={Object {}}
                                 viewBox="0 0 20 20"
                                 width="20"
@@ -353,6 +354,7 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable gives panels a
                             className="indicator"
                           >
                             <Icon
+                              role="presentation"
                               shape="chevron-down"
                               size="xs"
                             >
@@ -360,7 +362,7 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable gives panels a
                                 className="svg svg--chevron-down svg-icon valign--middle"
                                 height="20"
                                 preserveAspectRatio="xMinYMin meet"
-                                role="img"
+                                role="presentation"
                                 style={Object {}}
                                 viewBox="0 0 20 20"
                                 width="20"
@@ -538,6 +540,7 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable gives panels a
                             className="indicator"
                           >
                             <Icon
+                              role="presentation"
                               shape="chevron-down"
                               size="xs"
                             >
@@ -545,7 +548,7 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable gives panels a
                                 className="svg svg--chevron-down svg-icon valign--middle"
                                 height="20"
                                 preserveAspectRatio="xMinYMin meet"
-                                role="img"
+                                role="presentation"
                                 style={Object {}}
                                 viewBox="0 0 20 20"
                                 width="20"
@@ -792,6 +795,7 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable renders panels
                             className="indicator indicator--animateActive"
                           >
                             <Icon
+                              role="presentation"
                               shape="chevron-down"
                               size="xs"
                             >
@@ -799,7 +803,7 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable renders panels
                                 className="svg svg--chevron-down svg-icon valign--middle"
                                 height="20"
                                 preserveAspectRatio="xMinYMin meet"
-                                role="img"
+                                role="presentation"
                                 style={Object {}}
                                 viewBox="0 0 20 20"
                                 width="20"
@@ -977,6 +981,7 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable renders panels
                             className="indicator"
                           >
                             <Icon
+                              role="presentation"
                               shape="chevron-down"
                               size="xs"
                             >
@@ -984,7 +989,7 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable renders panels
                                 className="svg svg--chevron-down svg-icon valign--middle"
                                 height="20"
                                 preserveAspectRatio="xMinYMin meet"
-                                role="img"
+                                role="presentation"
                                 style={Object {}}
                                 viewBox="0 0 20 20"
                                 width="20"
@@ -1162,6 +1167,7 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable renders panels
                             className="indicator"
                           >
                             <Icon
+                              role="presentation"
                               shape="chevron-down"
                               size="xs"
                             >
@@ -1169,7 +1175,7 @@ exports[`AccordionPanelGroup AccordionPanelGroup, multiselectable renders panels
                                 className="svg svg--chevron-down svg-icon valign--middle"
                                 height="20"
                                 preserveAspectRatio="xMinYMin meet"
-                                role="img"
+                                role="presentation"
                                 style={Object {}}
                                 viewBox="0 0 20 20"
                                 width="20"

--- a/src/media/Icon.jsx
+++ b/src/media/Icon.jsx
@@ -19,11 +19,16 @@ class Icon extends React.PureComponent {
 	}
 
 	render() {
-		const { className, circled, role, ...other } = this.props;
+		const { className, circled, role, ariaLabel, ...other } = this.props;
 
 		return (
 			<span className={className}>
-				<SwarmIcon circle={circled} role={role || 'presentation'} {...other} />
+				<SwarmIcon
+					circle={circled}
+					role={role || 'presentation'}
+					aria-label={ariaLabel}
+					{...other}
+				/>
 			</span>
 		);
 	}

--- a/src/media/Icon.jsx
+++ b/src/media/Icon.jsx
@@ -52,7 +52,7 @@ Icon.propTypes = {
 	color: PropTypes.string,
 
 	/** Gives icon role */
-	role: PropTypes.bool,
+	role: PropTypes.string,
 
 	/** If an Icon is used on its own without supporting text to explain what it is/does, be a good citizen and pass in an `aria-label` */
 	ariaLabel: PropTypes.string,

--- a/src/media/Icon.jsx
+++ b/src/media/Icon.jsx
@@ -19,11 +19,11 @@ class Icon extends React.PureComponent {
 	}
 
 	render() {
-		const { className, circled, ...other } = this.props;
+		const { className, circled, role, ...other } = this.props;
 
 		return (
 			<span className={className}>
-				<SwarmIcon circle={circled} {...other} />
+				<SwarmIcon circle={circled} role={role || 'presentation'} {...other} />
 			</span>
 		);
 	}
@@ -45,6 +45,12 @@ Icon.propTypes = {
 
 	/** What color the icon should be filled with */
 	color: PropTypes.string,
+
+	/** Gives icon role */
+	role: PropTypes.bool,
+
+	/** If an Icon is used on its own without supporting text to explain what it is/does, be a good citizen and pass in an `aria-label` */
+	ariaLabel: PropTypes.string,
 };
 
 export default Icon;


### PR DESCRIPTION
#### Related issues
Fixes PIVOTAL-xxx

#### Description
Set the presentation role as the default for our image component.

In many cases, we use an icon with the `img` role without an `aria-label`, which can cause a lot of errors. In my opinion, it would be better to set an `aria-label` for icons that are used without supporting text, instead default role `img`.
#### Screenshots (if applicable)
