### PR TITLE
Updated `meetup-red` and `viridian` values globally for meetup-web-components 

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -4824,6 +4824,9 @@ input.field--reset:active {
       fill: #707070 !important; }
 >>>>>>> fe3f93ae (generated styles)
 
+.toggleSwitch[data-swarm-toggle="checked"] [data-swarm-toggle-switch-disc] {
+  border-color: #707070; }
+
 .tooltip-bubble {
   background-color: #353e48; }
   .tooltip-bubble::after {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -4799,6 +4799,7 @@ input.field--reset:active {
 .toggleButton-input:focus + .toggleButton-label {
   outline: 1px dotted rgba(46, 62, 72, 0.54); }
 
+<<<<<<< HEAD
 .toggleSwitch {
   /* stylelint-disable */
   /* stylelint disabling is a temporary solution to override styles from swarm ui */
@@ -4814,6 +4815,14 @@ input.field--reset:active {
   .toggleSwitch[data-swarm-toggle="checked"] [data-swarm-toggle-switch-disc] {
     border-color: #707070;
     margin-top: 0; }
+=======
+.toggleSwitch[data-swarm-toggle="unchecked"]:not(:disabled) {
+  border-color: #707070 !important; }
+  .toggleSwitch[data-swarm-toggle="unchecked"]:not(:disabled) [data-swarm-toggle-switch-disc] {
+    border-color: inherit; }
+    .toggleSwitch[data-swarm-toggle="unchecked"]:not(:disabled) [data-swarm-toggle-switch-disc] svg {
+      fill: #707070 !important; }
+>>>>>>> fe3f93ae (generated styles)
 
 .tooltip-bubble {
   background-color: #353e48; }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1805,6 +1805,10 @@ Class							  | Description
   animation: spin 0.8s linear;
   animation-iteration-count: infinite; }
 
+:root {
+  --color-meetup-red: #e32359 !important;
+  --color-viridian: #00798a !important; }
+
 /*doc
 ---
 title: Bounds
@@ -3460,6 +3464,13 @@ $('#fadeInLink').on('click', function(e) {
 .button--iconOnly {
   padding: 8px 16px; }
 
+[data-swarm-button="primary"] {
+  background-color: #e32359 !important;
+  border: 1px solid #e32359 !important; }
+  [data-swarm-button="primary"]:hover {
+    background-color: #e63a6a !important;
+    border: 1px solid #e63a6a !important; }
+
 /*doc
 ---
 title: Cards
@@ -4799,7 +4810,6 @@ input.field--reset:active {
 .toggleButton-input:focus + .toggleButton-label {
   outline: 1px dotted rgba(46, 62, 72, 0.54); }
 
-<<<<<<< HEAD
 .toggleSwitch {
   /* stylelint-disable */
   /* stylelint disabling is a temporary solution to override styles from swarm ui */
@@ -4815,17 +4825,6 @@ input.field--reset:active {
   .toggleSwitch[data-swarm-toggle="checked"] [data-swarm-toggle-switch-disc] {
     border-color: #707070;
     margin-top: 0; }
-=======
-.toggleSwitch[data-swarm-toggle="unchecked"]:not(:disabled) {
-  border-color: #707070 !important; }
-  .toggleSwitch[data-swarm-toggle="unchecked"]:not(:disabled) [data-swarm-toggle-switch-disc] {
-    border-color: inherit; }
-    .toggleSwitch[data-swarm-toggle="unchecked"]:not(:disabled) [data-swarm-toggle-switch-disc] svg {
-      fill: #707070 !important; }
->>>>>>> fe3f93ae (generated styles)
-
-.toggleSwitch[data-swarm-toggle="checked"] [data-swarm-toggle-switch-disc] {
-  border-color: #707070; }
 
 .tooltip-bubble {
   background-color: #353e48; }

--- a/assets/scss/components/_button.scss
+++ b/assets/scss/components/_button.scss
@@ -219,3 +219,14 @@
 .button--iconOnly {
 	padding: $space-half $space;
 }
+
+[data-swarm-button="primary"] {
+	$hover: lighten($color-meetup-red, 5%);
+	background-color: $color-meetup-red !important;
+	border: 1px solid $color-meetup-red !important;
+
+	&:hover {
+		background-color: $hover !important;
+		border: 1px solid $hover !important;
+	}
+}

--- a/assets/scss/util/_vars.scss
+++ b/assets/scss/util/_vars.scss
@@ -1,5 +1,18 @@
-
 // shadow for "interactive" elements,
 // like popover or dropdown menus
-$interactiveShadow: 0 2px 2px 0 $C_border,0 3px 1px -2px $C_separator,0 1px 5px 0 $C_border;
-$animate_easeOutQuad: cubic-bezier(0.165, 0.84, 0.44, 1); // stylelint-disable-line number-max-precision
+$interactiveShadow: 0 2px 2px 0 $C_border, 0 3px 1px -2px $C_separator,
+	0 1px 5px 0 $C_border;
+$animate_easeOutQuad: cubic-bezier(
+	0.165,
+	0.84,
+	0.44,
+	1
+); // stylelint-disable-line number-max-precision
+
+$color-meetup-red: #e32359;
+$color-viridian: #00798a;
+
+:root {
+	--color-meetup-red: #{$color-meetup-red} !important;
+	--color-viridian: #{$color-viridian} !important;
+}


### PR DESCRIPTION
#### Related issues
Fixes PIVOTAL-xxx

#### Description
This PR 

- updates values of `--color-meetup-red` and `--color-viridian` css variables, because it's value defines in non-deployable swarm-ui repo
- updates styling of primary button 

#### Screenshots (if applicable)
<img width="403" alt="image" src="https://user-images.githubusercontent.com/43377137/232486446-74c36731-e499-4e80-b34b-6d8af8b9f528.png">

