### PR TITLE
[SC-73296] An icon lacks 3 to 1 contrast ratio

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -4365,7 +4365,7 @@ input.field--reset:active {
   transform-origin: center center; }
 
 .infoToggle-trigger {
-  background-color: var(--c-textHint);
+  background-color: var(--c-textSecondary);
   border-radius: 50%;
   color: var(--c-white);
   font-size: 10px;

--- a/assets/scss/components/_infoToggle.scss
+++ b/assets/scss/components/_infoToggle.scss
@@ -1,6 +1,6 @@
 .infoToggle {
 	&-trigger {
-		background-color: var(--c-textHint);
+		background-color: var(--c-textSecondary);
 		border-radius: 50%;
 		color: var(--c-white);
 		font-size: 10px;


### PR DESCRIPTION
#### Related issues
https://app.shortcut.com/meetup/story/73296/pro-dashboard-an-icon-lacks-3-to-1-contrast-ratio

**Description:**
Contrast ratio issue, screenshot from the deque task:
![image](https://github.com/meetup/meetup-web-components/assets/79593437/e63801a9-55ab-4341-806f-641b9383635a)

**Fix:** Updating the background color for this icon. Expecting the contrast ratio to go from 1.7 to 3.47.
#### Screenshots (tested with MWC beta build)
![Screenshot 2023-06-20 at 9 18 48 AM](https://github.com/meetup/meetup-web-components/assets/79593437/d22aeed5-9678-4353-8927-6f0a5c4442ef)
