### PR TITLE
Hide Facebook option in registration modal.

### DIFF
--- a/src/SignupModal.jsx
+++ b/src/SignupModal.jsx
@@ -27,6 +27,7 @@ export const SignupModal = ({
 	appleOnClick,
 	facebookOnClick,
 	emailOnClick,
+	hideFacebook,
 	...other
 }) => {
 	const { apple, google, facebook, email, login, title } = signupOptions;
@@ -52,7 +53,7 @@ export const SignupModal = ({
 						</a>
 					</div>
 				</div>
-				{!HIDE_FACEBOOK && (
+				{!hideFacebook && (
 					<a
 						href={facebook.link}
 						className={btnClassName}
@@ -89,6 +90,11 @@ export const SignupModal = ({
 			</div>
 		</Modal>
 	);
+};
+
+SignupModal.defaultProps = {
+	/** app.shortcut.com/meetup/story/91014/web-hide-facebook-registration-option */
+	hideFacebook: false,
 };
 
 SignupModal.propTypes = {

--- a/src/SignupModal.jsx
+++ b/src/SignupModal.jsx
@@ -14,6 +14,7 @@ import emailIcon from '../assets/svg/email.svg';
 /* consts */
 export const SIGNUP_MODAL_CLASS = 'meetup-signupModal';
 export const SIGNUP_MODAL_WRAPPER_CLASS = `${SIGNUP_MODAL_CLASS}-wrapper`;
+const HIDE_FACEBOOK = true;
 
 /**
  * @param {Object} props component properties
@@ -51,14 +52,18 @@ export const SignupModal = ({
 						</a>
 					</div>
 				</div>
-				<a
-					href={facebook.link}
-					className={btnClassName}
-					onClick={facebookOnClick}
-				>
-					<img src={facebookIcon} />
-					<div className="tw-flex-grow tw-text-center">{facebook.label} </div>
-				</a>
+				{!HIDE_FACEBOOK && (
+					<a
+						href={facebook.link}
+						className={btnClassName}
+						onClick={facebookOnClick}
+					>
+						<img src={facebookIcon} />
+						<div className="tw-flex-grow tw-text-center">
+							{facebook.label}{' '}
+						</div>
+					</a>
+				)}
 				<a href={google.link} className={btnClassName} onClick={googleOnClick}>
 					<img src={googleIcon} />
 					<div className="tw-flex-grow tw-text-center">{google.label} </div>

--- a/src/SignupModal.jsx
+++ b/src/SignupModal.jsx
@@ -14,7 +14,6 @@ import emailIcon from '../assets/svg/email.svg';
 /* consts */
 export const SIGNUP_MODAL_CLASS = 'meetup-signupModal';
 export const SIGNUP_MODAL_WRAPPER_CLASS = `${SIGNUP_MODAL_CLASS}-wrapper`;
-const HIDE_FACEBOOK = true;
 
 /**
  * @param {Object} props component properties

--- a/src/__snapshots__/SignupModal.test.jsx.snap
+++ b/src/__snapshots__/SignupModal.test.jsx.snap
@@ -36,20 +36,6 @@ exports[`SignupModal should match the snapshot 1`] = `
     </div>
     <a
       className="tw-font-normal tw-box-border tw-border tw-border-gray2 tw-border-solid tw-p-4 tw-mb-4 tw-rounded-lg tw-flex tw-flex-row"
-      href="facebook.com"
-    >
-      <img
-        src=""
-      />
-      <div
-        className="tw-flex-grow tw-text-center"
-      >
-        Continue with Facebook
-         
-      </div>
-    </a>
-    <a
-      className="tw-font-normal tw-box-border tw-border tw-border-gray2 tw-border-solid tw-p-4 tw-mb-4 tw-rounded-lg tw-flex tw-flex-row"
       href="google.com"
     >
       <img

--- a/src/__snapshots__/SignupModal.test.jsx.snap
+++ b/src/__snapshots__/SignupModal.test.jsx.snap
@@ -36,6 +36,20 @@ exports[`SignupModal should match the snapshot 1`] = `
     </div>
     <a
       className="tw-font-normal tw-box-border tw-border tw-border-gray2 tw-border-solid tw-p-4 tw-mb-4 tw-rounded-lg tw-flex tw-flex-row"
+      href="facebook.com"
+    >
+      <img
+        src=""
+      />
+      <div
+        className="tw-flex-grow tw-text-center"
+      >
+        Continue with Facebook
+         
+      </div>
+    </a>
+    <a
+      className="tw-font-normal tw-box-border tw-border tw-border-gray2 tw-border-solid tw-p-4 tw-mb-4 tw-rounded-lg tw-flex tw-flex-row"
       href="google.com"
     >
       <img

--- a/src/navigation/Nav.jsx
+++ b/src/navigation/Nav.jsx
@@ -608,6 +608,7 @@ export class Nav extends React.Component {
 							googleOnClick={signup.signupModal.googleOnClick}
 							facebookOnClick={signup.signupModal.facebookOnClick}
 							emailOnClick={signup.signupModal.emailOnClick}
+							hideFacebook
 						/>
 					)}
 					{showMobileDashboard && (


### PR DESCRIPTION
### Don't merge yet. Facebook looks OK...

---

The [ticket](https://app.shortcut.com/meetup/story/91014/web-hide-facebook-registration-option). 

![image](https://github.com/meetup/meetup-web-components/assets/85247244/6702728d-9465-4acb-8710-a5befde37e31)

---

From the [readme](https://github.com/meetup/meetup-web-components#developmentbeta-releases): _When developing a consumer application that requires changes to the platform code, you can release a beta version of the platform on npm by opening a PR in the meetup-web-platform repo..._ This is seriously outdated.