### PR TITLE
FE Add currency label to discounted price [sc-93677]

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -5225,8 +5225,8 @@ input.field--reset:active {
   background-color: var(--color-gray-2);
   border: 1px solid var(--color-gray-5);
   border-bottom-right-radius: 4px;
-  border-top-right-radius: 4px;
   border-left: 0;
+  border-top-right-radius: 4px;
   display: flex;
   font-weight: 500;
   justify-items: center;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -5225,9 +5225,10 @@ input.field--reset:active {
   background-color: var(--color-gray-2);
   border: 1px solid var(--color-gray-5);
   border-bottom-right-radius: 4px;
-  border-left: 0;
   border-top-right-radius: 4px;
+  border-left: 0;
   display: flex;
+  font-weight: 500;
   justify-items: center;
   padding: 0 calc(var(--responsive-space) / 2); }
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -5211,6 +5211,42 @@ input.field--reset:active {
   display: flex;
   padding: 6px 8px; }
 
+.text-input-container {
+  display: flex !important; }
+
+.input-with-currency-label {
+  border-bottom-right-radius: 0 !important;
+  border-right: 0 !important;
+  border-top-right-radius: 0 !important;
+  margin-bottom: 0; }
+
+.currency-label {
+  align-items: center;
+  background-color: var(--color-gray-2);
+  border: 1px solid var(--color-gray-5);
+  border-bottom-right-radius: 4px;
+  border-left: 0;
+  border-top-right-radius: 4px;
+  display: flex;
+  justify-items: center;
+  padding: 0 calc(var(--responsive-space) / 2); }
+
+[data-swarm-text-input]:hover + .currency-label {
+  border-color: var(--color-gray-6);
+  outline: none; }
+
+[data-swarm-text-input]:focus + .currency-label {
+  border-color: var(--color-viridian);
+  outline: none; }
+
+[data-swarm-text-input="disabled"] + .currency-label {
+  background-color: var(--color-gray-3);
+  border-color: var(--color-gray-3) !important;
+  color: var(--color-gray-6); }
+
+[data-swarm-text-input="error"] + .currency-label {
+  border-color: var(--color-alert-red); }
+
 /**
 * modifierClasses/all.scss
 * -------------------

--- a/assets/scss/components/_all.scss
+++ b/assets/scss/components/_all.scss
@@ -57,3 +57,4 @@
 @import "signup";
 @import "adminBar";
 @import "lockedBadge";
+@import "textInput";

--- a/assets/scss/components/_textInput.scss
+++ b/assets/scss/components/_textInput.scss
@@ -17,6 +17,7 @@
 	border-left: 0;
 	border-top-right-radius: 4px;
 	display: flex;
+	font-weight: 500;
 	justify-items: center;
 	padding: 0 calc(var(--responsive-space) / 2);
 }

--- a/assets/scss/components/_textInput.scss
+++ b/assets/scss/components/_textInput.scss
@@ -1,0 +1,42 @@
+.text-input-container {
+	display: flex !important;
+}
+
+.input-with-currency-label {
+	border-bottom-right-radius: 0 !important;
+	border-right: 0 !important;
+	border-top-right-radius: 0 !important;
+	margin-bottom: 0;
+}
+
+.currency-label {
+	align-items: center;
+	background-color: var(--color-gray-2);
+	border: 1px solid var(--color-gray-5);
+	border-bottom-right-radius: 4px;
+	border-left: 0;
+	border-top-right-radius: 4px;
+	display: flex;
+	justify-items: center;
+	padding: 0 calc(var(--responsive-space) / 2);
+}
+
+[data-swarm-text-input]:hover + .currency-label {
+	border-color: var(--color-gray-6);
+	outline: none; // stylelint-disable-line declaration-property-value-blacklist
+}
+
+[data-swarm-text-input]:focus + .currency-label {
+	border-color: var(--color-viridian);
+	outline: none; // stylelint-disable-line declaration-property-value-blacklist
+}
+
+[data-swarm-text-input="disabled"] + .currency-label {
+	background-color: var(--color-gray-3);
+	border-color: var(--color-gray-3) !important;
+	color: var(--color-gray-6);
+}
+
+[data-swarm-text-input="error"] + .currency-label {
+	border-color: var(--color-alert-red);
+}

--- a/src/forms/SwarmTextInput.jsx
+++ b/src/forms/SwarmTextInput.jsx
@@ -3,6 +3,8 @@
 import React, { useState, useCallback } from 'react';
 import Icon from '@meetup/swarm-components/lib/Icon';
 import cn from 'classnames';
+import withErrorList from '../utils/components/withErrorList';
+import DeprecationWarning from '../utils/components/DeprecationWarning';
 
 export const getFormFieldState = (props: {
 	disabled?: boolean,
@@ -89,6 +91,7 @@ type TextInputProps = {
 	currencyLabel?: string,
 	className?: string,
 	defaultValue?: string,
+	currencyLabelStyle?: string,
 };
 
 /**
@@ -108,6 +111,7 @@ const SwarmTextInput = (props: TextInputProps) => {
 		maxLength,
 		currencyLabel,
 		className,
+		currencyLabelStyle,
 		...other
 	} = props;
 	const wrapperState = iconShape ? 'icon' : 'default';
@@ -156,7 +160,7 @@ const SwarmTextInput = (props: TextInputProps) => {
 	return (
 		<div
 			data-swarm-text-input-wrapper={wrapperState}
-			className={cn({ ['text-input-container']: !!currencyLabel })}
+			className={cn({ 'text-input-container': !!currencyLabel })}
 		>
 			<input
 				data-swarm-text-input={inputState}
@@ -177,9 +181,13 @@ const SwarmTextInput = (props: TextInputProps) => {
 				</span>
 			)}
 			{maxLength && <CharCount maxLength={maxLength} charLength={charLength} />}
-			{currencyLabel && <span className="currency-label">{currencyLabel}</span>}
+			{currencyLabel && (
+				<span className={cn('currency-label', currencyLabelStyle)}>
+					{currencyLabel}
+				</span>
+			)}
 		</div>
 	);
 };
 
-export default SwarmTextInput;
+export default withErrorList(DeprecationWarning(SwarmTextInput));

--- a/src/forms/SwarmTextInput.jsx
+++ b/src/forms/SwarmTextInput.jsx
@@ -1,0 +1,185 @@
+// @flow
+// $FlowFixMe
+import React, { useState, useCallback } from 'react';
+import Icon from '@meetup/swarm-components/lib/Icon';
+import cn from 'classnames';
+
+export const getFormFieldState = (props: {
+	disabled?: boolean,
+	error?: boolean,
+}): string => {
+	let state = 'default';
+
+	if (props.disabled) {
+		state = 'disabled';
+	} else if (props.error) {
+		state = 'error';
+	}
+
+	return state;
+};
+
+export const getRemainingCharacters = (
+	maxLength: number,
+	charLength: number = 0
+): number => maxLength - charLength;
+
+const CharCount = (props: { maxLength: number, charLength?: number }) => {
+	const { maxLength, charLength = 0, ...other } = props;
+
+	return (
+		<p data-swarm-textarea-char-count className="text--tiny" {...other}>
+			{getRemainingCharacters(maxLength, charLength)}
+		</p>
+	);
+};
+
+const hasMaxLengthError = (maxLength: number = 0, charLength: number): boolean =>
+	!!maxLength && charLength > maxLength;
+
+type TextInputProps = {
+	/**
+	 * Input type
+	 */
+	type?: string,
+	/**
+	 * Whether the input should be interactive.
+	 */
+	disabled?: boolean,
+	/**
+	 * Whether the field has an error.
+	 */
+	error?: boolean,
+	/**
+	 * An identifier for the input.
+	 */
+	id: string,
+	/**
+	 * Whether the input is a search field.
+	 */
+	isSearch?: boolean,
+	/**
+	 * Name for the input.
+	 */
+	name: string,
+	/**
+	 * A regular expression that the input's value is checked against on form submission.
+	 */
+	pattern?: string,
+	/**
+	 * Value of input.
+	 */
+	value?: string,
+	/**
+	 * Name of icon to render in the input
+	 */
+	iconShape?: string,
+	/**
+	 * Optional size for icon if `iconShape` is provided.
+	 * Default size is `xs`
+	 */
+	iconSize?: 'xxs' | 'xs' | 's' | 'm' | 'l' | 'xl' | 'xxl',
+	/**
+	 * max length of input field
+	 */
+	maxLength?: number,
+	/**
+	 * currency label for price field
+	 */
+	currencyLabel?: string,
+	className?: string,
+	defaultValue?: string,
+};
+
+/**
+ * @module TextInput
+ */
+const SwarmTextInput = (props: TextInputProps) => {
+	const {
+		type,
+		name,
+		error,
+		isSearch,
+		pattern,
+		disabled,
+		id,
+		iconShape,
+		value = '',
+		maxLength,
+		currencyLabel,
+		className,
+		...other
+	} = props;
+	const wrapperState = iconShape ? 'icon' : 'default';
+	const charLength = value.length;
+	const inputState = getFormFieldState({
+		...props,
+		error: error || hasMaxLengthError(maxLength, charLength),
+	});
+
+	const [showPassword, setShowPassword] = useState(false);
+	const togglePassword = useCallback(
+		() => {
+			setShowPassword(!showPassword);
+		},
+		[showPassword]
+	);
+
+	if (type === 'password') {
+		return (
+			<div data-swarm-text-input-wrapper={wrapperState}>
+				<input
+					data-swarm-text-input={inputState}
+					type={showPassword ? 'text' : 'password'}
+					name={name}
+					disabled={disabled}
+					id={id}
+					value={value}
+					{...other}
+				/>
+				<span
+					onClick={togglePassword}
+					data-swarm-input-icon="xs"
+					data-swarm-position-right
+					data-swarm-focusable
+				>
+					<Icon
+						shape={showPassword ? 'eye-visible' : 'eye-hidden'}
+						aria-hidden
+					/>
+				</span>
+				{maxLength && <CharCount maxLength={maxLength} charLength={charLength} />}
+			</div>
+		);
+	}
+
+	return (
+		<div
+			data-swarm-text-input-wrapper={wrapperState}
+			className={cn({ ['text-input-container']: !!currencyLabel })}
+		>
+			<input
+				data-swarm-text-input={inputState}
+				type={isSearch ? 'search' : 'text'}
+				name={name}
+				pattern={pattern}
+				disabled={disabled}
+				id={id}
+				className={cn(className, {
+					'input-with-currency-label': !!currencyLabel,
+				})}
+				value={value}
+				{...other}
+			/>
+			{iconShape && (
+				<span data-swarm-input-icon={iconShape}>
+					<Icon shape={iconShape} aria-hidden />
+				</span>
+			)}
+			{maxLength && <CharCount maxLength={maxLength} charLength={charLength} />}
+			{currencyLabel && <span className="currency-label">{currencyLabel}</span>}
+		</div>
+	);
+};
+
+export default SwarmTextInput;

--- a/src/forms/TextInput.jsx
+++ b/src/forms/TextInput.jsx
@@ -34,6 +34,7 @@ type Props = {
 	labelClassName?: string,
 	value: string,
 	currencyLabel?: string,
+	currencyLabelStyle?: string,
 	defaultValue?: string,
 };
 
@@ -63,6 +64,7 @@ export class TextInput extends React.Component<Props> {
 			validityMessage,
 			placeholder,
 			currencyLabel,
+			currencyLabelStyle,
 			value,
 			...other
 		} = this.props;
@@ -118,6 +120,7 @@ export class TextInput extends React.Component<Props> {
 					pattern={pattern}
 					disabled={disabled}
 					currencyLabel={currencyLabel}
+					currencyLabelStyle={currencyLabelStyle}
 					id={id || ''}
 					aria-label={label ? undefined : id || name}
 					{...optionalInputProps}
@@ -176,6 +179,9 @@ TextInput.propTypes = {
 
 	/** What to render in order to indicate the field is required */
 	requiredText: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+
+	/** Currency right label for price input */
+	currencyLabel: PropTypes.string,
 };
 
 export default withErrorList(DeprecationWarning(TextInput));

--- a/src/forms/TextInput.jsx
+++ b/src/forms/TextInput.jsx
@@ -2,7 +2,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { TextInput as SwarmTextInput, FieldLabel } from '@meetup/swarm-components';
+import { FieldLabel } from '@meetup/swarm-components';
+
+import SwarmTextInput from './SwarmTextInput';
 
 import withErrorList from '../utils/components/withErrorList';
 import DeprecationWarning from '../utils/components/DeprecationWarning';
@@ -31,6 +33,8 @@ type Props = {
 	validityMessage?: string,
 	labelClassName?: string,
 	value: string,
+	currencyLabel?: string,
+	defaultValue?: string,
 };
 
 /**
@@ -53,11 +57,12 @@ export class TextInput extends React.Component<Props> {
 			labelClassName,
 			onChange,
 			pattern,
-			placeholder,
 			refCallback,
 			required,
 			requiredText = '*',
 			validityMessage,
+			placeholder,
+			currencyLabel,
 			value,
 			...other
 		} = this.props;
@@ -102,24 +107,22 @@ export class TextInput extends React.Component<Props> {
 				)}
 
 				{helperText && <p data-swarm-select-helper-text="1">{helperText}</p>}
-
-				<div data-swarm-select-wrapper="1">
-					<SwarmTextInput
-						isSearch={isSearch}
-						name={name}
-						error={error}
-						required={required}
-						placeholder={placeholder}
-						onChange={handleOnChange}
-						onInvalid={handleInvalid}
-						pattern={pattern}
-						disabled={disabled}
-						id={id}
-						aria-label={label ? undefined : id || name}
-						{...optionalInputProps}
-						{...other}
-					/>
-				</div>
+				<SwarmTextInput
+					isSearch={isSearch}
+					name={name}
+					error={!!error}
+					required={required}
+					placeholder={placeholder}
+					onChange={handleOnChange}
+					onInvalid={handleInvalid}
+					pattern={pattern}
+					disabled={disabled}
+					currencyLabel={currencyLabel}
+					id={id || ''}
+					aria-label={label ? undefined : id || name}
+					{...optionalInputProps}
+					{...other}
+				/>
 			</div>
 		);
 	}

--- a/src/forms/__snapshots__/textInput.test.jsx.snap
+++ b/src/forms/__snapshots__/textInput.test.jsx.snap
@@ -22,43 +22,42 @@ exports[`TextInput renders a required HTML <input> with expected attributes for 
         Super Hero
       </label>
     </FieldLabel>
-    <div
-      data-swarm-select-wrapper="1"
+    <SwarmTextInput
+      error={false}
+      id="superhero"
+      maxLength={20}
+      name="superhero"
+      onChange={[Function]}
+      onInvalid={[Function]}
+      value="Batman"
     >
-      <TextInput
-        id="superhero"
-        maxLength={20}
-        name="superhero"
-        onChange={[Function]}
-        onInvalid={[Function]}
-        value="Batman"
+      <div
+        className=""
+        data-swarm-text-input-wrapper="default"
       >
-        <div
-          data-swarm-text-input-wrapper="default"
+        <input
+          className=""
+          data-swarm-text-input="default"
+          id="superhero"
+          name="superhero"
+          onChange={[Function]}
+          onInvalid={[Function]}
+          type="text"
+          value="Batman"
+        />
+        <CharCount
+          charLength={6}
+          maxLength={20}
         >
-          <input
-            data-swarm-text-input="default"
-            id="superhero"
-            name="superhero"
-            onChange={[Function]}
-            onInvalid={[Function]}
-            type="text"
-            value="Batman"
-          />
-          <CharCount
-            charLength={6}
-            maxLength={20}
+          <p
+            className="text--tiny"
+            data-swarm-textarea-char-count={true}
           >
-            <p
-              className="text--tiny"
-              data-swarm-textarea-char-count={true}
-            >
-              14
-            </p>
-          </CharCount>
-        </div>
-      </TextInput>
-    </div>
+            14
+          </p>
+        </CharCount>
+      </div>
+    </SwarmTextInput>
   </div>
 </TextInput>
 `;

--- a/src/forms/__snapshots__/textInput.test.jsx.snap
+++ b/src/forms/__snapshots__/textInput.test.jsx.snap
@@ -22,7 +22,7 @@ exports[`TextInput renders a required HTML <input> with expected attributes for 
         Super Hero
       </label>
     </FieldLabel>
-    <SwarmTextInput
+    <WithErrorList(SwarmTextInput)
       error={false}
       id="superhero"
       maxLength={20}
@@ -31,33 +31,70 @@ exports[`TextInput renders a required HTML <input> with expected attributes for 
       onInvalid={[Function]}
       value="Batman"
     >
-      <div
-        className=""
-        data-swarm-text-input-wrapper="default"
-      >
-        <input
-          className=""
-          data-swarm-text-input="default"
+      <div>
+        <SwarmTextInput
+          aria-describedby="superhero-error"
+          aria-invalid={false}
+          error={false}
           id="superhero"
+          maxLength={20}
           name="superhero"
           onChange={[Function]}
           onInvalid={[Function]}
-          type="text"
           value="Batman"
-        />
-        <CharCount
-          charLength={6}
-          maxLength={20}
         >
-          <p
-            className="text--tiny"
-            data-swarm-textarea-char-count={true}
+          <SwarmTextInput
+            aria-describedby="superhero-error"
+            aria-invalid={false}
+            error={false}
+            id="superhero"
+            maxLength={20}
+            name="superhero"
+            onChange={[Function]}
+            onInvalid={[Function]}
+            value="Batman"
           >
-            14
-          </p>
-        </CharCount>
+            <div
+              className=""
+              data-swarm-text-input-wrapper="default"
+            >
+              <input
+                aria-describedby="superhero-error"
+                aria-invalid={false}
+                className=""
+                data-swarm-text-input="default"
+                id="superhero"
+                name="superhero"
+                onChange={[Function]}
+                onInvalid={[Function]}
+                type="text"
+                value="Batman"
+              />
+              <CharCount
+                charLength={6}
+                maxLength={20}
+              >
+                <p
+                  className="text--tiny"
+                  data-swarm-textarea-char-count={true}
+                >
+                  14
+                </p>
+              </CharCount>
+            </div>
+          </SwarmTextInput>
+        </SwarmTextInput>
+        <ErrorList
+          error={false}
+          id="superhero-error"
+        >
+          <ul
+            aria-live="assertive"
+            id="superhero-error"
+          />
+        </ErrorList>
       </div>
-    </SwarmTextInput>
+    </WithErrorList(SwarmTextInput)>
   </div>
 </TextInput>
 `;

--- a/src/forms/textInput.story.jsx
+++ b/src/forms/textInput.story.jsx
@@ -36,6 +36,25 @@ storiesOf('Forms/TextInput', module)
 			disabled
 		/>
 	))
+	.add('with currency label', () => (
+		<TextInput
+			label="Your name"
+			id="fullname"
+			name="name"
+			value="test "
+			currencyLabel="USD"
+		/>
+	))
+	.add('disabled with currency label', () => (
+		<TextInput
+			label="Your name"
+			id="fullname"
+			name="name"
+			disabled
+			value="test "
+			currencyLabel="USD"
+		/>
+	))
 	.add('error state', () => (
 		<TextInput
 			label="Your name"
@@ -127,7 +146,7 @@ storiesOf('Forms/TextInput', module)
 		},
 		{
 			info: {
-				text: `Note: updating field with charcounter relies on parent to give value, 
+				text: `Note: updating field with charcounter relies on parent to give value,
             thats why you cant interact with the field in this story`,
 			},
 		}


### PR DESCRIPTION
#### Description
 I moved Text input from swarm-ui, to add a curr label and synchronize it by style with the input.
 For it just use props `currencyLabel`
#### Screenshots (if applicable)
![image](https://github.com/meetup/meetup-web-components/assets/87324157/b3089a37-d04f-4e66-9c27-be8c4c79bc15)
![image](https://github.com/meetup/meetup-web-components/assets/87324157/1b58568b-3f5e-4293-9e87-53dd792e4218)
![image](https://github.com/meetup/meetup-web-components/assets/87324157/9a49024b-48d7-46a4-b73a-5101a8f459dc)
