### PR TITLE
feat: [sc-74797] Pro Dashboard: Function cannot be performed by keyboard alone

### DIFF
--- a/src/forms/Checkbox.jsx
+++ b/src/forms/Checkbox.jsx
@@ -38,6 +38,16 @@ export class Checkbox extends React.PureComponent {
 		}
 	}
 
+	handleKeyPress = e => {
+		if (e.key === 'Enter') {
+			this.props.onChange && this.props.onChange(e);
+
+			if (this.props.controlled) {
+				this.setState({ checked: !this.state.checked });
+			}
+		}
+	};
+
 	getChecked() {
 		if (this.props.controlled) {
 			return this.state.checked;
@@ -77,7 +87,8 @@ export class Checkbox extends React.PureComponent {
 					role="checkbox"
 					aria-checked={stateChecked}
 					aria-label="checkbox"
-					tabindex={0}
+					tabIndex={0}
+					onKeyPress={this.handleKeyPress}
 				>
 					{stateChecked && (
 						<Icon shape="check" color={disabled ? '#707070' : '#ffffff'} />

--- a/src/forms/__snapshots__/checkbox.test.jsx.snap
+++ b/src/forms/__snapshots__/checkbox.test.jsx.snap
@@ -10,8 +10,9 @@ exports[`Checkbox basic renders checked checkbox 1`] = `
     aria-label="checkbox"
     className="checkbox"
     data-swarm-checkbox-field="checked"
+    onKeyPress={[Function]}
     role="checkbox"
-    tabindex={0}
+    tabIndex={0}
   >
     <Icon
       color="#ffffff"
@@ -41,8 +42,9 @@ exports[`Checkbox basic renders unchecked checkbox 1`] = `
     aria-checked={false}
     aria-label="checkbox"
     className="checkbox"
+    onKeyPress={[Function]}
     role="checkbox"
-    tabindex={0}
+    tabIndex={0}
   />
   <input
     checked={false}

--- a/src/forms/checkbox.story.jsx
+++ b/src/forms/checkbox.story.jsx
@@ -19,6 +19,14 @@ storiesOf('Forms/Checkbox', module)
 	.add('with label', () => (
 		<Checkbox label="Ketchup" value="ketchup" name="condiment" />
 	))
+	.add('with onChange handler', () => (
+		<Checkbox
+			label="Mayo"
+			value="mayo"
+			name="condiment"
+			onChange={() => console.log('changed')}
+		/>
+	))
 	.add('checked', () => (
 		<Checkbox label="Mustard" checked value="mustard" name="condiment" />
 	))


### PR DESCRIPTION
Story details: https://app.shortcut.com/meetup/story/74797

1) Make checkbox `checked` value accessible with keyboard "Enter" key.
2) Fix tabindex error:
Meetup web components storybook:
![Screenshot from 2023-10-05 16-18-14](https://github.com/meetup/meetup-web-components/assets/23707157/316424b6-4bbd-48f8-8493-f16b3c5d4257)
Pro-web:
![Screenshot from 2023-10-05 16-19-05](https://github.com/meetup/meetup-web-components/assets/23707157/ef74a11a-5a46-4147-a46a-802303dea214)
